### PR TITLE
Generate `protocolUpdateUTxOCostPerByte` in `genProtocolParametersUpdate` era dependently 2

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -51,6 +51,7 @@ library internal
                         Cardano.Api.EraCast
                         Cardano.Api.Eras
                         Cardano.Api.Error
+                        Cardano.Api.Features
                         Cardano.Api.Fees
                         Cardano.Api.Genesis
                         Cardano.Api.GenesisParameters

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -118,8 +118,8 @@ import           Cardano.Api hiding (txIns)
 import qualified Cardano.Api as Api
 import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness),
                    WitnessNetworkIdOrByronAddress (..))
-import           Cardano.Api.Shelley (GovernancePoll (..), GovernancePollAnswer (..),
-                   Hash (..), KESPeriod (KESPeriod),
+import           Cardano.Api.Shelley (GovernancePoll (..), GovernancePollAnswer (..), Hash (..),
+                   KESPeriod (KESPeriod),
                    OperationalCertificateIssueCounter (OperationalCertificateIssueCounter),
                    PlutusScript (PlutusScriptSerialised), ProtocolParameters (..),
                    ReferenceScript (..), ReferenceTxInsScriptsInlineDatumsSupportedInEra (..),
@@ -154,7 +154,6 @@ import           Cardano.Ledger.Alonzo.Language (Language (..))
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import           Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
 
-import           Data.Functor (($>))
 import           Test.Cardano.Chain.UTxO.Gen (genVKWitness)
 import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
 import           Test.Gen.Cardano.Api.Metadata (genTxMetadata)
@@ -851,7 +850,7 @@ genProtocolParameters era = do
   protocolParamPoolPledgeInfluence <- genRationalInt64
   protocolParamMonetaryExpansion <- genRational
   protocolParamTreasuryCut <- genRational
-  protocolParamUTxOCostPerWord <- sequence $ supportedInEra ProtocolParameterUTxOCostPerWord era $> genLovelace
+  protocolParamUTxOCostPerWord <- whenMaybeSupportedInEra genLovelace ProtocolParameterUTxOCostPerWord era
   protocolParamCostModels <- pure mempty
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
@@ -861,7 +860,7 @@ genProtocolParameters era = do
   protocolParamMaxValueSize <- Gen.maybe genNat
   protocolParamCollateralPercent <- Gen.maybe genNat
   protocolParamMaxCollateralInputs <- Gen.maybe genNat
-  protocolParamUTxOCostPerByte <- sequence $ supportedInEra ProtocolParameterUTxOCostPerByte era $> genLovelace
+  protocolParamUTxOCostPerByte <- whenMaybeSupportedInEra genLovelace ProtocolParameterUTxOCostPerByte era
 
   pure ProtocolParameters {..}
 
@@ -884,7 +883,7 @@ genProtocolParametersUpdate era = do
   protocolUpdatePoolPledgeInfluence <- Gen.maybe genRationalInt64
   protocolUpdateMonetaryExpansion   <- Gen.maybe genRational
   protocolUpdateTreasuryCut         <- Gen.maybe genRational
-  protocolUpdateUTxOCostPerWord     <- sequence $ supportedInEra ProtocolParameterUTxOCostPerWord era $> genLovelace
+  protocolUpdateUTxOCostPerWord     <- whenMaybeSupportedInEra genLovelace ProtocolParameterUTxOCostPerWord era
   let protocolUpdateCostModels = mempty -- genCostModels
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
@@ -894,7 +893,7 @@ genProtocolParametersUpdate era = do
   protocolUpdateMaxValueSize        <- Gen.maybe genNat
   protocolUpdateCollateralPercent   <- Gen.maybe genNat
   protocolUpdateMaxCollateralInputs <- Gen.maybe genNat
-  protocolUpdateUTxOCostPerByte     <- sequence $ supportedInEra ProtocolParameterUTxOCostPerByte era $> genLovelace
+  protocolUpdateUTxOCostPerByte     <- whenMaybeSupportedInEra genLovelace ProtocolParameterUTxOCostPerByte era
 
   pure ProtocolParametersUpdate{..}
 

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -851,7 +851,7 @@ genProtocolParameters era = do
   protocolParamPoolPledgeInfluence <- genRationalInt64
   protocolParamMonetaryExpansion <- genRational
   protocolParamTreasuryCut <- genRational
-  protocolParamUTxOCostPerWord <- Gen.maybe genLovelace
+  protocolParamUTxOCostPerWord <- sequence $ protocolUTxOCostPerWordSupportedInEra era $> genLovelace
   protocolParamCostModels <- pure mempty
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
@@ -884,7 +884,7 @@ genProtocolParametersUpdate era = do
   protocolUpdatePoolPledgeInfluence <- Gen.maybe genRationalInt64
   protocolUpdateMonetaryExpansion   <- Gen.maybe genRational
   protocolUpdateTreasuryCut         <- Gen.maybe genRational
-  protocolUpdateUTxOCostPerWord     <- Gen.maybe genLovelace
+  protocolUpdateUTxOCostPerWord     <- sequence $ protocolUTxOCostPerWordSupportedInEra era $> genLovelace
   let protocolUpdateCostModels = mempty -- genCostModels
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -851,7 +851,7 @@ genProtocolParameters era = do
   protocolParamPoolPledgeInfluence <- genRationalInt64
   protocolParamMonetaryExpansion <- genRational
   protocolParamTreasuryCut <- genRational
-  protocolParamUTxOCostPerWord <- sequence $ protocolUTxOCostPerWordSupportedInEra era $> genLovelace
+  protocolParamUTxOCostPerWord <- sequence $ supportedInEra ProtocolParameterUTxOCostPerWord era $> genLovelace
   protocolParamCostModels <- pure mempty
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
@@ -861,7 +861,7 @@ genProtocolParameters era = do
   protocolParamMaxValueSize <- Gen.maybe genNat
   protocolParamCollateralPercent <- Gen.maybe genNat
   protocolParamMaxCollateralInputs <- Gen.maybe genNat
-  protocolParamUTxOCostPerByte <- sequence $ protocolUTxOCostPerByteSupportedInEra era $> genLovelace
+  protocolParamUTxOCostPerByte <- sequence $ supportedInEra ProtocolParameterUTxOCostPerByte era $> genLovelace
 
   pure ProtocolParameters {..}
 
@@ -884,7 +884,7 @@ genProtocolParametersUpdate era = do
   protocolUpdatePoolPledgeInfluence <- Gen.maybe genRationalInt64
   protocolUpdateMonetaryExpansion   <- Gen.maybe genRational
   protocolUpdateTreasuryCut         <- Gen.maybe genRational
-  protocolUpdateUTxOCostPerWord     <- sequence $ protocolUTxOCostPerWordSupportedInEra era $> genLovelace
+  protocolUpdateUTxOCostPerWord     <- sequence $ supportedInEra ProtocolParameterUTxOCostPerWord era $> genLovelace
   let protocolUpdateCostModels = mempty -- genCostModels
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
@@ -894,7 +894,7 @@ genProtocolParametersUpdate era = do
   protocolUpdateMaxValueSize        <- Gen.maybe genNat
   protocolUpdateCollateralPercent   <- Gen.maybe genNat
   protocolUpdateMaxCollateralInputs <- Gen.maybe genNat
-  protocolUpdateUTxOCostPerByte     <- sequence $ protocolUTxOCostPerByteSupportedInEra era $> genLovelace
+  protocolUpdateUTxOCostPerByte     <- sequence $ supportedInEra ProtocolParameterUTxOCostPerByte era $> genLovelace
 
   pure ProtocolParametersUpdate{..}
 

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -635,7 +635,7 @@ genTxBodyContent era = do
   txMetadata <- genTxMetadataInEra era
   txAuxScripts <- genTxAuxScripts era
   let txExtraKeyWits = TxExtraKeyWitnessesNone --TODO: Alonzo era: Generate witness key hashes
-  txProtocolParams <- BuildTxWith <$> Gen.maybe genProtocolParameters
+  txProtocolParams <- BuildTxWith <$> Gen.maybe (genProtocolParameters era)
   txWithdrawals <- genTxWithdrawals era
   txCertificates <- genTxCertificates era
   txUpdateProposal <- genTxUpdateProposal era
@@ -832,8 +832,8 @@ genPraosNonce = makePraosNonce <$> Gen.bytes (Range.linear 0 32)
 genMaybePraosNonce :: Gen (Maybe PraosNonce)
 genMaybePraosNonce = Gen.maybe genPraosNonce
 
-genProtocolParameters :: Gen ProtocolParameters
-genProtocolParameters = do
+genProtocolParameters :: CardanoEra era -> Gen ProtocolParameters
+genProtocolParameters era = do
   protocolParamProtocolVersion <- (,) <$> genNat <*> genNat
   protocolParamDecentralization <- Gen.maybe genRational
   protocolParamExtraPraosEntropy <- genMaybePraosNonce
@@ -861,7 +861,7 @@ genProtocolParameters = do
   protocolParamMaxValueSize <- Gen.maybe genNat
   protocolParamCollateralPercent <- Gen.maybe genNat
   protocolParamMaxCollateralInputs <- Gen.maybe genNat
-  protocolParamUTxOCostPerByte <- Gen.maybe genLovelace
+  protocolParamUTxOCostPerByte <- sequence $ protocolUTxOCostPerByteSupportedInEra era $> genLovelace
 
   pure ProtocolParameters {..}
 

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -121,7 +121,7 @@ import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness),
 import           Cardano.Api.Shelley (GovernancePoll (..), GovernancePollAnswer (..),
                    Hash (..), KESPeriod (KESPeriod),
                    OperationalCertificateIssueCounter (OperationalCertificateIssueCounter),
-                   PlutusScript (PlutusScriptSerialised), ProtocolParameters (ProtocolParameters),
+                   PlutusScript (PlutusScriptSerialised), ProtocolParameters (..),
                    ReferenceScript (..), ReferenceTxInsScriptsInlineDatumsSupportedInEra (..),
                    StakeCredential (StakeCredentialByKey), StakePoolKey,
                    refInsScriptsAndInlineDatsSupportedInEra)
@@ -160,6 +160,7 @@ import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
 import           Test.Gen.Cardano.Api.Metadata (genTxMetadata)
 
 {- HLINT ignore "Reduce duplication" -}
+{- HLINT ignore "Use let" -}
 
 genAddressByron :: Gen (Address ByronAddr)
 genAddressByron = makeByronAddress <$> genNetworkId
@@ -832,36 +833,37 @@ genMaybePraosNonce :: Gen (Maybe PraosNonce)
 genMaybePraosNonce = Gen.maybe genPraosNonce
 
 genProtocolParameters :: Gen ProtocolParameters
-genProtocolParameters =
-  ProtocolParameters
-    <$> ((,) <$> genNat <*> genNat)
-    <*> Gen.maybe genRational
-    <*> genMaybePraosNonce
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> genLovelace
-    <*> genLovelace
-    <*> Gen.maybe genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genEpochNo
-    <*> genNat
-    <*> genRationalInt64
-    <*> genRational
-    <*> genRational
-    <*> Gen.maybe genLovelace
-    <*> return mempty
-    --TODO: Babbage figure out how to deal with
-    -- asymmetric cost model JSON instances
-    <*> Gen.maybe genExecutionUnitPrices
-    <*> Gen.maybe genExecutionUnits
-    <*> Gen.maybe genExecutionUnits
-    <*> Gen.maybe genNat
-    <*> Gen.maybe genNat
-    <*> Gen.maybe genNat
-    <*> Gen.maybe genLovelace
+genProtocolParameters = do
+  protocolParamProtocolVersion <- (,) <$> genNat <*> genNat
+  protocolParamDecentralization <- Gen.maybe genRational
+  protocolParamExtraPraosEntropy <- genMaybePraosNonce
+  protocolParamMaxBlockHeaderSize <- genNat
+  protocolParamMaxBlockBodySize <- genNat
+  protocolParamMaxTxSize <- genNat
+  protocolParamTxFeeFixed <- genLovelace
+  protocolParamTxFeePerByte <- genLovelace
+  protocolParamMinUTxOValue <- Gen.maybe genLovelace
+  protocolParamStakeAddressDeposit <- genLovelace
+  protocolParamStakePoolDeposit <- genLovelace
+  protocolParamMinPoolCost <- genLovelace
+  protocolParamPoolRetireMaxEpoch <- genEpochNo
+  protocolParamStakePoolTargetNum <- genNat
+  protocolParamPoolPledgeInfluence <- genRationalInt64
+  protocolParamMonetaryExpansion <- genRational
+  protocolParamTreasuryCut <- genRational
+  protocolParamUTxOCostPerWord <- Gen.maybe genLovelace
+  protocolParamCostModels <- pure mempty
+  --TODO: Babbage figure out how to deal with
+  -- asymmetric cost model JSON instances
+  protocolParamPrices <- Gen.maybe genExecutionUnitPrices
+  protocolParamMaxTxExUnits <- Gen.maybe genExecutionUnits
+  protocolParamMaxBlockExUnits <- Gen.maybe genExecutionUnits
+  protocolParamMaxValueSize <- Gen.maybe genNat
+  protocolParamCollateralPercent <- Gen.maybe genNat
+  protocolParamMaxCollateralInputs <- Gen.maybe genNat
+  protocolParamUTxOCostPerByte <- Gen.maybe genLovelace
+
+  pure ProtocolParameters {..}
 
 genProtocolParametersUpdate :: CardanoEra era -> Gen ProtocolParametersUpdate
 genProtocolParametersUpdate era = do

--- a/cardano-api/internal/Cardano/Api/Features.hs
+++ b/cardano-api/internal/Cardano/Api/Features.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Cardano.Api.Features
+  ( Feature(..)
+  , SupportedInEra(..)
+  , supportedInEra
+  ) where
+
+import           Cardano.Api.Eras
+import           Data.Aeson (ToJSON (..))
+
+data ProtocolParameterUTxOCostPerWord
+
+data ProtocolParameterUTxOCostPerByte
+
+-- | A representation of a feature that is supported in a given era.
+data Feature f where
+  ProtocolParameterUTxOCostPerWord :: Feature ProtocolParameterUTxOCostPerWord
+  ProtocolParameterUTxOCostPerByte :: Feature ProtocolParameterUTxOCostPerByte
+
+deriving instance Eq (Feature f)
+deriving instance Show (Feature f)
+
+instance ToJSON (Feature f) where
+  toJSON = toJSON . show
+
+-- | A representation of a feature whether a feature is supported in a given era.
+data SupportedInEra f era where
+  ProtocolParameterUTxOCostPerWordSupportedInAlonzoEra  :: SupportedInEra ProtocolParameterUTxOCostPerWord AlonzoEra
+
+  ProtocolParameterUTxOCostPerByteSupportedInBabbageEra :: SupportedInEra ProtocolParameterUTxOCostPerByte BabbageEra
+  ProtocolParameterUTxOCostPerByteSupportedInConwayEra  :: SupportedInEra ProtocolParameterUTxOCostPerByte ConwayEra
+
+deriving instance Eq   (SupportedInEra f era)
+deriving instance Show (SupportedInEra f era)
+
+instance ToJSON (SupportedInEra f era) where
+  toJSON = toJSON . show
+
+-- | Determine whether a feature is supported in a given era.
+--
+-- If the feature is not supported in the given era, 'Nothing' is returned.
+supportedInEra
+  :: Feature f
+  -> CardanoEra era
+  -> Maybe (SupportedInEra f era)
+
+supportedInEra ProtocolParameterUTxOCostPerWord AlonzoEra  = Just ProtocolParameterUTxOCostPerWordSupportedInAlonzoEra
+
+supportedInEra ProtocolParameterUTxOCostPerByte BabbageEra = Just ProtocolParameterUTxOCostPerByteSupportedInBabbageEra
+supportedInEra ProtocolParameterUTxOCostPerByte ConwayEra  = Just ProtocolParameterUTxOCostPerByteSupportedInConwayEra
+
+supportedInEra _ _  = Nothing

--- a/cardano-api/internal/Cardano/Api/Features.hs
+++ b/cardano-api/internal/Cardano/Api/Features.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.Api.Features
   ( Feature(..)
-  , SupportedInEra(..)
   , supportedInEra
+  , maybeSupportedInEra
+  , whenMaybeSupportedInEra
   ) where
 
 import           Cardano.Api.Eras
@@ -15,7 +17,7 @@ data ProtocolParameterUTxOCostPerWord
 data ProtocolParameterUTxOCostPerByte
 
 -- | A representation of a feature that is supported in a given era.
-data Feature f where
+data Feature feature where
   ProtocolParameterUTxOCostPerWord :: Feature ProtocolParameterUTxOCostPerWord
   ProtocolParameterUTxOCostPerByte :: Feature ProtocolParameterUTxOCostPerByte
 
@@ -25,30 +27,60 @@ deriving instance Show (Feature f)
 instance ToJSON (Feature f) where
   toJSON = toJSON . show
 
--- | A representation of a feature whether a feature is supported in a given era.
-data SupportedInEra f era where
-  ProtocolParameterUTxOCostPerWordSupportedInAlonzoEra  :: SupportedInEra ProtocolParameterUTxOCostPerWord AlonzoEra
-
-  ProtocolParameterUTxOCostPerByteSupportedInBabbageEra :: SupportedInEra ProtocolParameterUTxOCostPerByte BabbageEra
-  ProtocolParameterUTxOCostPerByteSupportedInConwayEra  :: SupportedInEra ProtocolParameterUTxOCostPerByte ConwayEra
-
-deriving instance Eq   (SupportedInEra f era)
-deriving instance Show (SupportedInEra f era)
-
-instance ToJSON (SupportedInEra f era) where
-  toJSON = toJSON . show
+-- | Determine whether a feature is supported in a given era.
+--
+-- If the feature is not supported in the given era, 'no' is returned, otherwise 'yes'.
+supportedInEra
+  :: a
+  -- ^ The value to return if the feature is not supported in the given era.
+  -> a
+  -- ^ The value to return if the feature is supported in the given era.
+  -> Feature feature
+  -- ^ The feature to check.
+  -> CardanoEra era
+  -- ^ The era to check.
+  -> a
+supportedInEra no yes = \case
+  ProtocolParameterUTxOCostPerWord -> \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> yes
+    BabbageEra  -> no
+    ConwayEra   -> no
+  ProtocolParameterUTxOCostPerByte -> \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> yes
+    ConwayEra   -> yes
 
 -- | Determine whether a feature is supported in a given era.
 --
--- If the feature is not supported in the given era, 'Nothing' is returned.
-supportedInEra
-  :: Feature f
+-- If the feature is not supported in the given era, 'pure Nothing' is returned, otherwise 'Just <$> fa'.
+whenMaybeSupportedInEra :: ()
+  => Applicative f
+  => f a
+  -- ^ The value to return if the feature is not supported in the given era.
+  -> Feature feature
+  -- ^ The feature to check.
   -> CardanoEra era
-  -> Maybe (SupportedInEra f era)
+  -- ^ The era to check.
+  -> f (Maybe a)
+whenMaybeSupportedInEra fa = supportedInEra (pure Nothing) (Just <$> fa)
 
-supportedInEra ProtocolParameterUTxOCostPerWord AlonzoEra  = Just ProtocolParameterUTxOCostPerWordSupportedInAlonzoEra
-
-supportedInEra ProtocolParameterUTxOCostPerByte BabbageEra = Just ProtocolParameterUTxOCostPerByteSupportedInBabbageEra
-supportedInEra ProtocolParameterUTxOCostPerByte ConwayEra  = Just ProtocolParameterUTxOCostPerByteSupportedInConwayEra
-
-supportedInEra _ _  = Nothing
+-- | Determine whether a feature is supported in a given era.
+--
+-- If the feature is not supported in the given era, 'Nothing' is returned, otherwise 'Just a'.
+maybeSupportedInEra :: ()
+  => a
+  -- ^ The value to return if the feature is not supported in the given era.
+  -> Feature feature
+  -- ^ The feature to check.
+  -> CardanoEra era
+  -- ^ The era to check.
+  -> Maybe a
+maybeSupportedInEra a = supportedInEra Nothing (Just a)

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -151,9 +151,11 @@ module Cardano.Api.TxBody (
 
     -- ** Era-dependent protocol features
     ProtocolUTxOCostPerByteSupportedInEra(..),
+    ProtocolUTxOCostPerWordSupportedInEra(..),
 
     -- ** Era-dependent protocol feature availability functions
     protocolUTxOCostPerByteSupportedInEra,
+    protocolUTxOCostPerWordSupportedInEra,
 
     -- * Inspecting 'ScriptWitness'es
     AnyScriptWitness(..),
@@ -1315,6 +1317,28 @@ updateProposalSupportedInEra MaryEra    = Just UpdateProposalInMaryEra
 updateProposalSupportedInEra AlonzoEra  = Just UpdateProposalInAlonzoEra
 updateProposalSupportedInEra BabbageEra = Just UpdateProposalInBabbageEra
 updateProposalSupportedInEra ConwayEra  = Just UpdateProposalInConwayEra
+
+-- | A representation of whether the era supports the 'UTxO Cost Per Word'
+-- protocol parameter.
+--
+-- The Babbage and subsequent eras support such a protocol parameter.
+--
+data ProtocolUTxOCostPerWordSupportedInEra era where
+  ProtocolUpdateUTxOCostPerWordInAlonzoEra :: ProtocolUTxOCostPerWordSupportedInEra AlonzoEra
+
+deriving instance Eq   (ProtocolUTxOCostPerWordSupportedInEra era)
+deriving instance Show (ProtocolUTxOCostPerWordSupportedInEra era)
+
+protocolUTxOCostPerWordSupportedInEra
+  :: CardanoEra era
+  -> Maybe (ProtocolUTxOCostPerWordSupportedInEra era)
+protocolUTxOCostPerWordSupportedInEra ByronEra   = Nothing
+protocolUTxOCostPerWordSupportedInEra ShelleyEra = Nothing
+protocolUTxOCostPerWordSupportedInEra AllegraEra = Nothing
+protocolUTxOCostPerWordSupportedInEra MaryEra    = Nothing
+protocolUTxOCostPerWordSupportedInEra AlonzoEra  = Just ProtocolUpdateUTxOCostPerWordInAlonzoEra
+protocolUTxOCostPerWordSupportedInEra BabbageEra = Nothing
+protocolUTxOCostPerWordSupportedInEra ConwayEra  = Nothing
 
 -- | A representation of whether the era supports the 'UTxO Cost Per Byte'
 -- protocol parameter.

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -149,14 +149,6 @@ module Cardano.Api.TxBody (
     txScriptValiditySupportedInCardanoEra,
     totalAndReturnCollateralSupportedInEra,
 
-    -- ** Era-dependent protocol features
-    ProtocolUTxOCostPerByteSupportedInEra(..),
-    ProtocolUTxOCostPerWordSupportedInEra(..),
-
-    -- ** Era-dependent protocol feature availability functions
-    protocolUTxOCostPerByteSupportedInEra,
-    protocolUTxOCostPerWordSupportedInEra,
-
     -- * Inspecting 'ScriptWitness'es
     AnyScriptWitness(..),
     ScriptWitnessIndex(..),
@@ -1317,51 +1309,6 @@ updateProposalSupportedInEra MaryEra    = Just UpdateProposalInMaryEra
 updateProposalSupportedInEra AlonzoEra  = Just UpdateProposalInAlonzoEra
 updateProposalSupportedInEra BabbageEra = Just UpdateProposalInBabbageEra
 updateProposalSupportedInEra ConwayEra  = Just UpdateProposalInConwayEra
-
--- | A representation of whether the era supports the 'UTxO Cost Per Word'
--- protocol parameter.
---
--- The Babbage and subsequent eras support such a protocol parameter.
---
-data ProtocolUTxOCostPerWordSupportedInEra era where
-  ProtocolUpdateUTxOCostPerWordInAlonzoEra :: ProtocolUTxOCostPerWordSupportedInEra AlonzoEra
-
-deriving instance Eq   (ProtocolUTxOCostPerWordSupportedInEra era)
-deriving instance Show (ProtocolUTxOCostPerWordSupportedInEra era)
-
-protocolUTxOCostPerWordSupportedInEra
-  :: CardanoEra era
-  -> Maybe (ProtocolUTxOCostPerWordSupportedInEra era)
-protocolUTxOCostPerWordSupportedInEra ByronEra   = Nothing
-protocolUTxOCostPerWordSupportedInEra ShelleyEra = Nothing
-protocolUTxOCostPerWordSupportedInEra AllegraEra = Nothing
-protocolUTxOCostPerWordSupportedInEra MaryEra    = Nothing
-protocolUTxOCostPerWordSupportedInEra AlonzoEra  = Just ProtocolUpdateUTxOCostPerWordInAlonzoEra
-protocolUTxOCostPerWordSupportedInEra BabbageEra = Nothing
-protocolUTxOCostPerWordSupportedInEra ConwayEra  = Nothing
-
--- | A representation of whether the era supports the 'UTxO Cost Per Byte'
--- protocol parameter.
---
--- The Babbage and subsequent eras support such a protocol parameter.
---
-data ProtocolUTxOCostPerByteSupportedInEra era where
-  ProtocolUpdateUTxOCostPerByteInBabbageEra :: ProtocolUTxOCostPerByteSupportedInEra BabbageEra
-  ProtocolUpdateUTxOCostPerByteInConwayEra  :: ProtocolUTxOCostPerByteSupportedInEra ConwayEra
-
-deriving instance Eq   (ProtocolUTxOCostPerByteSupportedInEra era)
-deriving instance Show (ProtocolUTxOCostPerByteSupportedInEra era)
-
-protocolUTxOCostPerByteSupportedInEra
-  :: CardanoEra era
-  -> Maybe (ProtocolUTxOCostPerByteSupportedInEra era)
-protocolUTxOCostPerByteSupportedInEra ByronEra   = Nothing
-protocolUTxOCostPerByteSupportedInEra ShelleyEra = Nothing
-protocolUTxOCostPerByteSupportedInEra AllegraEra = Nothing
-protocolUTxOCostPerByteSupportedInEra MaryEra    = Nothing
-protocolUTxOCostPerByteSupportedInEra AlonzoEra  = Nothing
-protocolUTxOCostPerByteSupportedInEra BabbageEra = Just ProtocolUpdateUTxOCostPerByteInBabbageEra
-protocolUTxOCostPerByteSupportedInEra ConwayEra  = Just ProtocolUpdateUTxOCostPerByteInConwayEra
 
 -- ----------------------------------------------------------------------------
 -- Building vs viewing transactions

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -149,6 +149,12 @@ module Cardano.Api.TxBody (
     txScriptValiditySupportedInCardanoEra,
     totalAndReturnCollateralSupportedInEra,
 
+    -- ** Era-dependent protocol features
+    ProtocolUTxOCostPerByteSupportedInEra(..),
+
+    -- ** Era-dependent protocol feature availability functions
+    protocolUTxOCostPerByteSupportedInEra,
+
     -- * Inspecting 'ScriptWitness'es
     AnyScriptWitness(..),
     ScriptWitnessIndex(..),
@@ -1309,6 +1315,29 @@ updateProposalSupportedInEra MaryEra    = Just UpdateProposalInMaryEra
 updateProposalSupportedInEra AlonzoEra  = Just UpdateProposalInAlonzoEra
 updateProposalSupportedInEra BabbageEra = Just UpdateProposalInBabbageEra
 updateProposalSupportedInEra ConwayEra  = Just UpdateProposalInConwayEra
+
+-- | A representation of whether the era supports the 'UTxO Cost Per Byte'
+-- protocol parameter.
+--
+-- The Babbage and subsequent eras support such a protocol parameter.
+--
+data ProtocolUTxOCostPerByteSupportedInEra era where
+  ProtocolUpdateUTxOCostPerByteInBabbageEra :: ProtocolUTxOCostPerByteSupportedInEra BabbageEra
+  ProtocolUpdateUTxOCostPerByteInConwayEra  :: ProtocolUTxOCostPerByteSupportedInEra ConwayEra
+
+deriving instance Eq   (ProtocolUTxOCostPerByteSupportedInEra era)
+deriving instance Show (ProtocolUTxOCostPerByteSupportedInEra era)
+
+protocolUTxOCostPerByteSupportedInEra
+  :: CardanoEra era
+  -> Maybe (ProtocolUTxOCostPerByteSupportedInEra era)
+protocolUTxOCostPerByteSupportedInEra ByronEra   = Nothing
+protocolUTxOCostPerByteSupportedInEra ShelleyEra = Nothing
+protocolUTxOCostPerByteSupportedInEra AllegraEra = Nothing
+protocolUTxOCostPerByteSupportedInEra MaryEra    = Nothing
+protocolUTxOCostPerByteSupportedInEra AlonzoEra  = Nothing
+protocolUTxOCostPerByteSupportedInEra BabbageEra = Just ProtocolUpdateUTxOCostPerByteInBabbageEra
+protocolUTxOCostPerByteSupportedInEra ConwayEra  = Just ProtocolUpdateUTxOCostPerByteInConwayEra
 
 -- ----------------------------------------------------------------------------
 -- Building vs viewing transactions

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -294,6 +294,12 @@ module Cardano.Api (
     scriptDataSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
 
+    -- ** Era-dependent protocol features
+    ProtocolUTxOCostPerByteSupportedInEra(..),
+
+    -- ** Era-dependent protocol feature availability functions
+    protocolUTxOCostPerByteSupportedInEra,
+
     -- ** Fee calculation
     LedgerEpochInfo(..),
     transactionFee,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -296,9 +296,11 @@ module Cardano.Api (
 
     -- ** Era-dependent protocol features
     ProtocolUTxOCostPerByteSupportedInEra(..),
+    ProtocolUTxOCostPerWordSupportedInEra(..),
 
     -- ** Era-dependent protocol feature availability functions
     protocolUTxOCostPerByteSupportedInEra,
+    protocolUTxOCostPerWordSupportedInEra,
 
     -- ** Fee calculation
     LedgerEpochInfo(..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -278,7 +278,6 @@ module Cardano.Api (
     UpdateProposalSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
     Feature(..),
-    SupportedInEra(..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,
@@ -296,6 +295,8 @@ module Cardano.Api (
     scriptDataSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
     supportedInEra,
+    maybeSupportedInEra,
+    whenMaybeSupportedInEra,
 
     -- ** Fee calculation
     LedgerEpochInfo(..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -277,6 +277,8 @@ module Cardano.Api (
     CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
+    Feature(..),
+    SupportedInEra(..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,
@@ -293,14 +295,7 @@ module Cardano.Api (
     updateProposalSupportedInEra,
     scriptDataSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
-
-    -- ** Era-dependent protocol features
-    ProtocolUTxOCostPerByteSupportedInEra(..),
-    ProtocolUTxOCostPerWordSupportedInEra(..),
-
-    -- ** Era-dependent protocol feature availability functions
-    protocolUTxOCostPerByteSupportedInEra,
-    protocolUTxOCostPerWordSupportedInEra,
+    supportedInEra,
 
     -- ** Fee calculation
     LedgerEpochInfo(..),
@@ -864,6 +859,7 @@ import           Cardano.Api.DeserialiseAnyOf
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
+import           Cardano.Api.Features
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters

--- a/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
@@ -8,6 +8,8 @@ module Test.Cardano.Api.Typed.JSON
   ( tests
   ) where
 
+import           Cardano.Api
+
 import           Data.Aeson (eitherDecode, encode)
 
 import           Hedgehog (Property, forAll, tripping)
@@ -28,7 +30,8 @@ prop_roundtrip_praos_nonce_JSON = H.property $ do
 
 prop_roundtrip_protocol_parameters_JSON :: Property
 prop_roundtrip_protocol_parameters_JSON = H.property $ do
-  pp <- forAll genProtocolParameters
+  AnyCardanoEra era <- forAll $ Gen.element [minBound .. maxBound]
+  pp <- forAll (genProtocolParameters era)
   tripping pp encode eitherDecode
 
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Also introduce `Feature` data type which encodes the features that may or may not be supported by particular eras.

The `supportedInEra` encodes the logic of whether the support for a feature is supported by an era.

`whenMaybeSupportedInEra` and `maybeSuportedInEra` functions are convenience functions.

This is an alternative implementation of https://github.com/input-output-hk/cardano-api/pull/5

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
