### PR TITLE
Import groups in stylish haskell

### DIFF
--- a/.github/workflows/check-stylish-haskell.yml
+++ b/.github/workflows/check-stylish-haskell.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  check-stylish-haskell:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -9,8 +9,9 @@
 # 5. Redunant imports and pragmas should be removed
 # 6. Consistent syntax
 # 7. No trailing whitespaces
-# 8. Slightly generous screen with assumed
+# 8. Slightly generous screen width assumed
 # 9. All Haskell files in the project are subject to code formatting style
+# 10. Import grouping is handled by stylish-haskell
 
 steps:
   # Principle 4
@@ -40,6 +41,18 @@ steps:
       separate_lists: true
 
       space_surround: false
+
+      # Principle 10
+      group_imports: true
+
+      group_rules:
+        - match: ^Cardano.Api\>
+        - match: ^(Cardano|Ouroboros|PlutusCore|PlutusLedgerApi)\>
+        - match: ^Prelude\>
+        - match: ^(Control|Codec|Data|Formatting|GHC|Lens|Network|Numeric|Options|Prettyprinter|System|Text)\>
+        - match: ^(Test.Gen.Cardano.Api)\>
+        - match: ^(Test.Cardano|Test.Gen.Cardano)\>
+        - match: ^(Hedgehog|HaskellWorks.Hspec|Test)\>
 
   - language_pragmas:
       style: vertical

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -59,6 +59,9 @@ library internal
                         Cardano.Api.HasTypeProxy
                         Cardano.Api.InMode
                         Cardano.Api.IO
+                        Cardano.Api.IO.Compat
+                        Cardano.Api.IO.Compat.Posix
+                        Cardano.Api.IO.Compat.Win32
                         Cardano.Api.IPC
                         Cardano.Api.IPC.Monad
                         Cardano.Api.IPC.Version

--- a/cardano-api/gen/Test/Gen/Cardano/Api.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api.hs
@@ -8,19 +8,18 @@ module Test.Gen.Cardano.Api
   , genAlonzoGenesis
   ) where
 
-import qualified Data.Map.Strict as Map
-import           Data.Word (Word64)
-
---TODO: why do we have this odd split? We can get rid of the old name "typed"
-import           Test.Gen.Cardano.Api.Typed (genCostModel, genRational)
-
+import qualified Cardano.Ledger.Alonzo.Core as Ledger
 import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Coin as Ledger
-import qualified Cardano.Ledger.Alonzo.Core as Ledger
-import           Cardano.Ledger.Shelley.TxAuxData (ShelleyTxAuxData (..), Metadatum (..))
+import           Cardano.Ledger.Shelley.TxAuxData (Metadatum (..), ShelleyTxAuxData (..))
+
+import qualified Data.Map.Strict as Map
+import           Data.Word (Word64)
+
+import           Test.Gen.Cardano.Api.Typed (genCostModel, genRational)
 
 import           Hedgehog (Gen, Range)
 import qualified Hedgehog.Gen as Gen

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Metadata.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Metadata.hs
@@ -7,19 +7,20 @@ module Test.Gen.Cardano.Api.Metadata
   ) where
 
 import           Cardano.Api
-import           Data.Aeson (ToJSON (..))
-import           Data.ByteString (ByteString)
-import           Data.Text (Text)
-import           Data.Word (Word64)
-import           Hedgehog (Gen)
 
+import           Data.Aeson (ToJSON (..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.Map.Strict as Map
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import           Data.Word (Word64)
+
+import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Internal.Gen as Gen
 import qualified Hedgehog.Range as Range

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -127,6 +127,14 @@ import           Cardano.Api.Shelley (GovernancePoll (..), GovernancePollAnswer 
                    StakeCredential (StakeCredentialByKey), StakePoolKey,
                    refInsScriptsAndInlineDatsSupportedInEra)
 
+import qualified Cardano.Binary as CBOR
+import qualified Cardano.Crypto.Hash as Crypto
+import qualified Cardano.Crypto.Hash.Class as CRYPTO
+import qualified Cardano.Crypto.Seed as Crypto
+import           Cardano.Ledger.Alonzo.Language (Language (..))
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import           Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
+import qualified Cardano.Ledger.Shelley.TxBody as Ledger (EraIndependentTxBody)
 
 import           Control.Applicative (optional)
 import           Data.ByteString (ByteString)
@@ -140,24 +148,15 @@ import           Data.String
 import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 
-import qualified Cardano.Binary as CBOR
-import qualified Cardano.Crypto.Hash as Crypto
-import qualified Cardano.Crypto.Seed as Crypto
-import qualified Cardano.Ledger.Shelley.TxBody as Ledger (EraIndependentTxBody)
+import           Test.Gen.Cardano.Api.Metadata (genTxMetadata)
+
+import           Test.Cardano.Chain.UTxO.Gen (genVKWitness)
+import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
 import qualified Test.Cardano.Ledger.Alonzo.PlutusScripts as Plutus
 
 import           Hedgehog (Gen, Range)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-
-import qualified Cardano.Crypto.Hash.Class as CRYPTO
-import           Cardano.Ledger.Alonzo.Language (Language (..))
-import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
-import           Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
-
-import           Test.Cardano.Chain.UTxO.Gen (genVKWitness)
-import           Test.Cardano.Crypto.Gen (genProtocolMagicId)
-import           Test.Gen.Cardano.Api.Metadata (genTxMetadata)
 
 {- HLINT ignore "Reduce duplication" -}
 

--- a/cardano-api/gen/Test/Gen/Cardano/Crypto/Seed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Crypto/Seed.hs
@@ -4,11 +4,12 @@ module Test.Gen.Cardano.Crypto.Seed
   ) where
 
 import           Cardano.Api (AsType, Key)
-import           Cardano.Crypto.Seed (Seed)
-import           Hedgehog (MonadGen, Range)
-
 import qualified Cardano.Api as API
+
+import           Cardano.Crypto.Seed (Seed)
 import qualified Cardano.Crypto.Seed as C
+
+import           Hedgehog (MonadGen, Range)
 import qualified Hedgehog.Gen as G
 import qualified Hedgehog.Range as R
 

--- a/cardano-api/gen/Test/Hedgehog/Roundtrip/Bech32.hs
+++ b/cardano-api/gen/Test/Hedgehog/Roundtrip/Bech32.hs
@@ -3,8 +3,8 @@ module Test.Hedgehog.Roundtrip.Bech32
   ) where
 
 import           Cardano.Api
-import           Hedgehog (Gen, Property)
 
+import           Hedgehog (Gen, Property)
 import qualified Hedgehog as H
 
 roundtrip_Bech32

--- a/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
+++ b/cardano-api/gen/Test/Hedgehog/Roundtrip/CBOR.hs
@@ -10,6 +10,7 @@ import           Cardano.Api
 
 import           GHC.Stack (HasCallStack)
 import qualified GHC.Stack as GHC
+
 import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-api/golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/golden/Test/Golden/ErrorsSpec.hs
@@ -9,13 +9,13 @@ module Test.Golden.ErrorsSpec
 import           Cardano.Api
 import           Cardano.Api.Shelley (LeadershipError (..), OperationalCertIssueError (..),
                    ProtocolParametersError (..), ReferenceScript (..))
+
 import           Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Seed as Crypto
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
 import qualified Cardano.Ledger.Alonzo.TxInfo as Ledger
 import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
-
 import qualified PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
 import qualified PlutusLedgerApi.Common as Plutus
 
@@ -28,13 +28,14 @@ import           Data.Data (Data (..))
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import           Data.Text (Text)
-import           Data.Typeable
+import           Data.Typeable (typeOf, typeRep)
 import           GHC.Stack (withFrozenCallStack)
+import           System.FilePath ((</>))
+
 import qualified HaskellWorks.Hspec.Hedgehog as H
 import           Hedgehog (MonadTest)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Golden as H
-import           System.FilePath ((</>))
 import           Test.Hspec
 
 seed1 :: ByteString

--- a/cardano-api/internal/Cardano/Api/Address.hs
+++ b/cardano-api/internal/Cardano/Api/Address.hs
@@ -77,27 +77,6 @@ module Cardano.Api.Address (
     isKeyAddress
   ) where
 
-import           Control.Applicative ((<|>))
-import           Data.Aeson (FromJSON (..), ToJSON (..), withText, (.=))
-import qualified Data.Aeson as Aeson
-import           Data.Bifunctor (first)
-import qualified Data.ByteString.Base58 as Base58
-import           Data.Char (isAsciiLower, isAsciiUpper, isDigit)
-import           Data.Either.Combinators (rightToMaybe)
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Text.Parsec as Parsec
-import qualified Text.Parsec.String as Parsec
-
-import qualified Cardano.Chain.Common as Byron
-import qualified Cardano.Ledger.Address as Shelley
-import qualified Cardano.Ledger.Alonzo.TxInfo as Alonzo
-import qualified Cardano.Ledger.BaseTypes as Shelley
-import qualified Cardano.Ledger.Credential as Shelley
-import           Cardano.Ledger.Crypto (StandardCrypto)
-import qualified PlutusLedgerApi.V1 as Plutus
-
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Hash
@@ -109,7 +88,28 @@ import           Cardano.Api.Script
 import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.Utils
+
+import qualified Cardano.Chain.Common as Byron
+import qualified Cardano.Ledger.Address as Shelley
+import qualified Cardano.Ledger.Alonzo.TxInfo as Alonzo
+import qualified Cardano.Ledger.BaseTypes as Shelley
+import qualified Cardano.Ledger.Credential as Shelley
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified PlutusLedgerApi.V1 as Plutus
+
+import           Control.Applicative ((<|>))
 import           Control.DeepSeq (NFData (..), deepseq)
+import           Data.Aeson (FromJSON (..), ToJSON (..), withText, (.=))
+import qualified Data.Aeson as Aeson
+import           Data.Bifunctor (first)
+import qualified Data.ByteString.Base58 as Base58
+import           Data.Char (isAsciiLower, isAsciiUpper, isDigit)
+import           Data.Either.Combinators (rightToMaybe)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Text.Parsec as Parsec
+import qualified Text.Parsec.String as Parsec
 
 
 

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -50,19 +50,23 @@ module Cardano.Api.Block (
     makeChainTip,
   ) where
 
-import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), object, withObject, (.:), (.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Short as SBS
-import           Data.Foldable (Foldable (toList))
-import           Data.String (IsString)
-import           Data.Text (Text)
+import           Cardano.Api.Eras
+import           Cardano.Api.Hash
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Keys.Shelley
+import           Cardano.Api.Modes
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseUsing
+import           Cardano.Api.Tx
 
-import           Cardano.Slotting.Block (BlockNo)
-import           Cardano.Slotting.Slot (EpochNo, SlotNo, WithOrigin (..))
-
+import qualified Cardano.Chain.Block as Byron
+import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Crypto.Hashing
+import qualified Cardano.Ledger.Block as Ledger
+import qualified Cardano.Ledger.Era as Ledger
+import           Cardano.Slotting.Block (BlockNo)
+import           Cardano.Slotting.Slot (EpochNo, SlotNo, WithOrigin (..))
 import qualified Ouroboros.Consensus.Block as Consensus
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
 import qualified Ouroboros.Consensus.Cardano.Block as Consensus
@@ -76,19 +80,13 @@ import qualified Ouroboros.Consensus.Shelley.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus
 import qualified Ouroboros.Network.Block as Consensus
 
-import qualified Cardano.Chain.Block as Byron
-import qualified Cardano.Chain.UTxO as Byron
-import qualified Cardano.Ledger.Block as Ledger
-import qualified Cardano.Ledger.Era as Ledger
-
-import           Cardano.Api.Eras
-import           Cardano.Api.Hash
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Keys.Shelley
-import           Cardano.Api.Modes
-import           Cardano.Api.SerialiseRaw
-import           Cardano.Api.SerialiseUsing
-import           Cardano.Api.Tx
+import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), object, withObject, (.:), (.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
+import           Data.Foldable (Foldable (toList))
+import           Data.String (IsString)
+import           Data.Text (Text)
 
 {- HLINT ignore "Use lambda" -}
 {- HLINT ignore "Use lambda-case" -}

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -37,31 +37,6 @@ module Cardano.Api.Certificate (
     AsType(..)
   ) where
 
-import           Data.ByteString (ByteString)
-import qualified Data.Foldable as Foldable
-import qualified Data.Map.Strict as Map
-import           Data.Maybe
-import qualified Data.Sequence.Strict as Seq
-import qualified Data.Set as Set
-import           Data.Text (Text)
-import qualified Data.Text.Encoding as Text
-
-import           Data.IP (IPv4, IPv6)
-import           Network.Socket (PortNumber)
-
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import           Cardano.Slotting.Slot (EpochNo (..))
-
-import           Cardano.Ledger.Crypto (StandardCrypto)
-
-import           Cardano.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
-import qualified Cardano.Ledger.BaseTypes as Shelley
-import qualified Cardano.Ledger.Coin as Shelley (toDeltaCoin)
-import qualified Cardano.Ledger.Core as Shelley
-import qualified Cardano.Ledger.Shelley as Shelley
-import           Cardano.Ledger.Shelley.TxBody (MIRPot (..))
-import qualified Cardano.Ledger.Shelley.TxBody as Shelley
-
 import           Cardano.Api.Address
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
@@ -72,6 +47,28 @@ import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.StakePoolMetadata
 import           Cardano.Api.Value
+
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import           Cardano.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
+import qualified Cardano.Ledger.BaseTypes as Shelley
+import qualified Cardano.Ledger.Coin as Shelley (toDeltaCoin)
+import qualified Cardano.Ledger.Core as Shelley
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Shelley as Shelley
+import           Cardano.Ledger.Shelley.TxBody (MIRPot (..))
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
+import           Cardano.Slotting.Slot (EpochNo (..))
+
+import           Data.ByteString (ByteString)
+import qualified Data.Foldable as Foldable
+import           Data.IP (IPv4, IPv6)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe
+import qualified Data.Sequence.Strict as Seq
+import qualified Data.Set as Set
+import           Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import           Network.Socket (PortNumber)
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
@@ -13,13 +13,6 @@ module Cardano.Api.Convenience.Construction (
 
   ) where
 
-import qualified Data.List as List
-import qualified Data.Map.Strict as Map
-import           Data.Set (Set)
-import qualified Data.Set as Set
-import           Data.Text (Text)
-import qualified Data.Text as Text
-
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
@@ -30,6 +23,13 @@ import           Cardano.Api.Tx
 import           Cardano.Api.TxBody
 import           Cardano.Api.Utils
 import           Cardano.Api.Value
+
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Text (Text)
+import qualified Data.Text as Text
 
 -- | Construct a balanced transaction.
 -- See Cardano.Api.Convenience.Query.queryStateForBalancedTx for a

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -14,18 +14,6 @@ module Cardano.Api.Convenience.Query (
     renderQueryConvenienceError,
   ) where
 
-import           Control.Monad.Trans.Except (ExceptT (..), except, runExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistMaybe, left, onLeft,
-                   onNothing)
-import           Data.Function ((&))
-import           Data.Map (Map)
-import           Data.Maybe (mapMaybe)
-import           Data.Set (Set)
-import qualified Data.Set as Set
-import           Data.Text (Text)
-
-import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch (..))
-
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Convenience.Constraints
@@ -39,7 +27,19 @@ import           Cardano.Api.Query
 import           Cardano.Api.TxBody
 import           Cardano.Api.Utils
 import           Cardano.Api.Value
+
+import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch (..))
+
 import           Control.Monad.Trans (MonadTrans (..))
+import           Control.Monad.Trans.Except (ExceptT (..), except, runExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistMaybe, left, onLeft,
+                   onNothing)
+import           Data.Function ((&))
+import           Data.Map (Map)
+import           Data.Maybe (mapMaybe)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Text (Text)
 
 data QueryConvenienceError
   = AcqFailure AcquiringFailure

--- a/cardano-api/internal/Cardano/Api/DeserialiseAnyOf.hs
+++ b/cardano-api/internal/Cardano/Api/DeserialiseAnyOf.hs
@@ -18,6 +18,19 @@ module Cardano.Api.DeserialiseAnyOf
   , renderSomeAddressVerificationKey
   ) where
 
+import           Cardano.Api.Address
+import           Cardano.Api.Error
+import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Class
+import           Cardano.Api.Keys.Praos
+import           Cardano.Api.Keys.Shelley
+import           Cardano.Api.SerialiseBech32
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseTextEnvelope
+
+import qualified Cardano.Chain.Common as Common
+import qualified Cardano.Crypto.Signing as Crypto
+
 import qualified Data.Aeson as Aeson
 import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)
@@ -29,21 +42,6 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Formatting (build, sformat, (%))
-
-import qualified Cardano.Chain.Common as Common
-import qualified Cardano.Crypto.Signing as Crypto
-
-import           Cardano.Api.Error
-import           Cardano.Api.SerialiseBech32
-import           Cardano.Api.SerialiseRaw
-import           Cardano.Api.SerialiseTextEnvelope
-
--- TODO: Think about if these belong
-import           Cardano.Api.Address
-import           Cardano.Api.Keys.Byron
-import           Cardano.Api.Keys.Class
-import           Cardano.Api.Keys.Praos
-import           Cardano.Api.Keys.Shelley
 
 ------------------------------------------------------------------------------
 -- Formatted/encoded input deserialisation

--- a/cardano-api/internal/Cardano/Api/EraCast.hs
+++ b/cardano-api/internal/Cardano/Api/EraCast.hs
@@ -7,6 +7,7 @@ module Cardano.Api.EraCast
   ) where
 
 import           Cardano.Api.Eras (CardanoEra (..), IsCardanoEra)
+
 import           Data.Kind (Type)
 
 data EraCastError = forall fromEra toEra value.

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -53,15 +53,15 @@ module Cardano.Api.Eras
 
 import           Cardano.Api.HasTypeProxy
 
-import           Control.DeepSeq
-import           Data.Aeson (FromJSON (..), ToJSON, toJSON, withText)
-import qualified Data.Text as Text
-import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
-
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.BaseTypes as L
 import           Ouroboros.Consensus.Shelley.Eras as Consensus (StandardAllegra, StandardAlonzo,
                    StandardBabbage, StandardConway, StandardMary, StandardShelley)
+
+import           Control.DeepSeq
+import           Data.Aeson (FromJSON (..), ToJSON, toJSON, withText)
+import qualified Data.Text as Text
+import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 
 -- | A type used as a tag to distinguish the Byron era.
 data ByronEra

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -40,26 +40,20 @@ module Cardano.Api.Fees (
     mapTxScriptWitnesses,
   ) where
 
-import           Control.Monad (forM_)
-import           Data.Bifunctor (bimap, first)
-import qualified Data.ByteString as BS
-import           Data.ByteString.Short (ShortByteString)
-import           Data.Function ((&))
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes, fromMaybe, maybeToList)
-import           Data.Ratio
-import           Data.Set (Set)
-import qualified Data.Set as Set
-import qualified Data.Text as Text
-import           Lens.Micro ((^.))
-import           Prettyprinter
-import           Prettyprinter.Render.String
+import           Cardano.Api.Address
+import           Cardano.Api.Certificate
+import           Cardano.Api.Eras
+import           Cardano.Api.Error
+import           Cardano.Api.NetworkId
+import           Cardano.Api.ProtocolParameters
+import           Cardano.Api.Query
+import           Cardano.Api.Script
+import           Cardano.Api.Tx
+import           Cardano.Api.TxBody
+import           Cardano.Api.Value
 
 import qualified Cardano.Binary as CBOR
-
 import qualified Cardano.Chain.Common as Byron
-
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
@@ -76,22 +70,24 @@ import           Cardano.Ledger.Mary.Value (MaryValue)
 import qualified Cardano.Ledger.Shelley.API.Wallet as Ledger (evaluateTransactionFee)
 import           Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody)
 import           Cardano.Ledger.UTxO as Ledger (EraUTxO)
-
 import qualified Ouroboros.Consensus.HardFork.History as Consensus
-
 import qualified PlutusLedgerApi.V1 as Plutus
 
-import           Cardano.Api.Address
-import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
-import           Cardano.Api.Error
-import           Cardano.Api.NetworkId
-import           Cardano.Api.ProtocolParameters
-import           Cardano.Api.Query
-import           Cardano.Api.Script
-import           Cardano.Api.Tx
-import           Cardano.Api.TxBody
-import           Cardano.Api.Value
+import           Control.Monad (forM_)
+import           Data.Bifunctor (bimap, first)
+import qualified Data.ByteString as BS
+import           Data.ByteString.Short (ShortByteString)
+import           Data.Function ((&))
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes, fromMaybe, maybeToList)
+import           Data.Ratio
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import           Lens.Micro ((^.))
+import           Prettyprinter
+import           Prettyprinter.Render.String
 
 {- HLINT ignore "Redundant return" -}
 

--- a/cardano-api/internal/Cardano/Api/Genesis.hs
+++ b/cardano-api/internal/Cardano/Api/Genesis.hs
@@ -25,21 +25,11 @@ module Cardano.Api.Genesis
   , ConwayGenesisFile
   ) where
 
-import           Data.ByteString (ByteString)
-import qualified Data.ListMap as ListMap
-import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe)
-import           Data.Text (Text)
-import qualified Data.Time as Time
-import           Lens.Micro
-
-import qualified Cardano.Crypto.Hash.Blake2b
-import qualified Cardano.Crypto.Hash.Class
-
 import           Cardano.Api.IO
 
 import qualified Cardano.Chain.Genesis
-
+import qualified Cardano.Crypto.Hash.Blake2b
+import qualified Cardano.Crypto.Hash.Class
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import           Cardano.Ledger.BaseTypes as Ledger
 import           Cardano.Ledger.Coin (Coin (..))
@@ -48,10 +38,16 @@ import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Cardano.Ledger.Shelley.Core
 import           Cardano.Ledger.Shelley.Genesis (NominalDiffTimeMicro, ShelleyGenesis (..),
                    emptyGenesisStaking)
-
 import qualified Cardano.Ledger.Shelley.Genesis as Ledger
-
 import qualified Ouroboros.Consensus.Shelley.Eras as Shelley
+
+import           Data.ByteString (ByteString)
+import qualified Data.ListMap as ListMap
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
+import           Data.Text (Text)
+import qualified Data.Time as Time
+import           Lens.Micro
 
 data ShelleyConfig = ShelleyConfig
   { scConfig :: !(Ledger.ShelleyGenesis Shelley.StandardCrypto)

--- a/cardano-api/internal/Cardano/Api/GenesisParameters.hs
+++ b/cardano-api/internal/Cardano/Api/GenesisParameters.hs
@@ -16,18 +16,17 @@ module Cardano.Api.GenesisParameters (
 
   ) where
 
-import           Data.Time (NominalDiffTime, UTCTime)
-
-import           Cardano.Slotting.Slot (EpochSize (..))
-
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Cardano.Ledger.Crypto as Ledger
-import qualified Cardano.Ledger.Shelley.Genesis as Shelley
-
 import           Cardano.Api.Eras (ShelleyBasedEra (ShelleyBasedEraShelley))
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Value
+
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Crypto as Ledger
+import qualified Cardano.Ledger.Shelley.Genesis as Shelley
+import           Cardano.Slotting.Slot (EpochSize (..))
+
+import           Data.Time (NominalDiffTime, UTCTime)
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Governance/Poll.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Poll.hs
@@ -36,22 +36,9 @@ module Cardano.Api.Governance.Poll(
     verifyPollAnswer,
   ) where
 
-import           Control.Arrow (left)
-import           Control.Monad (foldM, when)
-import           Data.Either.Combinators (maybeToRight)
-import           Data.Function ((&))
-import qualified Data.Map.Strict as Map
-import           Data.String (IsString(..))
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Lazy as Text.Lazy
-import qualified Data.Text.Lazy.Builder as Text.Builder
-import           Data.Word (Word64)
-import           Formatting (build, sformat)
-
 import           Cardano.Api.Eras
-import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Hash
+import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
@@ -62,11 +49,23 @@ import           Cardano.Api.TxBody
 import           Cardano.Api.TxMetadata
 import           Cardano.Api.Utils
 
-import           Cardano.Binary (DecoderError(..))
-import           Cardano.Ledger.Crypto (HASH, StandardCrypto)
-
+import           Cardano.Binary (DecoderError (..))
 import           Cardano.Crypto.Hash (hashFromBytes, hashToBytes, hashWith)
 import qualified Cardano.Crypto.Hash as Hash
+import           Cardano.Ledger.Crypto (HASH, StandardCrypto)
+
+import           Control.Arrow (left)
+import           Control.Monad (foldM, when)
+import           Data.Either.Combinators (maybeToRight)
+import           Data.Function ((&))
+import qualified Data.Map.Strict as Map
+import           Data.String (IsString (..))
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as Text.Lazy
+import qualified Data.Text.Lazy.Builder as Text.Builder
+import           Data.Word (Word64)
+import           Formatting (build, sformat)
 
 -- | Associated metadata label as defined in CIP-0094
 pollMetadataLabel :: Word64

--- a/cardano-api/internal/Cardano/Api/Hash.hs
+++ b/cardano-api/internal/Cardano/Api/Hash.hs
@@ -7,9 +7,9 @@ module Cardano.Api.Hash
   , AsType(AsHash)
   ) where
 
-import           Data.Kind (Type)
-
 import           Cardano.Api.HasTypeProxy
+
+import           Data.Kind (Type)
 
 
 data family Hash keyrole :: Type

--- a/cardano-api/internal/Cardano/Api/IO/Compat.hs
+++ b/cardano-api/internal/Cardano/Api/IO/Compat.hs
@@ -1,0 +1,23 @@
+{-# OPTIONS_GHC -Wno-dodgy-exports #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Cardano.Api.IO.Compat
+  ( handleFileForWritingWithOwnerPermission
+  , writeSecrets
+  ) where
+
+import           Cardano.Api.Error
+import           Cardano.Api.IO.Compat.Posix
+import           Cardano.Api.IO.Compat.Win32
+
+import           Data.ByteString (ByteString)
+import           System.IO
+
+handleFileForWritingWithOwnerPermission
+  :: FilePath
+  -> (Handle -> IO ())
+  -> IO (Either (FileError e) ())
+handleFileForWritingWithOwnerPermission = handleFileForWritingWithOwnerPermissionImpl
+
+writeSecrets :: FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
+writeSecrets = writeSecretsImpl

--- a/cardano-api/internal/Cardano/Api/IO/Compat/Posix.hs
+++ b/cardano-api/internal/Cardano/Api/IO/Compat/Posix.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+#if !defined(mingw32_HOST_OS)
+#define UNIX
+#endif
+
+module Cardano.Api.IO.Compat.Posix
+  (
+#ifdef UNIX
+    handleFileForWritingWithOwnerPermissionImpl,
+    writeSecretsImpl,
+#endif
+  ) where
+
+#ifdef UNIX
+
+import           Cardano.Api.Error (FileError (..))
+
+import           Control.Exception (IOException, bracket, bracketOnError, try)
+import           Control.Monad (forM_)
+import           Control.Monad.Except (runExceptT)
+import           Control.Monad.Trans.Except.Extra (handleIOExceptT)
+import qualified Data.ByteString as BS
+import           System.Directory ()
+import           System.FilePath ((</>))
+import qualified System.IO as IO
+import           System.IO (Handle)
+import           System.Posix.Files (ownerModes, ownerReadMode, setFdOwnerAndGroup, setFileMode)
+import           System.Posix.IO (OpenMode (..), closeFd, defaultFileFlags, fdToHandle, openFd)
+import           System.Posix.User (getRealUserID)
+import           Text.Printf (printf)
+
+handleFileForWritingWithOwnerPermissionImpl
+  :: FilePath
+  -> (Handle -> IO ())
+  -> IO (Either (FileError e) ())
+handleFileForWritingWithOwnerPermissionImpl path f = do
+  -- On a unix based system, we grab a file descriptor and set ourselves as owner.
+  -- Since we're holding the file descriptor at this point, we can be sure that
+  -- what we're about to write to is owned by us if an error didn't occur.
+  user <- getRealUserID
+  ownedFile <- try $
+    -- We only close the FD on error here, otherwise we let it leak out, since
+    -- it will be immediately turned into a Handle (which will be closed when
+    -- the Handle is closed)
+    bracketOnError
+      (openFd path WriteOnly (Just ownerModes) defaultFileFlags)
+      closeFd
+      (\fd -> setFdOwnerAndGroup fd user (-1) >> pure fd)
+  case ownedFile of
+    Left (err :: IOException) -> do
+      pure $ Left $ FileIOError path err
+    Right fd -> do
+      bracket
+        (fdToHandle fd)
+        IO.hClose
+        (runExceptT . handleIOExceptT (FileIOError path) . f)
+
+writeSecretsImpl :: FilePath -> [Char] -> [Char] -> (a -> BS.ByteString) -> [a] -> IO ()
+writeSecretsImpl outDir prefix suffix secretOp xs =
+  forM_ (zip xs [0::Int ..]) $
+  \(secret, nr)-> do
+    let filename = outDir </> prefix <> "." <> printf "%03d" nr <> "." <> suffix
+    BS.writeFile filename $ secretOp secret
+    setFileMode filename ownerReadMode
+
+#endif

--- a/cardano-api/internal/Cardano/Api/IO/Compat/Win32.hs
+++ b/cardano-api/internal/Cardano/Api/IO/Compat/Win32.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE CPP #-}
+
+#if !defined(mingw32_HOST_OS)
+#define UNIX
+#endif
+
+module Cardano.Api.IO.Compat.Win32
+  (
+#ifndef UNIX
+    handleFileForWritingWithOwnerPermissionImpl,
+    writeSecretsImpl,
+#endif
+  ) where
+
+#ifndef UNIX
+
+import           Cardano.Api.Error (FileError (..))
+
+import           Control.Exception (bracketOnError)
+import           Control.Monad (forM_)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified System.Directory as IO
+import           System.Directory (emptyPermissions, readable, setPermissions)
+import           System.FilePath (splitFileName, (<.>), (</>))
+import qualified System.IO as IO
+import           System.IO (Handle)
+import           Text.Printf (printf)
+
+handleFileForWritingWithOwnerPermissionImpl
+  :: FilePath
+  -> (Handle -> IO ())
+  -> IO (Either (FileError e) ())
+handleFileForWritingWithOwnerPermissionImpl path f = do
+  -- On something other than unix, we make a _new_ file, and since we created it,
+  -- we must own it. We then place it at the target location. Unfortunately this
+  -- won't work correctly with pseudo-files.
+  bracketOnError
+    (IO.openTempFile targetDir $ targetFile <.> "tmp")
+    (\(tmpPath, h) -> do
+      IO.hClose h >> IO.removeFile tmpPath
+      return . Left $ FileErrorTempFile path tmpPath h)
+    (\(tmpPath, h) -> do
+        f h
+        IO.hClose h
+        IO.renameFile tmpPath path
+        return $ Right ())
+  where
+    (targetDir, targetFile) = splitFileName path
+
+writeSecretsImpl :: FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
+writeSecretsImpl outDir prefix suffix secretOp xs =
+  forM_ (zip xs [0::Int ..]) $
+  \(secret, nr)-> do
+    let filename = outDir </> prefix <> "." <> printf "%03d" nr <> "." <> suffix
+    BS.writeFile filename $ secretOp secret
+    setPermissions filename (emptyPermissions {readable = True})
+
+#endif

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -82,17 +82,29 @@ module Cardano.Api.IPC (
     UnsupportedNtcVersionError(..),
   ) where
 
-import           Data.Void (Void)
+import           Cardano.Api.Block
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.InMode
+import           Cardano.Api.IO
+import           Cardano.Api.IPC.Version
+import           Cardano.Api.Modes
+import           Cardano.Api.NetworkId
+import           Cardano.Api.Protocol
+import           Cardano.Api.Query
+import           Cardano.Api.Tx (getTxBody)
+import           Cardano.Api.TxBody
 
-import           Data.Aeson (ToJSON, object, toJSON, (.=))
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Map.Strict as Map
-
-import           Control.Concurrent.STM (TMVar, atomically, newEmptyTMVarIO, putTMVar, takeTMVar,
-                   tryPutTMVar)
-import           Control.Monad (void)
-import           Control.Tracer (nullTracer)
-
+import qualified Ouroboros.Consensus.Block as Consensus
+import           Ouroboros.Consensus.Cardano.CanHardFork
+import qualified Ouroboros.Consensus.Ledger.Query as Consensus
+import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Consensus
+import qualified Ouroboros.Consensus.Ledger.SupportsProtocol as Consensus
+import qualified Ouroboros.Consensus.Network.NodeToClient as Consensus
+import qualified Ouroboros.Consensus.Node.NetworkProtocolVersion as Consensus
+import qualified Ouroboros.Consensus.Node.ProtocolInfo as Consensus
+import qualified Ouroboros.Consensus.Protocol.TPraos as Consensus
+import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Consensus
 import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 import qualified Ouroboros.Network.Block as Net
 import qualified Ouroboros.Network.Mux as Net
@@ -114,29 +126,14 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Client (LocalTxSub
                    SubmitResult (..))
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
 
-import qualified Ouroboros.Consensus.Block as Consensus
-import           Ouroboros.Consensus.Cardano.CanHardFork
-import qualified Ouroboros.Consensus.Ledger.Query as Consensus
-import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Consensus
-import qualified Ouroboros.Consensus.Ledger.SupportsProtocol as Consensus
-import qualified Ouroboros.Consensus.Network.NodeToClient as Consensus
-import qualified Ouroboros.Consensus.Node.NetworkProtocolVersion as Consensus
-import qualified Ouroboros.Consensus.Node.ProtocolInfo as Consensus
-import qualified Ouroboros.Consensus.Protocol.TPraos as Consensus
-import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
-import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Consensus
-
-import           Cardano.Api.Block
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.InMode
-import           Cardano.Api.IO
-import           Cardano.Api.IPC.Version
-import           Cardano.Api.Modes
-import           Cardano.Api.NetworkId
-import           Cardano.Api.Protocol
-import           Cardano.Api.Query
-import           Cardano.Api.Tx (getTxBody)
-import           Cardano.Api.TxBody
+import           Control.Concurrent.STM (TMVar, atomically, newEmptyTMVarIO, putTMVar, takeTMVar,
+                   tryPutTMVar)
+import           Control.Monad (void)
+import           Control.Tracer (nullTracer)
+import           Data.Aeson (ToJSON, object, toJSON, (.=))
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map.Strict as Map
+import           Data.Void (Void)
 
 -- ----------------------------------------------------------------------------
 -- The types for the client side of the node-to-client IPC protocols

--- a/cardano-api/internal/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/internal/Cardano/Api/IPC/Monad.hs
@@ -9,21 +9,21 @@ module Cardano.Api.IPC.Monad
   , determineEraExpr
   ) where
 
+import           Cardano.Api.Block
+import           Cardano.Api.Eras
+import           Cardano.Api.IPC
+import           Cardano.Api.IPC.Version
+import           Cardano.Api.Modes
+
+import           Cardano.Ledger.Shelley.Scripts ()
+import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as Net.Query
+
 import           Control.Concurrent.STM
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import           Control.Monad.Trans.Cont
 import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
-
-import           Cardano.Ledger.Shelley.Scripts ()
-import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as Net.Query
-
-import           Cardano.Api.Block
-import           Cardano.Api.Eras
-import           Cardano.Api.IPC
-import           Cardano.Api.IPC.Version
-import           Cardano.Api.Modes
 
 
 {- HLINT ignore "Use const" -}

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -24,7 +24,10 @@ module Cardano.Api.InMode (
     fromConsensusApplyTxErr,
   ) where
 
-import           Data.SOP.Strict (NS (S, Z))
+import           Cardano.Api.Eras
+import           Cardano.Api.Modes
+import           Cardano.Api.Tx
+import           Cardano.Api.TxBody
 
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
 import qualified Ouroboros.Consensus.Cardano.Block as Consensus
@@ -38,10 +41,7 @@ import qualified Ouroboros.Consensus.Shelley.HFEras as Consensus
 import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 import qualified Ouroboros.Consensus.TypeFamilyWrappers as Consensus
 
-import           Cardano.Api.Eras
-import           Cardano.Api.Modes
-import           Cardano.Api.Tx
-import           Cardano.Api.TxBody
+import           Data.SOP.Strict (NS (S, Z))
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Keys/Class.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Class.hs
@@ -11,18 +11,17 @@ module Cardano.Api.Keys.Class
   , AsType(AsVerificationKey, AsSigningKey)
   ) where
 
-import           Data.Kind (Type)
-
-import qualified Cardano.Crypto.DSIGN.Class as Crypto
-import qualified Cardano.Crypto.Seed as Crypto
-
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
-import           System.Random (StdGen)
 
+import qualified Cardano.Crypto.DSIGN.Class as Crypto
+import qualified Cardano.Crypto.Seed as Crypto
+
+import           Data.Kind (Type)
 import qualified System.Random as Random
+import           System.Random (StdGen)
 
 -- | An interface for cryptographic keys used for signatures with a 'SigningKey'
 -- and a 'VerificationKey' key.

--- a/cardano-api/internal/Cardano/Api/Keys/Praos.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Praos.hs
@@ -26,9 +26,14 @@ module Cardano.Api.Keys.Praos (
     signArbitraryBytesKes,
   ) where
 
-import           Data.ByteString (ByteString)
-import           Data.Either.Combinators (maybeToRight)
-import           Data.String (IsString (..))
+import           Cardano.Api.Hash
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Keys.Class
+import           Cardano.Api.SerialiseBech32
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseTextEnvelope
+import           Cardano.Api.SerialiseUsing
 
 import qualified Cardano.Crypto.DSIGN.Class as Crypto
 import qualified Cardano.Crypto.Hash.Class as Crypto
@@ -38,14 +43,9 @@ import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Crypto as Shelley (KES, VRF)
 import qualified Cardano.Ledger.Keys as Shelley
 
-import           Cardano.Api.Hash
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Keys.Class
-import           Cardano.Api.SerialiseBech32
-import           Cardano.Api.SerialiseCBOR
-import           Cardano.Api.SerialiseRaw
-import           Cardano.Api.SerialiseTextEnvelope
-import           Cardano.Api.SerialiseUsing
+import           Data.ByteString (ByteString)
+import           Data.Either.Combinators (maybeToRight)
+import           Data.String (IsString (..))
 
 --
 -- KES keys

--- a/cardano-api/internal/Cardano/Api/Keys/Read.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Read.hs
@@ -10,11 +10,6 @@ module Cardano.Api.Keys.Read
   , readKeyFileAnyOf
   ) where
 
-import           Control.Exception
-import           Data.Bifunctor
-import           Data.ByteString as BS
-import           Data.List.NonEmpty (NonEmpty)
-
 import           Cardano.Api.DeserialiseAnyOf
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
@@ -22,6 +17,11 @@ import           Cardano.Api.IO
 import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.Utils
+
+import           Control.Exception
+import           Data.Bifunctor
+import           Data.ByteString as BS
+import           Data.List.NonEmpty (NonEmpty)
 
 -- | Read a cryptographic key from a file.
 --

--- a/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
@@ -35,24 +35,6 @@ module Cardano.Api.Keys.Shelley (
     Hash(..),
   ) where
 
-import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText, withText)
-import           Data.Bifunctor (first)
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import           Data.Either.Combinators (maybeToRight)
-import           Data.Maybe
-import           Data.String (IsString (..))
-import qualified Data.Text as Text
-
-import qualified Cardano.Crypto.DSIGN.Class as Crypto
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Cardano.Crypto.Seed as Crypto
-import qualified Cardano.Crypto.Wallet as Crypto.HD
-import qualified Cardano.Ledger.Crypto as Shelley (DSIGN)
-import qualified Cardano.Ledger.Keys as Shelley
-
-import           Cardano.Ledger.Crypto (StandardCrypto)
-
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
@@ -63,6 +45,23 @@ import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.SerialiseUsing
+
+import qualified Cardano.Crypto.DSIGN.Class as Crypto
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Crypto.Seed as Crypto
+import qualified Cardano.Crypto.Wallet as Crypto.HD
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Crypto as Shelley (DSIGN)
+import qualified Cardano.Ledger.Keys as Shelley
+
+import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText, withText)
+import           Data.Bifunctor (first)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import           Data.Either.Combinators (maybeToRight)
+import           Data.Maybe
+import           Data.String (IsString (..))
+import qualified Data.Text as Text
 
 --
 -- Shelley payment keys

--- a/cardano-api/internal/Cardano/Api/LedgerEvent.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerEvent.hs
@@ -22,6 +22,7 @@ import           Cardano.Api.Block (EpochNo)
 import           Cardano.Api.Certificate (Certificate)
 import           Cardano.Api.Keys.Shelley (Hash (StakePoolKeyHash), StakePoolKey)
 import           Cardano.Api.Value (Lovelace, fromShelleyDeltaLovelace, fromShelleyLovelace)
+
 import           Cardano.Ledger.Alonzo.Rules (AlonzoBbodyEvent (..), AlonzoUtxoEvent (..),
                    AlonzoUtxosEvent (FailedPlutusScriptsEvent, SuccessfulPlutusScriptsEvent),
                    AlonzoUtxowEvent (..))
@@ -42,12 +43,6 @@ import           Cardano.Ledger.Shelley.Rules (RupdEvent (..), ShelleyBbodyEvent
                    ShelleyUtxowEvent (UtxoEvent))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley (ShelleyLedgerEvent (UtxowEvent),
                    ShelleyLedgersEvent (LedgerEvent))
-import           Control.State.Transition (Event)
-import           Data.List.NonEmpty (NonEmpty)
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           Data.Set (Set)
-import           Data.SOP.Strict
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import           Ouroboros.Consensus.Cardano.Block (HardForkBlock)
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (getOneEraLedgerEvent)
@@ -55,6 +50,13 @@ import           Ouroboros.Consensus.Ledger.Basics (AuxLedgerEvent)
 import           Ouroboros.Consensus.Shelley.Ledger (LedgerState, ShelleyBlock,
                    ShelleyLedgerEvent (ShelleyLedgerEventBBODY, ShelleyLedgerEventTICK))
 import           Ouroboros.Consensus.TypeFamilyWrappers (WrapLedgerEvent (unwrapLedgerEvent))
+
+import           Control.State.Transition (Event)
+import           Data.List.NonEmpty (NonEmpty)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import           Data.SOP.Strict
 
 data LedgerEvent
   = -- | The given pool is being registered for the first time on chain.

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -80,45 +80,6 @@ module Cardano.Api.LedgerState
   )
   where
 
-import qualified Cardano.Binary as CBOR
-import           Control.Exception
-import           Control.Monad (when)
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left)
-import           Data.Aeson as Aeson
-import           Data.Aeson.Types (Parser)
-import           Data.Bifunctor
-import           Data.ByteArray (ByteArrayAccess)
-import qualified Data.ByteArray
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Lazy as LB
-import           Data.ByteString.Short as BSS
-import           Data.Foldable
-import           Data.IORef
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           Data.Maybe (mapMaybe)
-import           Data.Proxy (Proxy (Proxy))
-import           Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
-import           Data.Set (Set)
-import qualified Data.Set as Set
-import           Data.SOP.Strict (K (..), NP (..), fn, (:.:) (Comp))
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.Lazy as LT
-import           Data.Text.Lazy.Builder (toLazyText)
-import           Data.Word
-import qualified Data.Yaml as Yaml
-import           Formatting.Buildable (build)
-import           Lens.Micro ((^.))
-import           Network.TypedProtocol.Pipelined (Nat (..))
-import           System.FilePath
-
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
@@ -139,6 +100,8 @@ import           Cardano.Api.Query (CurrentEpochState (..), PoolDistribution (un
                    ProtocolState, SerialisedCurrentEpochState (..), SerialisedPoolDistribution,
                    decodeCurrentEpochState, decodePoolDistribution, decodeProtocolState)
 import           Cardano.Api.Utils (textShow)
+
+import qualified Cardano.Binary as CBOR
 import qualified Cardano.Chain.Genesis
 import qualified Cardano.Chain.Update
 import           Cardano.Crypto (ProtocolMagicId (unProtocolMagicId), RequiresNetworkMagic (..))
@@ -200,6 +163,44 @@ import qualified Ouroboros.Network.Block
 import qualified Ouroboros.Network.Protocol.ChainSync.Client as CS
 import qualified Ouroboros.Network.Protocol.ChainSync.ClientPipelined as CSP
 import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+
+import           Control.Exception
+import           Control.Monad (when)
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left)
+import           Data.Aeson as Aeson
+import           Data.Aeson.Types (Parser)
+import           Data.Bifunctor
+import           Data.ByteArray (ByteArrayAccess)
+import qualified Data.ByteArray
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Lazy as LB
+import           Data.ByteString.Short as BSS
+import           Data.Foldable
+import           Data.IORef
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
+import           Data.Proxy (Proxy (Proxy))
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.SOP.Strict (K (..), NP (..), fn, (:.:) (Comp))
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Lazy as LT
+import           Data.Text.Lazy.Builder (toLazyText)
+import           Data.Word
+import qualified Data.Yaml as Yaml
+import           Formatting.Buildable (build)
+import           Lens.Micro ((^.))
+import           Network.TypedProtocol.Pipelined (Nat (..))
+import           System.FilePath
 
 data InitialLedgerStateError
   = ILSEConfigFile Text

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -44,13 +44,9 @@ module Cardano.Api.Modes (
   ) where
 
 import           Cardano.Api.Eras
+
+import qualified Cardano.Chain.Slotting as Byron (EpochSlots (..))
 import           Cardano.Ledger.Crypto (StandardCrypto)
-
-import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value)
-import           Data.Aeson.Types (Parser, prependFailure, typeMismatch)
-import           Data.SOP.Strict (K (K), NS (S, Z))
-import           Data.Text (Text)
-
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
 import qualified Ouroboros.Consensus.Cardano.Block as Consensus
 import qualified Ouroboros.Consensus.Cardano.ByronHFC as Consensus (ByronBlockHFC)
@@ -61,7 +57,10 @@ import qualified Ouroboros.Consensus.Protocol.TPraos as Consensus
 import qualified Ouroboros.Consensus.Shelley.HFEras as Consensus
 import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus
 
-import qualified Cardano.Chain.Slotting as Byron (EpochSlots (..))
+import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value)
+import           Data.Aeson.Types (Parser, prependFailure, typeMismatch)
+import           Data.SOP.Strict (K (K), NS (S, Z))
+import           Data.Text (Text)
 
 -- ----------------------------------------------------------------------------
 -- Consensus modes

--- a/cardano-api/internal/Cardano/Api/NetworkId.hs
+++ b/cardano-api/internal/Cardano/Api/NetworkId.hs
@@ -16,13 +16,12 @@ module Cardano.Api.NetworkId (
     fromShelleyNetwork,
   ) where
 
-import           Ouroboros.Network.Magic (NetworkMagic (..))
-
 import qualified Cardano.Chain.Common as Byron (NetworkMagic (..))
 import qualified Cardano.Chain.Genesis as Byron (mainnetProtocolMagicId)
 import qualified Cardano.Crypto.ProtocolMagic as Byron (ProtocolMagicId (..),
                    RequiresNetworkMagic (..))
 import qualified Cardano.Ledger.BaseTypes as Shelley (Network (..))
+import           Ouroboros.Network.Magic (NetworkMagic (..))
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/OperationalCertificate.hs
+++ b/cardano-api/internal/Cardano/Api/OperationalCertificate.hs
@@ -18,11 +18,6 @@ module Cardano.Api.OperationalCertificate (
     AsType(..)
   ) where
 
-import           Data.Word
-
-import           Cardano.Ledger.Crypto (StandardCrypto)
-import qualified Cardano.Ledger.Keys as Shelley
-
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Error
@@ -36,7 +31,11 @@ import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.Tx
 
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Keys as Shelley
 import qualified Cardano.Protocol.TPraos.OCert as Shelley
+
+import           Data.Word
 
 -- ----------------------------------------------------------------------------
 -- Operational certificates

--- a/cardano-api/internal/Cardano/Api/Orphans.hs
+++ b/cardano-api/internal/Cardano/Api/Orphans.hs
@@ -5,13 +5,13 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Cardano.Api.Orphans () where
 
-import           Data.Aeson (ToJSON (..), object, pairs, (.=))
-import qualified Data.Aeson as Aeson
-import           Data.Data (Data)
-
 import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
 import qualified Cardano.Ledger.Crypto as Crypto
 import qualified Ouroboros.Consensus.Shelley.Ledger.Query as Consensus
+
+import           Data.Aeson (ToJSON (..), object, pairs, (.=))
+import qualified Data.Aeson as Aeson
+import           Data.Data (Data)
 
 -- FIXME: A temporary workaround for missing Eq and Data instances in plutus-ledger-api
 -- TODO: remove this when plutus-ledger-api gets bumped to >=1.6.1

--- a/cardano-api/internal/Cardano/Api/Protocol.hs
+++ b/cardano-api/internal/Cardano/Api/Protocol.hs
@@ -15,23 +15,23 @@ module Cardano.Api.Protocol
   , ProtocolClientInfoArgs(..)
   ) where
 
+import           Cardano.Api.Modes
+
 import           Ouroboros.Consensus.Cardano
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.ByronHFC (ByronBlockHFC)
 import           Ouroboros.Consensus.Cardano.Node
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
+import qualified Ouroboros.Consensus.Ledger.SupportsProtocol as Consensus
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolClientInfo (..), ProtocolInfo (..))
 import           Ouroboros.Consensus.Node.Run (RunNode)
+import           Ouroboros.Consensus.Protocol.Praos.Translate ()
 import qualified Ouroboros.Consensus.Protocol.TPraos as Consensus
+import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Consensus
 import           Ouroboros.Consensus.Shelley.Node.Praos
 import           Ouroboros.Consensus.Shelley.ShelleyHFC (ShelleyBlockHFC)
 import           Ouroboros.Consensus.Util.IOLike (IOLike)
-
-import           Cardano.Api.Modes
-import qualified Ouroboros.Consensus.Ledger.SupportsProtocol as Consensus
-import           Ouroboros.Consensus.Protocol.Praos.Translate ()
-import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
-import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Consensus
 
 class (RunNode blk, IOLike m) => Protocol m blk where
   data ProtocolInfoArgs m blk

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -72,6 +72,39 @@ module Cardano.Api.ProtocolParameters (
     AsType(..),
   ) where
 
+import           Cardano.Api.Address
+import           Cardano.Api.Eras
+import           Cardano.Api.Error
+import           Cardano.Api.Hash
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Json (toRationalJSON)
+import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Shelley
+import           Cardano.Api.Orphans ()
+import           Cardano.Api.Script
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseTextEnvelope
+import           Cardano.Api.SerialiseUsing
+import           Cardano.Api.StakePoolMetadata
+import           Cardano.Api.TxMetadata
+import           Cardano.Api.Utils
+import           Cardano.Api.Value
+
+import qualified Cardano.Binary as CBOR
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Ledger.Alonzo.Language as Alonzo
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.Api.Era as Ledger
+import           Cardano.Ledger.Api.PParams
+import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Core as Ledger
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Keys as Ledger
+import qualified Cardano.Ledger.Shelley.API as Ledger
+import           Cardano.Slotting.Slot (EpochNo)
+
 import           Control.Monad
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.!=), (.:), (.:?),
                    (.=))
@@ -87,47 +120,7 @@ import           Data.String (IsString)
 import           GHC.Generics
 import           Lens.Micro
 import           Numeric.Natural
-
-import           Cardano.Api.Json (toRationalJSON)
-import qualified Cardano.Binary as CBOR
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import           Cardano.Slotting.Slot (EpochNo)
-
-import qualified Cardano.Ledger.Api.Era as Ledger
-import           Cardano.Ledger.Api.PParams
-import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Cardano.Ledger.Core as Ledger
-import           Cardano.Ledger.Crypto (StandardCrypto)
-import qualified Cardano.Ledger.Keys as Ledger
-
--- Some of the things from Cardano.Ledger.ShelleyPParams are generic across all
--- eras, and some are specific to the Shelley era (and other pre-Alonzo eras).
--- So we import in twice under different names.
-
-import qualified Cardano.Ledger.Alonzo.Language as Alonzo
-import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
-import qualified Cardano.Ledger.Shelley.API as Ledger
-
 import           Text.PrettyBy.Default (display)
-
-import           Cardano.Api.Address
-import           Cardano.Api.Eras
-import           Cardano.Api.Error
-import           Cardano.Api.Hash
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Keys.Byron
-import           Cardano.Api.Keys.Shelley
-import           Cardano.Api.Orphans ()
-import           Cardano.Api.Script
-import           Cardano.Api.SerialiseCBOR
-import           Cardano.Api.SerialiseRaw
-import           Cardano.Api.SerialiseTextEnvelope
-import           Cardano.Api.SerialiseUsing
-import           Cardano.Api.StakePoolMetadata
-import           Cardano.Api.TxMetadata
-import           Cardano.Api.Utils
-import           Cardano.Api.Value
 
 -- | The values of the set of /updatable/ protocol parameters. At any
 -- particular point on the chain there is a current set of parameters in use.

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -78,6 +78,49 @@ module Cardano.Api.Query (
     fromLedgerUTxO,
   ) where
 
+import           Cardano.Api.Address
+import           Cardano.Api.Block
+import           Cardano.Api.Certificate
+import           Cardano.Api.EraCast
+import           Cardano.Api.Eras
+import           Cardano.Api.GenesisParameters
+import           Cardano.Api.IPC.Version
+import           Cardano.Api.Keys.Shelley
+import           Cardano.Api.Modes
+import           Cardano.Api.NetworkId
+import           Cardano.Api.ProtocolParameters
+import           Cardano.Api.TxBody
+import           Cardano.Api.Value
+
+import qualified Cardano.Chain.Update.Validation.Interface as Byron.Update
+import           Cardano.Ledger.Binary
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import qualified Cardano.Ledger.Credential as Shelley
+import           Cardano.Ledger.Crypto (Crypto)
+import qualified Cardano.Ledger.Shelley.API as Shelley
+import qualified Cardano.Ledger.Shelley.Core as Core
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
+import           Cardano.Slotting.EpochInfo (hoistEpochInfo)
+import           Cardano.Slotting.Slot (WithOrigin (..))
+import           Cardano.Slotting.Time (SystemStart (..))
+import           Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTime, SlotLength)
+import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
+import           Ouroboros.Consensus.Cardano.Block (LedgerState (..), StandardCrypto)
+import qualified Ouroboros.Consensus.Cardano.Block as Consensus
+import qualified Ouroboros.Consensus.HardFork.Combinator as Consensus
+import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
+import qualified Ouroboros.Consensus.HardFork.Combinator.AcrossEras as Consensus
+import qualified Ouroboros.Consensus.HardFork.Combinator.Degenerate as Consensus
+import qualified Ouroboros.Consensus.HardFork.History as Consensus
+import qualified Ouroboros.Consensus.HardFork.History as History
+import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
+import qualified Ouroboros.Consensus.Ledger.Query as Consensus
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+import           Ouroboros.Network.Block (Serialised (..))
+import           Ouroboros.Network.NodeToClient.Version (NodeToClientVersion (..))
+import           Ouroboros.Network.Protocol.LocalStateQuery.Client (Some (..))
+
 import           Control.Monad (forM)
 import           Control.Monad.Trans.Except
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.=))
@@ -98,54 +141,6 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Typeable
 import           Data.Word (Word64)
-
-import           Ouroboros.Network.Protocol.LocalStateQuery.Client (Some (..))
-
-import qualified Ouroboros.Consensus.HardFork.Combinator as Consensus
-import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
-import qualified Ouroboros.Consensus.HardFork.Combinator.AcrossEras as Consensus
-import qualified Ouroboros.Consensus.HardFork.Combinator.Degenerate as Consensus
-import qualified Ouroboros.Consensus.HardFork.History as Consensus
-import qualified Ouroboros.Consensus.HardFork.History as History
-import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
-
-import           Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTime, SlotLength)
-import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
-import           Ouroboros.Consensus.Cardano.Block (LedgerState (..), StandardCrypto)
-import qualified Ouroboros.Consensus.Cardano.Block as Consensus
-import qualified Ouroboros.Consensus.Ledger.Query as Consensus
-import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
-import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
-import           Ouroboros.Network.Block (Serialised (..))
-import           Ouroboros.Network.NodeToClient.Version (NodeToClientVersion (..))
-
-import           Cardano.Slotting.EpochInfo (hoistEpochInfo)
-import           Cardano.Slotting.Slot (WithOrigin (..))
-import           Cardano.Slotting.Time (SystemStart (..))
-
-import qualified Cardano.Chain.Update.Validation.Interface as Byron.Update
-
-import           Cardano.Ledger.Binary
-import qualified Cardano.Ledger.Binary.Plain as Plain
-import qualified Cardano.Ledger.Credential as Shelley
-import           Cardano.Ledger.Crypto (Crypto)
-import qualified Cardano.Ledger.Shelley.API as Shelley
-import qualified Cardano.Ledger.Shelley.Core as Core
-import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
-
-import           Cardano.Api.Address
-import           Cardano.Api.Block
-import           Cardano.Api.Certificate
-import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
-import           Cardano.Api.GenesisParameters
-import           Cardano.Api.IPC.Version
-import           Cardano.Api.Keys.Shelley
-import           Cardano.Api.Modes
-import           Cardano.Api.NetworkId
-import           Cardano.Api.ProtocolParameters
-import           Cardano.Api.TxBody
-import           Cardano.Api.Value
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -106,51 +106,6 @@ module Cardano.Api.Script (
     Hash(..),
   ) where
 
-import qualified Data.ByteString.Lazy as LBS
-import           Data.ByteString.Short (ShortByteString)
-import qualified Data.ByteString.Short as SBS
-import           Data.Either.Combinators (maybeToRight)
-import           Data.Foldable (toList)
-import           Data.Functor
-import           Data.Scientific (toBoundedInteger)
-import           Data.String (IsString)
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
-import           Data.Typeable (Typeable)
-import           Numeric.Natural (Natural)
-
-import           Data.Aeson (Value (..), object, (.:), (.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Types as Aeson
-import           Data.Vector (Vector)
-import qualified Data.Vector as Vector
-
-import           Control.Applicative
-import           Control.Monad
-
-import qualified Cardano.Binary as CBOR
-
-import qualified Cardano.Crypto.Hash.Class as Crypto
-
-import           Cardano.Slotting.Slot (SlotNo)
-
-import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import           Cardano.Ledger.Core (Era (EraCrypto))
-import qualified Cardano.Ledger.Core as Ledger
-
-import qualified Cardano.Ledger.Allegra.Scripts as Timelock
-import qualified Cardano.Ledger.Keys as Shelley
-import qualified Cardano.Ledger.Shelley.Scripts as Shelley
-import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
-
-import qualified Cardano.Ledger.Alonzo.Language as Alonzo
-import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
-import qualified Cardano.Ledger.Binary as Binary (decCBOR, decodeFullAnnotator)
-
-import qualified PlutusLedgerApi.Test.Examples as Plutus
-
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
@@ -165,7 +120,44 @@ import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.SerialiseUsing
 import           Cardano.Api.TxIn
 import           Cardano.Api.Utils (failEitherWith)
+
+import qualified Cardano.Binary as CBOR
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Ledger.Allegra.Scripts as Timelock
+import qualified Cardano.Ledger.Alonzo.Language as Alonzo
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
+import qualified Cardano.Ledger.Binary as Binary (decCBOR, decodeFullAnnotator)
+import           Cardano.Ledger.Core (Era (EraCrypto))
+import qualified Cardano.Ledger.Core as Ledger
+import qualified Cardano.Ledger.Keys as Shelley
+import qualified Cardano.Ledger.Shelley.Scripts as Shelley
+import           Cardano.Slotting.Slot (SlotNo)
+import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
+import qualified PlutusLedgerApi.Test.Examples as Plutus
+
+import           Control.Applicative
+import           Control.Monad
+import           Data.Aeson (Value (..), object, (.:), (.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import           Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as SBS
+import           Data.Either.Combinators (maybeToRight)
+import           Data.Foldable (toList)
+import           Data.Functor
+import           Data.Scientific (toBoundedInteger)
 import qualified Data.Sequence.Strict as Seq
+import           Data.String (IsString)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
+import           Data.Typeable (Typeable)
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import           Numeric.Natural (Natural)
 
 -- ----------------------------------------------------------------------------
 -- Types for script language and version

--- a/cardano-api/internal/Cardano/Api/ScriptData.hs
+++ b/cardano-api/internal/Cardano/Api/ScriptData.hs
@@ -44,8 +44,32 @@ module Cardano.Api.ScriptData (
     Hash(..),
   ) where
 
+import           Cardano.Api.Eras
+import           Cardano.Api.Error
+import           Cardano.Api.Hash
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Keys.Shelley
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.SerialiseJSON
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseUsing
+import           Cardano.Api.TxMetadata (pBytes, pSigned, parseAll)
+
 import qualified Cardano.Binary as CBOR
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Ledger.Alonzo.Scripts.Data as Alonzo
+import           Cardano.Ledger.Core (Era)
+import qualified Cardano.Ledger.SafeHash as Ledger
+import           Ouroboros.Consensus.Shelley.Eras (StandardAlonzo, StandardCrypto)
+import qualified PlutusLedgerApi.V1 as Plutus
+
 import           Codec.Serialise.Class (Serialise (..))
+import           Control.Applicative (Alternative (..))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Text as Aeson.Text
+import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import           Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
@@ -64,34 +88,6 @@ import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Vector as Vector
 import           Data.Word
-
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Aeson
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Aeson.Text as Aeson.Text
-import qualified Data.Attoparsec.ByteString.Char8 as Atto
-
-import           Control.Applicative (Alternative (..))
-
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import           Cardano.Ledger.Core (Era)
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Alonzo
-import qualified Cardano.Ledger.SafeHash as Ledger
-import           Ouroboros.Consensus.Shelley.Eras (StandardAlonzo, StandardCrypto)
-import qualified PlutusLedgerApi.V1 as Plutus
-
-import           Cardano.Api.Eras
-import           Cardano.Api.Error
-import           Cardano.Api.Hash
-
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Keys.Shelley
-
-import           Cardano.Api.SerialiseCBOR
-import           Cardano.Api.SerialiseJSON
-import           Cardano.Api.SerialiseRaw
-import           Cardano.Api.SerialiseUsing
-import           Cardano.Api.TxMetadata (pBytes, pSigned, parseAll)
 
 -- Original script data bytes
 data HashableScriptData

--- a/cardano-api/internal/Cardano/Api/SerialiseBech32.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseBech32.hs
@@ -10,21 +10,18 @@ module Cardano.Api.SerialiseBech32
   , deserialiseAnyOfFromBech32
   ) where
 
-import           Data.ByteString (ByteString)
-import           Data.Text (Text)
-
-import qualified Data.List as List
-import           Data.Set (Set)
-import qualified Data.Set as Set
-
-import           Control.Monad (guard)
-
-import qualified Codec.Binary.Bech32 as Bech32
-
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.Utils
+
+import qualified Codec.Binary.Bech32 as Bech32
+import           Control.Monad (guard)
+import           Data.ByteString (ByteString)
+import qualified Data.List as List
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Text (Text)
 
 
 class (HasTypeProxy a, SerialiseAsRawBytes a) => SerialiseAsBech32 a where

--- a/cardano-api/internal/Cardano/Api/SerialiseCBOR.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseCBOR.hs
@@ -8,12 +8,12 @@ module Cardano.Api.SerialiseCBOR
   , ToCBOR(..)
   ) where
 
-import           Data.ByteString (ByteString)
+import           Cardano.Api.HasTypeProxy
 
 import           Cardano.Binary (FromCBOR, ToCBOR)
 import qualified Cardano.Binary as CBOR
 
-import           Cardano.Api.HasTypeProxy
+import           Data.ByteString (ByteString)
 
 
 class HasTypeProxy a => SerialiseAsCBOR a where

--- a/cardano-api/internal/Cardano/Api/SerialiseJSON.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseJSON.hs
@@ -14,6 +14,9 @@ module Cardano.Api.SerialiseJSON
   , writeFileJSON
   ) where
 
+import           Cardano.Api.Error
+import           Cardano.Api.HasTypeProxy
+
 import           Control.Monad.Trans.Except (runExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
 import           Data.Aeson (FromJSON (..), FromJSONKey, ToJSON (..), ToJSONKey)
@@ -22,9 +25,6 @@ import           Data.Aeson.Encode.Pretty (encodePretty)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
-
-import           Cardano.Api.Error
-import           Cardano.Api.HasTypeProxy
 
 
 newtype JsonDecodeError = JsonDecodeError String

--- a/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
@@ -29,6 +29,17 @@ module Cardano.Api.SerialiseLedgerCddl
   )
   where
 
+import           Cardano.Api.Eras
+import           Cardano.Api.Error
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.IO
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.Tx
+import           Cardano.Api.Utils
+
+import           Cardano.Ledger.Binary (DecoderError)
+import qualified Cardano.Ledger.Binary as CBOR
+
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither,
                    newExceptT, runExceptT)
 import           Data.Aeson
@@ -42,17 +53,6 @@ import qualified Data.List as List
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-
-import           Cardano.Ledger.Binary (DecoderError)
-import qualified Cardano.Ledger.Binary as CBOR
-
-import           Cardano.Api.Eras
-import           Cardano.Api.Error
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.IO
-import           Cardano.Api.SerialiseCBOR
-import           Cardano.Api.Tx
-import           Cardano.Api.Utils
 
 
 -- Why have we gone this route? The serialization format of `TxBody era`

--- a/cardano-api/internal/Cardano/Api/SerialiseRaw.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseRaw.hs
@@ -13,6 +13,9 @@ module Cardano.Api.SerialiseRaw
   , serialiseToRawBytesHexText
   ) where
 
+import           Cardano.Api.Error (Error, displayError)
+import           Cardano.Api.HasTypeProxy
+
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
@@ -21,9 +24,6 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Typeable (TypeRep, Typeable)
-
-import           Cardano.Api.Error (Error, displayError)
-import           Cardano.Api.HasTypeProxy
 
 newtype SerialiseAsRawBytesError = SerialiseAsRawBytesError
   -- TODO We can do better than use String to carry the error message

--- a/cardano-api/internal/Cardano/Api/SerialiseTextEnvelope.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseTextEnvelope.hs
@@ -32,6 +32,20 @@ module Cardano.Api.SerialiseTextEnvelope
   , AsType(..)
   ) where
 
+import           Cardano.Api.Error
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.IO
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.Utils (readFileBlocking)
+
+import           Cardano.Binary (DecoderError)
+
+import           Control.Monad (unless)
+import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
+import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
+import qualified Data.Aeson as Aeson
+import           Data.Aeson.Encode.Pretty (Config (..), defConfig, encodePretty', keyOrder)
 import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
@@ -41,23 +55,6 @@ import           Data.Maybe (fromMaybe)
 import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as Text
-
-import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
-import qualified Data.Aeson as Aeson
-import           Data.Aeson.Encode.Pretty (Config (..), defConfig, encodePretty', keyOrder)
-
-import           Control.Monad (unless)
-import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
-
-
-import           Cardano.Binary (DecoderError)
-
-import           Cardano.Api.Error
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.IO
-import           Cardano.Api.SerialiseCBOR
-import           Cardano.Api.Utils (readFileBlocking)
 
 -- ----------------------------------------------------------------------------
 -- Text envelopes

--- a/cardano-api/internal/Cardano/Api/SerialiseUsing.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseUsing.hs
@@ -8,6 +8,13 @@ module Cardano.Api.SerialiseUsing
   , UsingBech32(..)
   ) where
 
+import           Cardano.Api.Error
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.SerialiseBech32
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.SerialiseJSON
+import           Cardano.Api.SerialiseRaw
+
 import qualified Data.Aeson.Types as Aeson
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
@@ -16,13 +23,6 @@ import           Data.String (IsString (..))
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Typeable (tyConName, typeRep, typeRepTyCon)
-
-import           Cardano.Api.Error
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.SerialiseBech32
-import           Cardano.Api.SerialiseCBOR
-import           Cardano.Api.SerialiseJSON
-import           Cardano.Api.SerialiseRaw
 
 
 

--- a/cardano-api/internal/Cardano/Api/SpecialByron.hs
+++ b/cardano-api/internal/Cardano/Api/SpecialByron.hs
@@ -15,12 +15,6 @@ module Cardano.Api.SpecialByron
     toByronLedgertoByronVote,
   ) where
 
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.Map.Strict as M
-import           Data.Word
-import           Numeric.Natural
-
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.NetworkId (NetworkId, toByronProtocolMagicId)
@@ -36,10 +30,15 @@ import           Cardano.Chain.Update (AProposal (aBody, annotation), InstallerH
 import qualified Cardano.Chain.Update.Vote as ByronVote
 import           Cardano.Crypto (SafeSigner, noPassSafeSigner)
 import qualified Cardano.Ledger.Binary as Binary (Annotated (..), ByteSpan (..), annotation,
-                   annotationBytes, reAnnotate, byronProtVer)
-
+                   annotationBytes, byronProtVer, reAnnotate)
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import qualified Ouroboros.Consensus.Byron.Ledger.Mempool as Mempool
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.Map.Strict as M
+import           Data.Word
+import           Numeric.Natural
 
 {- HLINT ignore "Use void" -}
 

--- a/cardano-api/internal/Cardano/Api/StakePoolMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/StakePoolMetadata.hs
@@ -14,19 +14,6 @@ module Cardano.Api.StakePoolMetadata (
     Hash(..),
   ) where
 
-import           Data.Bifunctor (first)
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import           Data.Either.Combinators (maybeToRight)
-import           Data.Text (Text)
-import qualified Data.Text as Text
-
-import           Data.Aeson ((.:))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Types as Aeson
-
-import qualified Cardano.Crypto.Hash.Class as Crypto
-
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
@@ -36,9 +23,20 @@ import           Cardano.Api.Keys.Praos
 import           Cardano.Api.Script
 import           Cardano.Api.SerialiseJSON
 import           Cardano.Api.SerialiseRaw
-import           Cardano.Ledger.Crypto (StandardCrypto)
 
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Keys as Shelley
+
+import           Data.Aeson ((.:))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import           Data.Bifunctor (first)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import           Data.Either.Combinators (maybeToRight)
+import           Data.Text (Text)
+import qualified Data.Text as Text
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Tx.hs
@@ -47,52 +47,6 @@ module Cardano.Api.Tx (
            AsKeyWitness, AsByronWitness, AsShelleyWitness),
   ) where
 
-import           Data.Maybe
-
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
-
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
-import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
-import qualified Data.Vector as Vector
-import           Lens.Micro
-
---
--- Crypto API used by consensus and Shelley (and should be used by Byron)
---
-import qualified Cardano.Crypto.DSIGN.Class as Crypto
-import qualified Cardano.Crypto.Util as Crypto
-import qualified Cardano.Crypto.Wallet as Crypto.HD
-
---
--- Byron imports
---
-import qualified Cardano.Chain.Common as Byron
-import qualified Cardano.Chain.UTxO as Byron
-import qualified Cardano.Crypto.Hashing as Byron
-import qualified Cardano.Crypto.ProtocolMagic as Byron
-import qualified Cardano.Crypto.Signing as Byron
-
---
--- Shelley imports
---
-import           Cardano.Ledger.Binary (Annotated (..))
-import qualified Cardano.Ledger.Binary as CBOR
-import qualified Cardano.Ledger.Binary.Plain as Plain
-
-import           Cardano.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
-import           Cardano.Ledger.Crypto (StandardCrypto)
-
-import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Keys as Shelley
-import qualified Cardano.Ledger.Keys.Bootstrap as Shelley
-import qualified Cardano.Ledger.SafeHash as Ledger
-
-import qualified Cardano.Ledger.Alonzo.Core as L
-import qualified Cardano.Ledger.Api as L
-
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
@@ -104,6 +58,36 @@ import           Cardano.Api.NetworkId
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.TxBody
+
+import qualified Cardano.Chain.Common as Byron
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Cardano.Crypto.DSIGN.Class as Crypto
+import qualified Cardano.Crypto.Hashing as Byron
+import qualified Cardano.Crypto.ProtocolMagic as Byron
+import qualified Cardano.Crypto.Signing as Byron
+import qualified Cardano.Crypto.Util as Crypto
+import qualified Cardano.Crypto.Wallet as Crypto.HD
+import qualified Cardano.Ledger.Alonzo.Core as L
+import qualified Cardano.Ledger.Api as L
+import           Cardano.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
+import           Cardano.Ledger.Binary (Annotated (..))
+import qualified Cardano.Ledger.Binary as CBOR
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import qualified Cardano.Ledger.Core as Ledger
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Keys as Shelley
+import qualified Cardano.Ledger.Keys.Bootstrap as Shelley
+import qualified Cardano.Ledger.SafeHash as Ledger
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map.Strict as Map
+import           Data.Maybe
+import qualified Data.Set as Set
+import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
+import qualified Data.Vector as Vector
+import           Lens.Micro
 
 -- ----------------------------------------------------------------------------
 -- Signed transactions

--- a/cardano-api/internal/Cardano/Api/TxIn.hs
+++ b/cardano-api/internal/Cardano/Api/TxIn.hs
@@ -35,11 +35,27 @@ module Cardano.Api.TxIn (
     renderTxIn,
   ) where
 
+import           Cardano.Api.Error
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.SerialiseJSON
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseUsing
+import           Cardano.Api.Utils
+
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Crypto.Hashing as Byron
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Keys as Shelley
+import qualified Cardano.Ledger.SafeHash as SafeHash
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
+import qualified Cardano.Ledger.TxIn as Ledger
+
 import           Control.Applicative (some)
 import           Data.Aeson (withText)
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
-
 import qualified Data.ByteString.Char8 as BSC
 import           Data.String
 import           Data.Text (Text)
@@ -49,26 +65,6 @@ import           Text.Parsec ((<?>))
 import qualified Text.Parsec.Language as Parsec
 import qualified Text.Parsec.String as Parsec
 import qualified Text.Parsec.Token as Parsec
-
-import qualified Cardano.Crypto.Hash.Class as Crypto
-
-import qualified Cardano.Chain.UTxO as Byron
-import qualified Cardano.Crypto.Hashing as Byron
-
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import           Cardano.Ledger.Crypto (StandardCrypto)
-import qualified Cardano.Ledger.Keys as Shelley
-import qualified Cardano.Ledger.SafeHash as SafeHash
-
-import qualified Cardano.Ledger.Shelley.TxBody as Shelley
-import qualified Cardano.Ledger.TxIn as Ledger
-
-import           Cardano.Api.Error
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.SerialiseJSON
-import           Cardano.Api.SerialiseRaw
-import           Cardano.Api.SerialiseUsing
-import           Cardano.Api.Utils
 
 {- HLINT ignore "Redundant flip" -}
 {- HLINT ignore "Use section" -}

--- a/cardano-api/internal/Cardano/Api/TxMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/TxMetadata.hs
@@ -50,8 +50,10 @@ import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.SerialiseCBOR (SerialiseAsCBOR (..))
+
 import qualified Cardano.Ledger.Binary as CBOR
 import qualified Cardano.Ledger.Shelley.TxAuxData as Shelley
+
 import           Control.Applicative (Alternative (..))
 import           Control.Monad (guard, when)
 import qualified Data.Aeson as Aeson

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -55,6 +55,21 @@ module Cardano.Api.Value
   , AsType(..)
   ) where
 
+import           Cardano.Api.Error (displayError)
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Script
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseUsing
+import           Cardano.Api.Utils (failEitherWith)
+
+import qualified Cardano.Chain.Common as Byron
+import qualified Cardano.Ledger.Coin as Shelley
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import           Cardano.Ledger.Mary.TxOut as Mary (scaledMinDeposit)
+import           Cardano.Ledger.Mary.Value (MaryValue (..))
+import qualified Cardano.Ledger.Mary.Value as Mary
+
 import           Data.Aeson (FromJSON, FromJSONKey, ToJSON, object, parseJSON, toJSON, withObject)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
@@ -71,21 +86,6 @@ import           Data.String (IsString (..))
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-
-import qualified Cardano.Chain.Common as Byron
-import qualified Cardano.Ledger.Coin as Shelley
-import           Cardano.Ledger.Crypto (StandardCrypto)
-
-import           Cardano.Api.Error (displayError)
-import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Script
-import           Cardano.Api.SerialiseCBOR
-import           Cardano.Api.SerialiseRaw
-import           Cardano.Api.SerialiseUsing
-import           Cardano.Api.Utils (failEitherWith)
-import           Cardano.Ledger.Mary.Value (MaryValue (..))
-import qualified Cardano.Ledger.Mary.Value as Mary
-import           Cardano.Ledger.Mary.TxOut as Mary (scaledMinDeposit)
 
 -- ----------------------------------------------------------------------------
 -- Lovelace

--- a/cardano-api/internal/Cardano/Api/ValueParser.hs
+++ b/cardano-api/internal/Cardano/Api/ValueParser.hs
@@ -4,6 +4,11 @@ module Cardano.Api.ValueParser
   , policyId
   ) where
 
+import           Cardano.Api.Error (displayError)
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.Utils (failEitherWith)
+import           Cardano.Api.Value
+
 import           Control.Applicative (many, some, (<|>))
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Char as Char
@@ -17,11 +22,6 @@ import           Text.Parsec.Char (alphaNum, char, digit, hexDigit, space, space
 import           Text.Parsec.Expr (Assoc (..), Operator (..), buildExpressionParser)
 import           Text.Parsec.String (Parser)
 import           Text.ParserCombinators.Parsec.Combinator (many1)
-
-import           Cardano.Api.Error (displayError)
-import           Cardano.Api.SerialiseRaw
-import           Cardano.Api.Utils (failEitherWith)
-import           Cardano.Api.Value
 
 -- | Parse a 'Value' from its string representation.
 parseValue :: Parser Value

--- a/cardano-api/src/Cardano/Api/ChainSync/ClientPipelined.hs
+++ b/cardano-api/src/Cardano/Api/ChainSync/ClientPipelined.hs
@@ -29,6 +29,7 @@ module Cardano.Api.ChainSync.ClientPipelined (
     , mapChainSyncClientPipelined
     ) where
 
-import           Network.TypedProtocol.Pipelined (N (..), Nat (..), natToInt)
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
 import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+
+import           Network.TypedProtocol.Pipelined (N (..), Nat (..), natToInt)

--- a/cardano-api/src/Cardano/Api/Crypto/Ed25519Bip32.hs
+++ b/cardano-api/src/Cardano/Api/Crypto/Ed25519Bip32.hs
@@ -18,22 +18,21 @@ module Cardano.Api.Crypto.Ed25519Bip32
   )
 where
 
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import           Cardano.Crypto.DSIGN.Class
+import           Cardano.Crypto.Seed
+import           Cardano.Crypto.Util (SignableRepresentation (..))
+import qualified Cardano.Crypto.Wallet as CC
+
 import           Control.DeepSeq (NFData)
 import           Data.ByteArray as BA (ByteArrayAccess, ScrubbedBytes, convert)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           GHC.Generics (Generic)
-import           NoThunks.Class (InspectHeap (..), NoThunks)
-
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import qualified Cardano.Crypto.Wallet as CC
-
-import           Cardano.Crypto.DSIGN.Class
-import           Cardano.Crypto.Seed
-import           Cardano.Crypto.Util (SignableRepresentation (..))
 
 import qualified Crypto.ECC.Edwards25519 as Ed25519
 import           Crypto.Error (eitherCryptoError)
+import           NoThunks.Class (InspectHeap (..), NoThunks)
 
 
 data Ed25519Bip32DSIGN

--- a/cardano-api/test/Test/Cardano/Api/Crypto.hs
+++ b/cardano-api/test/Test/Cardano/Api/Crypto.hs
@@ -12,19 +12,18 @@ module Test.Cardano.Api.Crypto
   )
 where
 
-import           Data.Proxy (Proxy (..))
-
 import           Cardano.Api.Crypto.Ed25519Bip32 (Ed25519Bip32DSIGN, SignKeyDSIGN (..))
 
 import           Cardano.Crypto.DSIGN
 import           Cardano.Crypto.Util (SignableRepresentation (..))
+import qualified Cardano.Crypto.Wallet as CC
+
+import           Data.Proxy (Proxy (..))
 
 import           Test.Crypto.Util
 import           Test.QuickCheck (Arbitrary (..), Gen, Property, (=/=), (===), (==>))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
-
-import qualified Cardano.Crypto.Wallet as CC
 
 --
 -- The list of all tests

--- a/cardano-api/test/Test/Cardano/Api/Eras.hs
+++ b/cardano-api/test/Test/Cardano/Api/Eras.hs
@@ -6,7 +6,9 @@ module Test.Cardano.Api.Eras
 
 import           Cardano.Api
 import           Cardano.Api.Orphans ()
+
 import           Data.Aeson (ToJSON (..), decode, encode)
+
 import           Hedgehog (Property, forAll, property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen

--- a/cardano-api/test/Test/Cardano/Api/Genesis.hs
+++ b/cardano-api/test/Test/Cardano/Api/Genesis.hs
@@ -9,13 +9,6 @@ module Test.Cardano.Api.Genesis
 
 import           Cardano.Api.Shelley (ShelleyGenesis (..))
 
-import           Data.ListMap (ListMap (ListMap))
-import qualified Data.Map.Strict as Map
-import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import           Lens.Micro
-
-import           Cardano.Slotting.Slot (EpochSize (..))
-
 import           Cardano.Ledger.Address (Addr (..))
 import           Cardano.Ledger.BaseTypes (Network (..))
 import           Cardano.Ledger.Coin (Coin (..))
@@ -26,6 +19,12 @@ import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Cardano.Ledger.Keys (GenDelegPair (..), Hash, KeyHash (..), KeyRole (..),
                    VerKeyVRF)
 import           Cardano.Ledger.Shelley.Genesis (emptyGenesisStaking)
+import           Cardano.Slotting.Slot (EpochSize (..))
+
+import           Data.ListMap (ListMap (ListMap))
+import qualified Data.Map.Strict as Map
+import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import           Lens.Micro
 
 import           Test.Cardano.Ledger.Shelley.Utils (unsafeBoundRational)
 

--- a/cardano-api/test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/Test/Cardano/Api/Json.hs
@@ -8,15 +8,17 @@ module Test.Cardano.Api.Json
 
 import           Cardano.Api.Orphans ()
 import           Cardano.Api.Shelley
+
 import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), eitherDecode, encode)
 import           Data.Aeson.Types (Parser, parseEither)
-import           Hedgehog (Property, forAll, tripping)
+
 import           Test.Gen.Cardano.Api (genAlonzoGenesis)
 import           Test.Gen.Cardano.Api.Typed
+
+import           Hedgehog (Property, forAll, tripping)
+import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-
-import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/KeysByron.hs
+++ b/cardano-api/test/Test/Cardano/Api/KeysByron.hs
@@ -6,14 +6,14 @@ module Test.Cardano.Api.KeysByron
 
 import           Cardano.Api (AsType (AsByronKey, AsSigningKey), Key (deterministicSigningKey))
 
-import           Hedgehog (Property)
 import           Test.Cardano.Api.Typed.Orphans ()
+import qualified Test.Gen.Cardano.Crypto.Seed as Gen
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
 import           Test.Hedgehog.Roundtrip.CBOR (trippingCbor)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-
-import qualified Hedgehog as H
-import qualified Test.Gen.Cardano.Crypto.Seed as Gen
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/Ledger.hs
+++ b/cardano-api/test/Test/Cardano/Api/Ledger.hs
@@ -8,22 +8,24 @@ module Test.Cardano.Api.Ledger
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Control.Monad.Identity
-
 import           Cardano.Ledger.Address (deserialiseAddr, serialiseAddr)
 import qualified Cardano.Ledger.Api as L
 import           Cardano.Ledger.Crypto
 import           Cardano.Ledger.SafeHash
 
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Aeson as H
-import           Hedgehog.Internal.Property
+import           Control.Monad.Identity
+
+import           Test.Gen.Cardano.Api.Typed
+
 import           Test.Cardano.Api.Genesis (exampleShelleyGenesis)
 import           Test.Cardano.Ledger.Core.Arbitrary ()
-import           Test.Gen.Cardano.Api.Typed
+
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Aeson as H
+import           Hedgehog.Gen.QuickCheck (arbitrary)
+import           Hedgehog.Internal.Property
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-import           Hedgehog.Gen.QuickCheck (arbitrary)
 
 prop_golden_ShelleyGenesis :: Property
 prop_golden_ShelleyGenesis = H.goldenTestJsonValuePretty exampleShelleyGenesis "test/golden/ShelleyGenesis"

--- a/cardano-api/test/Test/Cardano/Api/Metadata.hs
+++ b/cardano-api/test/Test/Cardano/Api/Metadata.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Test.Cardano.Api.Metadata
   ( tests
@@ -9,19 +9,20 @@ module Test.Cardano.Api.Metadata
 
 import           Cardano.Api
 
+import qualified Data.Aeson as Aeson
 import           Data.ByteString (ByteString)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import           Data.Word (Word64)
-import           Hedgehog (Gen, Property, property, (===))
-import           Test.Gen.Cardano.Api.Metadata
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
 
-import qualified Data.Aeson as Aeson
-import qualified Data.Map.Strict as Map
+import           Test.Gen.Cardano.Api.Metadata
+
+import           Hedgehog (Gen, Property, property, (===))
 import qualified Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog (testPropertyNamed)
 
 -- ----------------------------------------------------------------------------
 -- Golden / unit tests

--- a/cardano-api/test/Test/Cardano/Api/Typed/Address.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Address.hs
@@ -6,14 +6,16 @@ module Test.Cardano.Api.Typed.Address
 
 import           Cardano.Api
 
-import           Hedgehog (Property)
-import           Test.Cardano.Api.Typed.Orphans ()
+import qualified Data.Aeson as Aeson
+
 import           Test.Gen.Cardano.Api.Typed (genAddressByron, genAddressShelley)
+
+import           Test.Cardano.Api.Typed.Orphans ()
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-
-import qualified Data.Aeson as Aeson
-import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Bech32.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Bech32.hs
@@ -3,8 +3,10 @@ module Test.Cardano.Api.Typed.Bech32
   ) where
 
 import           Cardano.Api (AsType (AsShelleyAddress, AsStakeAddress))
-import           Hedgehog (Property)
+
 import           Test.Gen.Cardano.Api.Typed (genAddressShelley, genStakeAddress)
+
+import           Hedgehog (Property)
 import           Test.Hedgehog.Roundtrip.Bech32 (roundtrip_Bech32)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)

--- a/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/CBOR.hs
@@ -7,14 +7,17 @@ module Test.Cardano.Api.Typed.CBOR
   ) where
 
 import           Cardano.Api
-
 import           Cardano.Api.Shelley (AsType (..))
+
 import           Data.Proxy (Proxy (..))
+
+import           Test.Gen.Cardano.Api.Typed
+
+import           Test.Cardano.Api.Typed.Orphans ()
+
 import           Hedgehog (Property, forAll, property, tripping)
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
-import           Test.Cardano.Api.Typed.Orphans ()
-import           Test.Gen.Cardano.Api.Typed
 import qualified Test.Hedgehog.Roundtrip.CBOR as H
 import           Test.Hedgehog.Roundtrip.CBOR
 import           Test.Tasty (TestTree, testGroup)

--- a/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Envelope.hs
@@ -6,13 +6,14 @@ module Test.Cardano.Api.Typed.Envelope
 
 import           Cardano.Api
 
-import           Hedgehog (Property)
-import           Test.Cardano.Api.Typed.Orphans ()
 import           Test.Gen.Cardano.Api.Typed
+
+import           Test.Cardano.Api.Typed.Orphans ()
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-
-import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/JSON.hs
@@ -10,14 +10,15 @@ module Test.Cardano.Api.Typed.JSON
 
 import           Data.Aeson (eitherDecode, encode)
 
-import           Hedgehog (Property, forAll, tripping)
-import           Test.Cardano.Api.Typed.Orphans ()
 import           Test.Gen.Cardano.Api.Typed (genMaybePraosNonce, genProtocolParameters)
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
 
+import           Test.Cardano.Api.Typed.Orphans ()
+
+import           Hedgehog (Property, forAll, tripping)
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog (testPropertyNamed)
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Ord.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Ord.hs
@@ -5,13 +5,14 @@ module Test.Cardano.Api.Typed.Ord
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Hedgehog (Property, (===))
-import           Test.Cardano.Api.Metadata (genTxMetadataValue)
 import           Test.Gen.Cardano.Api.Typed
+
+import           Test.Cardano.Api.Metadata (genTxMetadataValue)
+
+import           Hedgehog (Property, (===))
+import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-
-import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Orphans.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Orphans.hs
@@ -8,6 +8,7 @@
 module Test.Cardano.Api.Typed.Orphans () where
 
 import           Cardano.Api.Shelley
+
 import           Cardano.Crypto.Hash hiding (Hash)
 import           Cardano.Crypto.KES
 import           Cardano.Crypto.Libsodium (SodiumHashAlgorithm)

--- a/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/RawBytes.hs
@@ -6,13 +6,14 @@ module Test.Cardano.Api.Typed.RawBytes
 
 import           Cardano.Api
 
-import           Hedgehog (Property)
-import           Test.Cardano.Api.Typed.Orphans ()
 import           Test.Gen.Cardano.Api.Typed
+
+import           Test.Cardano.Api.Typed.Orphans ()
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-
-import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Script.hs
@@ -6,15 +6,18 @@ module Test.Cardano.Api.Typed.Script
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
+
 import qualified Cardano.Ledger.Api.Era as L
+
 import           Data.Aeson
-import           Hedgehog (Property, (===))
-import           Hedgehog.Extras.Aeson
+
 import           Test.Gen.Cardano.Api.Typed
+
+import           Hedgehog (Property, (===))
+import qualified Hedgehog as H
+import           Hedgehog.Extras.Aeson
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-
-import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/TxBody.hs
@@ -6,15 +6,18 @@ module Test.Cardano.Api.Typed.TxBody
 
 import           Cardano.Api
 import           Cardano.Api.Shelley (ReferenceScript (..), refScriptToShelleyScript)
+
 import           Data.Maybe (isJust)
 import           Data.Type.Equality (TestEquality (testEquality))
-import           Hedgehog (MonadTest, Property, annotateShow, failure, (===))
-import           Test.Cardano.Api.Typed.Orphans ()
+
 import           Test.Gen.Cardano.Api.Typed (genTxBodyContent)
+
+import           Test.Cardano.Api.Typed.Orphans ()
+
+import           Hedgehog (MonadTest, Property, annotateShow, failure, (===))
+import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
-
-import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
+++ b/cardano-api/test/Test/Cardano/Api/Typed/Value.hs
@@ -2,17 +2,18 @@ module Test.Cardano.Api.Typed.Value
   ( tests
   ) where
 
-import           Prelude
-
 import           Cardano.Api (ValueNestedBundle (..), ValueNestedRep (..), valueFromNestedRep,
                    valueToNestedRep)
+
+import           Prelude
 
 import           Data.Aeson (eitherDecode, encode)
 import           Data.List (groupBy, sort)
 import qualified Data.Map.Strict as Map
 
-import           Hedgehog (Property, forAll, property, tripping, (===))
 import           Test.Gen.Cardano.Api.Typed (genAssetName, genValueDefault, genValueNestedRep)
+
+import           Hedgehog (Property, forAll, property, tripping, (===))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/cardano-api/test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test.hs
@@ -1,10 +1,8 @@
 module Main where
 
-import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
-
 import           Cardano.Crypto.Libsodium (sodiumInit)
 
-import           Test.Tasty (TestTree, defaultMain, testGroup)
+import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
 
 import qualified Test.Cardano.Api.Crypto
 import qualified Test.Cardano.Api.Eras
@@ -22,6 +20,8 @@ import qualified Test.Cardano.Api.Typed.RawBytes
 import qualified Test.Cardano.Api.Typed.Script
 import qualified Test.Cardano.Api.Typed.TxBody
 import qualified Test.Cardano.Api.Typed.Value
+
+import           Test.Tasty (TestTree, defaultMain, testGroup)
 
 main :: IO ()
 main = do


### PR DESCRIPTION
# Description

This means we no longer need to manually enforce import groups manually and the relevant sections can be removed from the style guide.

Also split out OS specific code into separate modules

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
