### PR TITLE
New `checkVrfFilePermissions` function

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-05-03T00:00:00Z
-  , cardano-haskell-packages 2023-04-30T00:28:07Z
+  , hackage.haskell.org 2023-05-10T10:34:57Z
+  , cardano-haskell-packages 2023-05-13T07:08:44Z
 
 packages:
     cardano-api

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -59,6 +59,7 @@ library internal
                         Cardano.Api.HasTypeProxy
                         Cardano.Api.InMode
                         Cardano.Api.IO
+                        Cardano.Api.IO.Base
                         Cardano.Api.IO.Compat
                         Cardano.Api.IO.Compat.Posix
                         Cardano.Api.IO.Compat.Win32

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -33,8 +33,12 @@ common maybe-unix
   if !os(windows)
      build-depends:    unix
 
+common maybe-Win32
+  if os(windows)
+    build-depends:      Win32
+
 library internal
-  import:               project-config, maybe-unix
+  import:               project-config, maybe-unix, maybe-Win32
 
   hs-source-dirs:       internal
 

--- a/cardano-api/internal/Cardano/Api/IO.hs
+++ b/cardano-api/internal/Cardano/Api/IO.hs
@@ -30,6 +30,7 @@ module Cardano.Api.IO
 
   , intoFile
 
+  , checkVrfFilePermissions
   , writeSecrets
   ) where
 

--- a/cardano-api/internal/Cardano/Api/IO.hs
+++ b/cardano-api/internal/Cardano/Api/IO.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -35,34 +34,19 @@ module Cardano.Api.IO
   ) where
 
 import           Cardano.Api.Error (FileError (..))
+import           Cardano.Api.IO.Base
 import           Cardano.Api.IO.Compat
 
 import           Control.Monad.Except (runExceptT)
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except.Extra (handleIOExceptT)
-import           Data.Aeson (FromJSON, ToJSON)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy as LBSC
-import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text.IO as Text
-
-data FileDirection
-  = In
-  -- ^ Indicate the file is to be used for reading.
-  | Out
-  -- ^ Indicate the file is to be used for writing.
-  | InOut
-  -- ^ Indicate the file is to be used for both reading and writing.
-
--- | A file path with additional type information to indicate what the file is meant to
--- contain and whether it is to be used for reading or writing.
-newtype File content (direction :: FileDirection) = File
-  { unFile :: FilePath
-  } deriving newtype (Eq, Ord, Read, Show, IsString, FromJSON, ToJSON)
 
 readByteStringFile :: ()
   => MonadIO m
@@ -188,7 +172,3 @@ intoFile :: ()
   -> (content -> stream)
   -> result
 intoFile fp content write serialise = write fp (serialise content)
-
-data Socket
-
-type SocketPath = File Socket 'InOut

--- a/cardano-api/internal/Cardano/Api/IO/Base.hs
+++ b/cardano-api/internal/Cardano/Api/IO/Base.hs
@@ -9,6 +9,7 @@ module Cardano.Api.IO.Base
   , File(..)
   , Socket
   , SocketPath
+  , VRFPrivateKeyFilePermissionError(..)
   ) where
 
 import           Data.Aeson (FromJSON, ToJSON)
@@ -31,3 +32,9 @@ newtype File content (direction :: FileDirection) = File
 data Socket
 
 type SocketPath = File Socket 'InOut
+
+data VRFPrivateKeyFilePermissionError
+  = OtherPermissionsExist FilePath
+  | GroupPermissionsExist FilePath
+  | GenericPermissionsExist FilePath
+  deriving Show

--- a/cardano-api/internal/Cardano/Api/IO/Base.hs
+++ b/cardano-api/internal/Cardano/Api/IO/Base.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Api.IO.Base
+  ( FileDirection(..)
+  , File(..)
+  , Socket
+  , SocketPath
+  ) where
+
+import           Data.Aeson (FromJSON, ToJSON)
+import           Data.String (IsString)
+
+data FileDirection
+  = In
+  -- ^ Indicate the file is to be used for reading.
+  | Out
+  -- ^ Indicate the file is to be used for writing.
+  | InOut
+  -- ^ Indicate the file is to be used for both reading and writing.
+
+-- | A file path with additional type information to indicate what the file is meant to
+-- contain and whether it is to be used for reading or writing.
+newtype File content (direction :: FileDirection) = File
+  { unFile :: FilePath
+  } deriving newtype (Eq, Ord, Read, Show, IsString, FromJSON, ToJSON)
+
+data Socket
+
+type SocketPath = File Socket 'InOut

--- a/cardano-api/internal/Cardano/Api/IO/Compat.hs
+++ b/cardano-api/internal/Cardano/Api/IO/Compat.hs
@@ -2,14 +2,17 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Cardano.Api.IO.Compat
-  ( handleFileForWritingWithOwnerPermission
+  ( checkVrfFilePermissions
+  , handleFileForWritingWithOwnerPermission
   , writeSecrets
   ) where
 
 import           Cardano.Api.Error
+import           Cardano.Api.IO.Base
 import           Cardano.Api.IO.Compat.Posix
 import           Cardano.Api.IO.Compat.Win32
 
+import           Control.Monad.Except (ExceptT)
 import           Data.ByteString (ByteString)
 import           System.IO
 
@@ -21,3 +24,6 @@ handleFileForWritingWithOwnerPermission = handleFileForWritingWithOwnerPermissio
 
 writeSecrets :: FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
 writeSecrets = writeSecretsImpl
+
+checkVrfFilePermissions :: File content direction -> ExceptT VRFPrivateKeyFilePermissionError IO ()
+checkVrfFilePermissions = checkVrfFilePermissionsImpl


### PR DESCRIPTION
# Description

This has been migrated from `cardano-node` repository and is required here because our CLI tests use it.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
