### PR TITLE
Switch to `tasty-discover`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -301,17 +301,18 @@ test-suite cardano-api-golden
                       , cardano-crypto-class
                       , cardano-ledger-alonzo
                       , containers
+                      , errors
                       , filepath
+                      , hedgehog
                       , hedgehog-extras >= 0.4.3.0
-                      , hspec
-                      , hw-hspec-hedgehog
                       , plutus-core ^>= 1.5
                       , plutus-ledger-api ^>= 1.5
+                      , tasty
+                      , tasty-hedgehog
                       , text
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
-  build-tool-depends:   hspec-discover:hspec-discover
+  build-tool-depends:   tasty-discover:tasty-discover
 
   other-modules:        Test.Golden.ErrorsSpec
-

--- a/cardano-api/test/cardano-api-golden/cardano-api-golden.hs
+++ b/cardano-api/test/cardano-api-golden/cardano-api-golden.hs
@@ -1,1 +1,1 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --hide-successes #-}


### PR DESCRIPTION
# Description

The switch to `tasty-discover` affords us more flexibility because the discovery tool supports a wide range of test types.

`tasty-discover` supports `hspec` (previously `hspec-discover` was used), so there is no regression in terms of test types supported.

`tasty` also tells you how to re-run that specific test for each test that failed.  For example:

```
      Use "--pattern '$NF ~ /TxMetadataNumberOutOfRange/' --hedgehog-replay '1: Seed 4728764660645527119 2003600736746438781'" to reproduce from the command-line.

      Use -p '/TxMetadataNumberOutOfRange/' to rerun this test only.
```

`tasty-hedgehog` is used to adapt property tests to `tasty`.

# Changelog

```yaml
- description: |
    Switch to `tasty-discover`
  compatibility: no-api-changes
  type: test
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
