### PR TITLE
update chaps index

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-05-10T10:34:57Z
-  , cardano-haskell-packages 2023-05-13T07:08:44Z
+  , cardano-haskell-packages 2023-05-24T10:41:02Z
 
 packages:
     cardano-api

--- a/cardano-api/ChangeLog.md
+++ b/cardano-api/ChangeLog.md
@@ -3,6 +3,7 @@
 ## New
 
 - **Breaking change** Remove support for reading `ApplicationName` and `ApplicationVersion` from node configuration and replace with hardcoded values. ([PR 8](https://github.com/input-output-hk/cardano-api/pull/8))
+- Updated ledger dependency bounds, added support for Plutus V3 in conway
 
 ## 8.1.0
 

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -126,7 +126,7 @@ library internal
                       , cardano-ledger-binary >= 1.1
                       , cardano-ledger-byron >= 1.0
                       , cardano-ledger-conway >= 1.1
-                      , cardano-ledger-core >= 1.1
+                      , cardano-ledger-core >= 1.2
                       , cardano-ledger-mary >= 1.1
                       , cardano-ledger-shelley >= 1.1.1
                       , cardano-protocol-tpraos >= 1.0.2
@@ -146,16 +146,16 @@ library internal
                       , mtl
                       , network
                       , optparse-applicative-fork
-                      , ouroboros-consensus >= 0.6
-                      , ouroboros-consensus-cardano >= 0.5
-                      , ouroboros-consensus-diffusion >= 0.5.1
+                      , ouroboros-consensus >= 0.7
+                      , ouroboros-consensus-cardano >= 0.6
+                      , ouroboros-consensus-diffusion >= 0.6
                       , ouroboros-consensus-protocol >= 0.5
                       , ouroboros-network
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , ouroboros-network-protocols
                       , parsec
-                      , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>=1.1
+                      , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>=1.5
                       , prettyprinter
                       , prettyprinter-configurable ^>= 1.1
                       , random
@@ -223,7 +223,7 @@ library gen
                       , cardano-ledger-alonzo >= 1.1
                       , cardano-ledger-alonzo-test
                       , cardano-ledger-byron-test >= 1.5
-                      , cardano-ledger-core >= 1.1
+                      , cardano-ledger-core >= 1.2
                       , cardano-ledger-shelley >= 1.1
                       , containers
                       , hedgehog
@@ -246,7 +246,7 @@ test-suite cardano-api-test
                       , cardano-crypto-tests ^>= 2.1
                       , cardano-data >= 1.0
                       , cardano-ledger-api >= 1.1
-                      , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.1
+                      , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.2
                       , cardano-ledger-shelley
                       , cardano-ledger-shelley-test >= 1.1
                       , cardano-slotting ^>= 0.1
@@ -302,8 +302,8 @@ test-suite cardano-api-golden
                       , hedgehog-extras >= 0.4.3.0
                       , hspec
                       , hw-hspec-hedgehog
-                      , plutus-core ^>= 1.1
-                      , plutus-ledger-api ^>= 1.1
+                      , plutus-core ^>= 1.5
+                      , plutus-ledger-api ^>= 1.5
                       , text
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -125,7 +125,7 @@ import           Cardano.Api.Shelley (GovernancePoll (..), GovernancePollAnswer 
                    PlutusScript (PlutusScriptSerialised), ProtocolParameters (ProtocolParameters),
                    ReferenceScript (..), ReferenceTxInsScriptsInlineDatumsSupportedInEra (..),
                    StakeCredential (StakeCredentialByKey), StakePoolKey,
-                   refInsScriptsAndInlineDatsSupportedInEra)
+                   refInsScriptsAndInlineDatsSupportedInEra, scriptInEraToRefScript)
 
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash as Crypto
@@ -512,7 +512,7 @@ genReferenceScript :: CardanoEra era -> Gen (ReferenceScript era)
 genReferenceScript era =
   case refInsScriptsAndInlineDatsSupportedInEra era of
     Nothing -> return ReferenceScriptNone
-    Just supp -> ReferenceScript supp <$> genScriptInAnyLang
+    Just _ -> scriptInEraToRefScript <$> genScriptInEra era
 
 genUTxO :: CardanoEra era -> Gen (UTxO era)
 genUTxO era =

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -590,6 +590,8 @@ evaluateTransactionExecutionUnits systemstart epochInfo bpp utxo txbody =
           ScriptErrorEvaluationFailed err logs
         L.ValidationFailure (L.ValidationFailedV2 err logs _) ->
           ScriptErrorEvaluationFailed err logs
+        L.ValidationFailure (L.ValidationFailedV3 err logs _) ->
+          ScriptErrorEvaluationFailed err logs
         L.IncompatibleBudget _ -> ScriptErrorExecutionUnitsOverflow
 
         -- This is only possible for spending scripts and occurs when

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -265,7 +265,8 @@ mkVersionedProtocols networkid ptcl unversionedClients =
           Net.versionedNodeToClientProtocols
             ptclVersion
             NodeToClientVersionData {
-              networkMagic = toNetworkMagic networkid
+              networkMagic = toNetworkMagic networkid,
+              query = True --TODO add this as a parameter to mkVersionedProtocols?
             }
             (\_connid _ctl -> protocols (unversionedClients ptclVersion) ptclBlockVersion ptclVersion))
       (Map.toList (Consensus.supportedNodeToClientVersions proxy))

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -809,10 +809,12 @@ fromAlonzoCostModels (Alonzo.CostModels m _ _) =
 toAlonzoScriptLanguage :: AnyPlutusScriptVersion -> Alonzo.Language
 toAlonzoScriptLanguage (AnyPlutusScriptVersion PlutusScriptV1) = Alonzo.PlutusV1
 toAlonzoScriptLanguage (AnyPlutusScriptVersion PlutusScriptV2) = Alonzo.PlutusV2
+toAlonzoScriptLanguage (AnyPlutusScriptVersion PlutusScriptV3) = Alonzo.PlutusV3
 
 fromAlonzoScriptLanguage :: Alonzo.Language -> AnyPlutusScriptVersion
 fromAlonzoScriptLanguage Alonzo.PlutusV1 = AnyPlutusScriptVersion PlutusScriptV1
 fromAlonzoScriptLanguage Alonzo.PlutusV2 = AnyPlutusScriptVersion PlutusScriptV2
+fromAlonzoScriptLanguage Alonzo.PlutusV3 = AnyPlutusScriptVersion PlutusScriptV3
 
 toAlonzoCostModel :: CostModel -> Alonzo.Language -> Either ProtocolParametersConversionError Alonzo.CostModel
 toAlonzoCostModel (CostModel m) l = first (PpceInvalidCostModel (CostModel m)) $ Alonzo.mkCostModel l m

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -455,14 +455,14 @@ decodeCurrentEpochState sbe (SerialisedCurrentEpochState (Serialised ls)) =
 
 
 newtype SerialisedPoolState era
-  = SerialisedPoolState (Serialised (Shelley.PState (Core.EraCrypto (ShelleyLedgerEra era))))
+  = SerialisedPoolState (Serialised (Shelley.PState (ShelleyLedgerEra era)))
 
-newtype PoolState era = PoolState (Shelley.PState (Core.EraCrypto (ShelleyLedgerEra era)))
+newtype PoolState era = PoolState (Shelley.PState (ShelleyLedgerEra era))
 
 decodePoolState
   :: forall era. ()
   => Core.Era (ShelleyLedgerEra era)
-  => DecCBOR (Shelley.PState (Core.EraCrypto (ShelleyLedgerEra era)))
+  => DecCBOR (Shelley.PState (ShelleyLedgerEra era))
   => SerialisedPoolState era
   -> Either DecoderError (PoolState era)
 decodePoolState (SerialisedPoolState (Serialised ls)) =

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -3452,7 +3452,16 @@ convConwayCertificates txCertificates =
       Seq.fromList (mapMaybe (fromShelleyDCertMaybe . toShelleyCertificate) cs)
 
 fromShelleyDCertMaybe :: Shelley.DCert c -> Maybe (Conway.ConwayDCert c)
-fromShelleyDCertMaybe (Shelley.DCertDeleg dc) = Just $ Conway.ConwayDCertDeleg dc
+fromShelleyDCertMaybe (Shelley.DCertDeleg (Shelley.RegKey sc)) =
+  Just $ Conway.ConwayDCertDeleg (Conway.ConwayUnDeleg sc (Ledger.Coin 0))
+  -- TODO when ledger is fixed, use ConwayReg sc
+  -- Note that ConwayUnDeleg is *blatantly* wrong
+fromShelleyDCertMaybe (Shelley.DCertDeleg (Shelley.DeRegKey sc)) =
+  Just $ Conway.ConwayDCertDeleg (Conway.ConwayUnDeleg sc (Ledger.Coin 0))
+  -- TODO when ledger is fixed, make zero coin a Nothing
+fromShelleyDCertMaybe (Shelley.DCertDeleg (Shelley.Delegate (Shelley.Delegation sc pool))) =
+  Just $ Conway.ConwayDCertDeleg (Conway.ConwayDeleg sc (Conway.DelegStake pool) (Ledger.Coin 0))
+  -- TODO when ledger is fixed, make zero coin a Nothing
 fromShelleyDCertMaybe (Shelley.DCertPool pc) = Just $ Conway.ConwayDCertPool pc
 fromShelleyDCertMaybe (Shelley.DCertGenesis gdc) = Just $ Conway.ConwayDCertConstitutional gdc
 fromShelleyDCertMaybe Shelley.DCertMir {} = Nothing

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -145,6 +145,7 @@ module Cardano.Api.Shelley
     ReferenceTxInsScriptsInlineDatumsSupportedInEra(..),
     refInsScriptsAndInlineDatsSupportedInEra,
     refScriptToShelleyScript,
+    scriptInEraToRefScript,
 
     -- * Certificates
     Certificate (..),


### PR DESCRIPTION
# Description

update chaps index:

* increase bounds on ledger core
* increase bounds on plutus
* support Plutus V3 in conway ledger era

# TODO

- [ ] There is a broken golden test, `Bech32DecodingError`
- [ ] There is a TODO to decide if we should change the signature of `mkVersionedProtocols` pass the new query parameter to `NodeToClientVersionData`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
