### PR TITLE
flake:  drop cardano-mainnet-mirror

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,22 +116,6 @@
         "type": "github"
       }
     },
-    "cardano-mainnet-mirror": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1557232434,
-        "narHash": "sha256-2rclcOjIVq0lFCdYAa8S9imzZZHqySn2LZ/O48hUofw=",
-        "owner": "input-output-hk",
-        "repo": "cardano-mainnet-mirror",
-        "rev": "a31ac7534ec855b715b9a6bb6a06861ee94935d9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-mainnet-mirror",
-        "type": "github"
-      }
-    },
     "cardano-shell": {
       "flake": false,
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,6 @@
     iohkNix.url = "github:input-output-hk/iohk-nix";
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
 
-    cardano-mainnet-mirror.url = "github:input-output-hk/cardano-mainnet-mirror";
-    cardano-mainnet-mirror.flake = false;
-
     CHaP.url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
     CHaP.flake = false;
 


### PR DESCRIPTION
# Description

The `cardano-mainnet-mirror` flake input is entirely unnecessary.

# Changelog

```yaml
- description: "Drop the cardano-mainnet-mirror flake input"
  type: maintenance
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
