### PR TITLE
input-output-hk/cardano-node#5222 Remove of reading of `ApplicationName` and `ApplicationVersion` from node config and replace with hardcoded values

### DIFF
--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for cardano-api
 
+## New
+
+- **Breaking change** Remove support for reading `ApplicationName` and `ApplicationVersion` from node configuration and replace with hardcoded values. ([PR 8](https://github.com/input-output-hk/cardano-api/pull/8))
+
 ## 8.1.0
 
 - Addition of `QueryStakeDelegDeposits` ledger state query.

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -99,6 +99,7 @@ import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query (CurrentEpochState (..), PoolDistribution (unPoolDistr),
                    ProtocolState, SerialisedCurrentEpochState (..), SerialisedPoolDistribution,
                    decodeCurrentEpochState, decodePoolDistribution, decodeProtocolState)
+import           Cardano.Api.SpecialByron as Byron
 import           Cardano.Api.Utils (textShow)
 
 import qualified Cardano.Binary as CBOR
@@ -799,7 +800,6 @@ data NodeConfig = NodeConfig
   , ncConwayGenesisFile :: !(File ConwayGenesisConfig 'In)
   , ncConwayGenesisHash :: !GenesisHashConway
   , ncRequiresNetworkMagic :: !Cardano.Crypto.RequiresNetworkMagic
-  , ncByronSoftwareVersion :: !Cardano.Chain.Update.SoftwareVersion
   , ncByronProtocolVersion :: !Cardano.Chain.Update.ProtocolVersion
 
   -- Per-era parameters for the hardfok transitions:
@@ -831,7 +831,6 @@ instance FromJSON NodeConfig where
           <*> fmap File (o .: "ConwayGenesisFile")
           <*> fmap GenesisHashConway (o .: "ConwayGenesisHash")
           <*> o .: "RequiresNetworkMagic"
-          <*> parseByronSoftwareVersion o
           <*> parseByronProtocolVersion o
           <*> (Consensus.ProtocolTransitionParamsShelleyBased emptyFromByronTranslationContext
                  <$> parseShelleyHardForkEpoch o)
@@ -849,12 +848,6 @@ instance FromJSON NodeConfig where
           <$> o .: "LastKnownBlockVersion-Major"
           <*> o .: "LastKnownBlockVersion-Minor"
           <*> o .: "LastKnownBlockVersion-Alt"
-
-      parseByronSoftwareVersion :: Object -> Parser Cardano.Chain.Update.SoftwareVersion
-      parseByronSoftwareVersion o =
-        Cardano.Chain.Update.SoftwareVersion
-          <$> fmap Cardano.Chain.Update.ApplicationName (o .: "ApplicationName")
-          <*> o .: "ApplicationVersion"
 
       parseShelleyHardForkEpoch :: Object -> Parser Consensus.TriggerHardFork
       parseShelleyHardForkEpoch o =
@@ -1006,7 +999,7 @@ mkProtocolInfoCardano (GenesisCardano dnc byronGenesis shelleyGenesis alonzoGene
             { Consensus.byronGenesis = byronGenesis
             , Consensus.byronPbftSignatureThreshold = Consensus.PBftSignatureThreshold <$> ncPBftSignatureThreshold dnc
             , Consensus.byronProtocolVersion = ncByronProtocolVersion dnc
-            , Consensus.byronSoftwareVersion = ncByronSoftwareVersion dnc
+            , Consensus.byronSoftwareVersion = Byron.softwareVersion
             , Consensus.byronLeaderCredentials = Nothing
             , Consensus.byronMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
             }

--- a/cardano-api/internal/Cardano/Api/SpecialByron.hs
+++ b/cardano-api/internal/Cardano/Api/SpecialByron.hs
@@ -13,6 +13,9 @@ module Cardano.Api.SpecialByron
     makeByronUpdateProposal,
     makeByronVote,
     toByronLedgertoByronVote,
+    applicationName,
+    applicationVersion,
+    softwareVersion
   ) where
 
 import           Cardano.Api.HasTypeProxy
@@ -27,6 +30,7 @@ import           Cardano.Chain.Update (AProposal (aBody, annotation), InstallerH
                    ProposalBody (ProposalBody), ProtocolParametersUpdate (..), ProtocolVersion,
                    SoftforkRule, SoftwareVersion, SystemTag, UpId, mkVote, recoverUpId,
                    recoverVoteId, signProposal)
+import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.Update.Vote as ByronVote
 import           Cardano.Crypto (SafeSigner, noPassSafeSigner)
 import qualified Cardano.Ledger.Binary as Binary (Annotated (..), ByteSpan (..), annotation,
@@ -197,3 +201,18 @@ makeByronVote nId sKey (ByronUpdateProposal proposal) yesOrNo =
 
 toByronLedgertoByronVote :: ByronVote -> Mempool.GenTx ByronBlock
 toByronLedgertoByronVote (ByronVote vote) = Mempool.ByronUpdateVote (recoverVoteId vote) vote
+
+-- | An application name.
+-- It has no functional impact in the Shelley eras onwards and therefore it is hardcoded.
+applicationName :: Update.ApplicationName
+applicationName = Update.ApplicationName "cardano-sl"
+
+-- | An application version.
+-- It has no functional impact in the Shelley eras onwards and therefore it is hardcoded.
+applicationVersion :: Update.NumSoftwareVersion
+applicationVersion = 1
+
+-- | A software version composed of 'applicationVersion' and 'applicationName'.
+-- It has no functional impact in the Shelley eras onwards and therefore it is hardcoded.
+softwareVersion :: Update.SoftwareVersion
+softwareVersion = Update.SoftwareVersion applicationName applicationVersion

--- a/cardano-api/src/Cardano/Api/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Byron.hs
@@ -84,6 +84,10 @@ module Cardano.Api.Byron
     toByronProtocolMagicId,
     toByronRequiresNetworkMagic,
 
+    -- * Hardcoded configuration parameters
+    applicationName,
+    applicationVersion,
+    softwareVersion
   ) where
 
 import           Cardano.Api


### PR DESCRIPTION
# Description

This is a part of input-output-hk/cardano-node#5222 . Removes reading of `ApplicationName` and `ApplicationVersion` from `FromJSON` instances.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
