### PR TITLE
fix: crypto pinning via iohkNix overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,9 +35,15 @@
         # setup our nixpkgs with the haskell.nix overlays, and the iohk-nix
         # overlays...
         nixpkgs = import inputs.nixpkgs {
-          overlays =
-            [inputs.haskellNix.overlay]
-            ++ builtins.attrValues inputs.iohkNix.overlays;
+          overlays = with inputs; [
+            # crypto needs to come before haskell.nix.
+            # FIXME: _THIS_IS_BAD_
+            iohkNix.overlays.crypto
+            haskellNix.overlay
+            iohkNix.overlays.haskell-nix-extra
+            iohkNix.overlays.cardano-lib
+            iohkNix.overlays.utils
+          ];
           inherit system;
           inherit (inputs.haskellNix) config;
         };


### PR DESCRIPTION
# Description

Ensure crypto lib from iohk-nix is used first via overlay ordering until haskell.nix addresses this.

# Checklist

- [X] CI passes.