### PR TITLE
Generate `protocolUpdateUTxOCostPerByte` in `genProtocolParametersUpdate` era dependently

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -57,6 +57,7 @@ library internal
                         Cardano.Api.EraCast
                         Cardano.Api.Eras
                         Cardano.Api.Error
+                        Cardano.Api.Features
                         Cardano.Api.Fees
                         Cardano.Api.Genesis
                         Cardano.Api.GenesisParameters

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -123,7 +123,7 @@ import           Cardano.Api.Script (scriptInEraToRefScript)
 import           Cardano.Api.Shelley (GovernancePoll (..), GovernancePollAnswer (..), Hash (..),
                    KESPeriod (KESPeriod),
                    OperationalCertificateIssueCounter (OperationalCertificateIssueCounter),
-                   PlutusScript (PlutusScriptSerialised), ProtocolParameters (ProtocolParameters),
+                   PlutusScript (PlutusScriptSerialised), ProtocolParameters (..),
                    ReferenceScript (..), ReferenceTxInsScriptsInlineDatumsSupportedInEra (..),
                    StakeCredential (StakeCredentialByKey), StakePoolKey,
                    refInsScriptsAndInlineDatsSupportedInEra)
@@ -161,6 +161,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 {- HLINT ignore "Reduce duplication" -}
+{- HLINT ignore "Use let" -}
 
 genAddressByron :: Gen (Address ByronAddr)
 genAddressByron = makeByronAddress <$> genNetworkId
@@ -833,36 +834,37 @@ genMaybePraosNonce :: Gen (Maybe PraosNonce)
 genMaybePraosNonce = Gen.maybe genPraosNonce
 
 genProtocolParameters :: Gen ProtocolParameters
-genProtocolParameters =
-  ProtocolParameters
-    <$> ((,) <$> genNat <*> genNat)
-    <*> Gen.maybe genRational
-    <*> genMaybePraosNonce
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> genLovelace
-    <*> genLovelace
-    <*> Gen.maybe genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genEpochNo
-    <*> genNat
-    <*> genRationalInt64
-    <*> genRational
-    <*> genRational
-    <*> Gen.maybe genLovelace
-    <*> return mempty
-    --TODO: Babbage figure out how to deal with
-    -- asymmetric cost model JSON instances
-    <*> Gen.maybe genExecutionUnitPrices
-    <*> Gen.maybe genExecutionUnits
-    <*> Gen.maybe genExecutionUnits
-    <*> Gen.maybe genNat
-    <*> Gen.maybe genNat
-    <*> Gen.maybe genNat
-    <*> Gen.maybe genLovelace
+genProtocolParameters = do
+  protocolParamProtocolVersion <- (,) <$> genNat <*> genNat
+  protocolParamDecentralization <- Gen.maybe genRational
+  protocolParamExtraPraosEntropy <- genMaybePraosNonce
+  protocolParamMaxBlockHeaderSize <- genNat
+  protocolParamMaxBlockBodySize <- genNat
+  protocolParamMaxTxSize <- genNat
+  protocolParamTxFeeFixed <- genLovelace
+  protocolParamTxFeePerByte <- genLovelace
+  protocolParamMinUTxOValue <- Gen.maybe genLovelace
+  protocolParamStakeAddressDeposit <- genLovelace
+  protocolParamStakePoolDeposit <- genLovelace
+  protocolParamMinPoolCost <- genLovelace
+  protocolParamPoolRetireMaxEpoch <- genEpochNo
+  protocolParamStakePoolTargetNum <- genNat
+  protocolParamPoolPledgeInfluence <- genRationalInt64
+  protocolParamMonetaryExpansion <- genRational
+  protocolParamTreasuryCut <- genRational
+  protocolParamUTxOCostPerWord <- Gen.maybe genLovelace
+  protocolParamCostModels <- pure mempty
+  --TODO: Babbage figure out how to deal with
+  -- asymmetric cost model JSON instances
+  protocolParamPrices <- Gen.maybe genExecutionUnitPrices
+  protocolParamMaxTxExUnits <- Gen.maybe genExecutionUnits
+  protocolParamMaxBlockExUnits <- Gen.maybe genExecutionUnits
+  protocolParamMaxValueSize <- Gen.maybe genNat
+  protocolParamCollateralPercent <- Gen.maybe genNat
+  protocolParamMaxCollateralInputs <- Gen.maybe genNat
+  protocolParamUTxOCostPerByte <- Gen.maybe genLovelace
+
+  pure ProtocolParameters {..}
 
 -- | Generate valid protocol parameters which pass validations in Cardano.Api.ProtocolParameters
 genValidProtocolParameters :: Gen ProtocolParameters

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -852,7 +852,7 @@ genProtocolParameters era = do
   protocolParamPoolPledgeInfluence <- genRationalInt64
   protocolParamMonetaryExpansion <- genRational
   protocolParamTreasuryCut <- genRational
-  protocolParamUTxOCostPerWord <- Gen.maybe genLovelace
+  protocolParamUTxOCostPerWord <- sequence $ protocolUTxOCostPerWordSupportedInEra era $> genLovelace
   protocolParamCostModels <- pure mempty
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
@@ -920,7 +920,7 @@ genProtocolParametersUpdate era = do
   protocolUpdatePoolPledgeInfluence <- Gen.maybe genRationalInt64
   protocolUpdateMonetaryExpansion   <- Gen.maybe genRational
   protocolUpdateTreasuryCut         <- Gen.maybe genRational
-  protocolUpdateUTxOCostPerWord     <- Gen.maybe genLovelace
+  protocolUpdateUTxOCostPerWord     <- sequence $ protocolUTxOCostPerWordSupportedInEra era $> genLovelace
   let protocolUpdateCostModels = mempty -- genCostModels
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -852,7 +852,7 @@ genProtocolParameters era = do
   protocolParamPoolPledgeInfluence <- genRationalInt64
   protocolParamMonetaryExpansion <- genRational
   protocolParamTreasuryCut <- genRational
-  protocolParamUTxOCostPerWord <- sequence $ protocolUTxOCostPerWordSupportedInEra era $> genLovelace
+  protocolParamUTxOCostPerWord <- sequence $ supportedInEra ProtocolParameterUTxOCostPerWord era $> genLovelace
   protocolParamCostModels <- pure mempty
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
@@ -862,7 +862,7 @@ genProtocolParameters era = do
   protocolParamMaxValueSize <- Gen.maybe genNat
   protocolParamCollateralPercent <- Gen.maybe genNat
   protocolParamMaxCollateralInputs <- Gen.maybe genNat
-  protocolParamUTxOCostPerByte <- sequence $ protocolUTxOCostPerByteSupportedInEra era $> genLovelace
+  protocolParamUTxOCostPerByte <- sequence $ supportedInEra ProtocolParameterUTxOCostPerByte era $> genLovelace
 
   pure ProtocolParameters {..}
 
@@ -899,7 +899,7 @@ genValidProtocolParameters era =
     <*> fmap Just genNat
     <*> fmap Just genNat
     <*> fmap Just genNat
-    <*> sequence (protocolUTxOCostPerByteSupportedInEra era $> genLovelace)
+    <*> sequence (supportedInEra ProtocolParameterUTxOCostPerByte era $> genLovelace)
 
 genProtocolParametersUpdate :: CardanoEra era -> Gen ProtocolParametersUpdate
 genProtocolParametersUpdate era = do
@@ -920,7 +920,7 @@ genProtocolParametersUpdate era = do
   protocolUpdatePoolPledgeInfluence <- Gen.maybe genRationalInt64
   protocolUpdateMonetaryExpansion   <- Gen.maybe genRational
   protocolUpdateTreasuryCut         <- Gen.maybe genRational
-  protocolUpdateUTxOCostPerWord     <- sequence $ protocolUTxOCostPerWordSupportedInEra era $> genLovelace
+  protocolUpdateUTxOCostPerWord     <- sequence $ supportedInEra ProtocolParameterUTxOCostPerWord era $> genLovelace
   let protocolUpdateCostModels = mempty -- genCostModels
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
@@ -930,7 +930,7 @@ genProtocolParametersUpdate era = do
   protocolUpdateMaxValueSize        <- Gen.maybe genNat
   protocolUpdateCollateralPercent   <- Gen.maybe genNat
   protocolUpdateMaxCollateralInputs <- Gen.maybe genNat
-  protocolUpdateUTxOCostPerByte     <- sequence $ protocolUTxOCostPerByteSupportedInEra era $> genLovelace
+  protocolUpdateUTxOCostPerByte     <- sequence $ supportedInEra ProtocolParameterUTxOCostPerByte era $> genLovelace
 
   pure ProtocolParametersUpdate{..}
 

--- a/cardano-api/internal/Cardano/Api/Features.hs
+++ b/cardano-api/internal/Cardano/Api/Features.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Cardano.Api.Features
+  ( Feature(..)
+  , SupportedInEra(..)
+  , supportedInEra
+  ) where
+
+import           Cardano.Api.Eras
+import           Data.Aeson (ToJSON (..))
+
+data ProtocolParameterUTxOCostPerWord
+
+data ProtocolParameterUTxOCostPerByte
+
+-- | A representation of a feature that is supported in a given era.
+data Feature f where
+  ProtocolParameterUTxOCostPerWord :: Feature ProtocolParameterUTxOCostPerWord
+  ProtocolParameterUTxOCostPerByte :: Feature ProtocolParameterUTxOCostPerByte
+
+deriving instance Eq (Feature f)
+deriving instance Show (Feature f)
+
+instance ToJSON (Feature f) where
+  toJSON = toJSON . show
+
+-- | A representation of a feature whether a feature is supported in a given era.
+data SupportedInEra f era where
+  ProtocolParameterUTxOCostPerWordSupportedInAlonzoEra  :: SupportedInEra ProtocolParameterUTxOCostPerWord AlonzoEra
+
+  ProtocolParameterUTxOCostPerByteSupportedInBabbageEra :: SupportedInEra ProtocolParameterUTxOCostPerByte BabbageEra
+  ProtocolParameterUTxOCostPerByteSupportedInConwayEra  :: SupportedInEra ProtocolParameterUTxOCostPerByte ConwayEra
+
+deriving instance Eq   (SupportedInEra f era)
+deriving instance Show (SupportedInEra f era)
+
+instance ToJSON (SupportedInEra f era) where
+  toJSON = toJSON . show
+
+-- | Determine whether a feature is supported in a given era.
+--
+-- If the feature is not supported in the given era, 'Nothing' is returned.
+supportedInEra
+  :: Feature f
+  -> CardanoEra era
+  -> Maybe (SupportedInEra f era)
+
+supportedInEra ProtocolParameterUTxOCostPerWord AlonzoEra  = Just ProtocolParameterUTxOCostPerWordSupportedInAlonzoEra
+
+supportedInEra ProtocolParameterUTxOCostPerByte BabbageEra = Just ProtocolParameterUTxOCostPerByteSupportedInBabbageEra
+supportedInEra ProtocolParameterUTxOCostPerByte ConwayEra  = Just ProtocolParameterUTxOCostPerByteSupportedInConwayEra
+
+supportedInEra _ _  = Nothing

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -149,6 +149,12 @@ module Cardano.Api.TxBody (
     txScriptValiditySupportedInCardanoEra,
     totalAndReturnCollateralSupportedInEra,
 
+    -- ** Era-dependent protocol features
+    ProtocolUTxOCostPerByteSupportedInEra(..),
+
+    -- ** Era-dependent protocol feature availability functions
+    protocolUTxOCostPerByteSupportedInEra,
+
     -- * Inspecting 'ScriptWitness'es
     AnyScriptWitness(..),
     ScriptWitnessIndex(..),
@@ -1302,6 +1308,29 @@ updateProposalSupportedInEra MaryEra    = Just UpdateProposalInMaryEra
 updateProposalSupportedInEra AlonzoEra  = Just UpdateProposalInAlonzoEra
 updateProposalSupportedInEra BabbageEra = Just UpdateProposalInBabbageEra
 updateProposalSupportedInEra ConwayEra  = Just UpdateProposalInConwayEra
+
+-- | A representation of whether the era supports the 'UTxO Cost Per Byte'
+-- protocol parameter.
+--
+-- The Babbage and subsequent eras support such a protocol parameter.
+--
+data ProtocolUTxOCostPerByteSupportedInEra era where
+  ProtocolUpdateUTxOCostPerByteInBabbageEra :: ProtocolUTxOCostPerByteSupportedInEra BabbageEra
+  ProtocolUpdateUTxOCostPerByteInConwayEra  :: ProtocolUTxOCostPerByteSupportedInEra ConwayEra
+
+deriving instance Eq   (ProtocolUTxOCostPerByteSupportedInEra era)
+deriving instance Show (ProtocolUTxOCostPerByteSupportedInEra era)
+
+protocolUTxOCostPerByteSupportedInEra
+  :: CardanoEra era
+  -> Maybe (ProtocolUTxOCostPerByteSupportedInEra era)
+protocolUTxOCostPerByteSupportedInEra ByronEra   = Nothing
+protocolUTxOCostPerByteSupportedInEra ShelleyEra = Nothing
+protocolUTxOCostPerByteSupportedInEra AllegraEra = Nothing
+protocolUTxOCostPerByteSupportedInEra MaryEra    = Nothing
+protocolUTxOCostPerByteSupportedInEra AlonzoEra  = Nothing
+protocolUTxOCostPerByteSupportedInEra BabbageEra = Just ProtocolUpdateUTxOCostPerByteInBabbageEra
+protocolUTxOCostPerByteSupportedInEra ConwayEra  = Just ProtocolUpdateUTxOCostPerByteInConwayEra
 
 -- ----------------------------------------------------------------------------
 -- Building vs viewing transactions

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -149,14 +149,6 @@ module Cardano.Api.TxBody (
     txScriptValiditySupportedInCardanoEra,
     totalAndReturnCollateralSupportedInEra,
 
-    -- ** Era-dependent protocol features
-    ProtocolUTxOCostPerByteSupportedInEra(..),
-    ProtocolUTxOCostPerWordSupportedInEra(..),
-
-    -- ** Era-dependent protocol feature availability functions
-    protocolUTxOCostPerByteSupportedInEra,
-    protocolUTxOCostPerWordSupportedInEra,
-
     -- * Inspecting 'ScriptWitness'es
     AnyScriptWitness(..),
     ScriptWitnessIndex(..),
@@ -1310,51 +1302,6 @@ updateProposalSupportedInEra MaryEra    = Just UpdateProposalInMaryEra
 updateProposalSupportedInEra AlonzoEra  = Just UpdateProposalInAlonzoEra
 updateProposalSupportedInEra BabbageEra = Just UpdateProposalInBabbageEra
 updateProposalSupportedInEra ConwayEra  = Just UpdateProposalInConwayEra
-
--- | A representation of whether the era supports the 'UTxO Cost Per Word'
--- protocol parameter.
---
--- The Babbage and subsequent eras support such a protocol parameter.
---
-data ProtocolUTxOCostPerWordSupportedInEra era where
-  ProtocolUpdateUTxOCostPerWordInAlonzoEra :: ProtocolUTxOCostPerWordSupportedInEra AlonzoEra
-
-deriving instance Eq   (ProtocolUTxOCostPerWordSupportedInEra era)
-deriving instance Show (ProtocolUTxOCostPerWordSupportedInEra era)
-
-protocolUTxOCostPerWordSupportedInEra
-  :: CardanoEra era
-  -> Maybe (ProtocolUTxOCostPerWordSupportedInEra era)
-protocolUTxOCostPerWordSupportedInEra ByronEra   = Nothing
-protocolUTxOCostPerWordSupportedInEra ShelleyEra = Nothing
-protocolUTxOCostPerWordSupportedInEra AllegraEra = Nothing
-protocolUTxOCostPerWordSupportedInEra MaryEra    = Nothing
-protocolUTxOCostPerWordSupportedInEra AlonzoEra  = Just ProtocolUpdateUTxOCostPerWordInAlonzoEra
-protocolUTxOCostPerWordSupportedInEra BabbageEra = Nothing
-protocolUTxOCostPerWordSupportedInEra ConwayEra  = Nothing
-
--- | A representation of whether the era supports the 'UTxO Cost Per Byte'
--- protocol parameter.
---
--- The Babbage and subsequent eras support such a protocol parameter.
---
-data ProtocolUTxOCostPerByteSupportedInEra era where
-  ProtocolUpdateUTxOCostPerByteInBabbageEra :: ProtocolUTxOCostPerByteSupportedInEra BabbageEra
-  ProtocolUpdateUTxOCostPerByteInConwayEra  :: ProtocolUTxOCostPerByteSupportedInEra ConwayEra
-
-deriving instance Eq   (ProtocolUTxOCostPerByteSupportedInEra era)
-deriving instance Show (ProtocolUTxOCostPerByteSupportedInEra era)
-
-protocolUTxOCostPerByteSupportedInEra
-  :: CardanoEra era
-  -> Maybe (ProtocolUTxOCostPerByteSupportedInEra era)
-protocolUTxOCostPerByteSupportedInEra ByronEra   = Nothing
-protocolUTxOCostPerByteSupportedInEra ShelleyEra = Nothing
-protocolUTxOCostPerByteSupportedInEra AllegraEra = Nothing
-protocolUTxOCostPerByteSupportedInEra MaryEra    = Nothing
-protocolUTxOCostPerByteSupportedInEra AlonzoEra  = Nothing
-protocolUTxOCostPerByteSupportedInEra BabbageEra = Just ProtocolUpdateUTxOCostPerByteInBabbageEra
-protocolUTxOCostPerByteSupportedInEra ConwayEra  = Just ProtocolUpdateUTxOCostPerByteInConwayEra
 
 -- ----------------------------------------------------------------------------
 -- Building vs viewing transactions

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -151,9 +151,11 @@ module Cardano.Api.TxBody (
 
     -- ** Era-dependent protocol features
     ProtocolUTxOCostPerByteSupportedInEra(..),
+    ProtocolUTxOCostPerWordSupportedInEra(..),
 
     -- ** Era-dependent protocol feature availability functions
     protocolUTxOCostPerByteSupportedInEra,
+    protocolUTxOCostPerWordSupportedInEra,
 
     -- * Inspecting 'ScriptWitness'es
     AnyScriptWitness(..),
@@ -1308,6 +1310,28 @@ updateProposalSupportedInEra MaryEra    = Just UpdateProposalInMaryEra
 updateProposalSupportedInEra AlonzoEra  = Just UpdateProposalInAlonzoEra
 updateProposalSupportedInEra BabbageEra = Just UpdateProposalInBabbageEra
 updateProposalSupportedInEra ConwayEra  = Just UpdateProposalInConwayEra
+
+-- | A representation of whether the era supports the 'UTxO Cost Per Word'
+-- protocol parameter.
+--
+-- The Babbage and subsequent eras support such a protocol parameter.
+--
+data ProtocolUTxOCostPerWordSupportedInEra era where
+  ProtocolUpdateUTxOCostPerWordInAlonzoEra :: ProtocolUTxOCostPerWordSupportedInEra AlonzoEra
+
+deriving instance Eq   (ProtocolUTxOCostPerWordSupportedInEra era)
+deriving instance Show (ProtocolUTxOCostPerWordSupportedInEra era)
+
+protocolUTxOCostPerWordSupportedInEra
+  :: CardanoEra era
+  -> Maybe (ProtocolUTxOCostPerWordSupportedInEra era)
+protocolUTxOCostPerWordSupportedInEra ByronEra   = Nothing
+protocolUTxOCostPerWordSupportedInEra ShelleyEra = Nothing
+protocolUTxOCostPerWordSupportedInEra AllegraEra = Nothing
+protocolUTxOCostPerWordSupportedInEra MaryEra    = Nothing
+protocolUTxOCostPerWordSupportedInEra AlonzoEra  = Just ProtocolUpdateUTxOCostPerWordInAlonzoEra
+protocolUTxOCostPerWordSupportedInEra BabbageEra = Nothing
+protocolUTxOCostPerWordSupportedInEra ConwayEra  = Nothing
 
 -- | A representation of whether the era supports the 'UTxO Cost Per Byte'
 -- protocol parameter.

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -277,6 +277,8 @@ module Cardano.Api (
     CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
+    Feature(..),
+    SupportedInEra(..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,
@@ -293,14 +295,7 @@ module Cardano.Api (
     updateProposalSupportedInEra,
     scriptDataSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
-
-    -- ** Era-dependent protocol features
-    ProtocolUTxOCostPerByteSupportedInEra(..),
-    ProtocolUTxOCostPerWordSupportedInEra(..),
-
-    -- ** Era-dependent protocol feature availability functions
-    protocolUTxOCostPerByteSupportedInEra,
-    protocolUTxOCostPerWordSupportedInEra,
+    supportedInEra,
 
     -- ** Fee calculation
     LedgerEpochInfo(..),
@@ -865,6 +860,7 @@ import           Cardano.Api.DeserialiseAnyOf
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
+import           Cardano.Api.Features
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -294,6 +294,12 @@ module Cardano.Api (
     scriptDataSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
 
+    -- ** Era-dependent protocol features
+    ProtocolUTxOCostPerByteSupportedInEra(..),
+
+    -- ** Era-dependent protocol feature availability functions
+    protocolUTxOCostPerByteSupportedInEra,
+
     -- ** Fee calculation
     LedgerEpochInfo(..),
     transactionFee,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -296,9 +296,11 @@ module Cardano.Api (
 
     -- ** Era-dependent protocol features
     ProtocolUTxOCostPerByteSupportedInEra(..),
+    ProtocolUTxOCostPerWordSupportedInEra(..),
 
     -- ** Era-dependent protocol feature availability functions
     protocolUTxOCostPerByteSupportedInEra,
+    protocolUTxOCostPerWordSupportedInEra,
 
     -- ** Fee calculation
     LedgerEpochInfo(..),

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/JSON.hs
@@ -8,6 +8,8 @@ module Test.Cardano.Api.Typed.JSON
   ( tests
   ) where
 
+import           Cardano.Api
+
 import           Data.Aeson (eitherDecode, encode)
 
 import           Test.Gen.Cardano.Api.Typed (genMaybePraosNonce, genProtocolParameters)
@@ -29,7 +31,8 @@ prop_roundtrip_praos_nonce_JSON = H.property $ do
 
 prop_roundtrip_protocol_parameters_JSON :: Property
 prop_roundtrip_protocol_parameters_JSON = H.property $ do
-  pp <- forAll genProtocolParameters
+  AnyCardanoEra era <- forAll $ Gen.element [minBound .. maxBound]
+  pp <- forAll (genProtocolParameters era)
   tripping pp encode eitherDecode
 
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

This PR was moved from https://github.com/input-output-hk/cardano-node/pull/5070

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
