### PR TITLE
Generate fields only if they make sense for the given era

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -57,6 +57,7 @@ library internal
                         Cardano.Api.EraCast
                         Cardano.Api.Eras
                         Cardano.Api.Error
+                        Cardano.Api.Feature
                         Cardano.Api.Fees
                         Cardano.Api.Genesis
                         Cardano.Api.GenesisParameters

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -946,11 +946,13 @@ genProtocolParametersUpdate = do
 
 
 genUpdateProposal :: CardanoEra era -> Gen UpdateProposal
-genUpdateProposal _era = -- TODO Make era specific
+genUpdateProposal _era =
   UpdateProposal
     <$> Gen.map (Range.constant 1 3)
-                ((,) <$> genVerificationKeyHash AsGenesisKey
-                     <*> genProtocolParametersUpdate)
+        ( (,)
+          <$> genVerificationKeyHash AsGenesisKey
+          <*> genProtocolParametersUpdate
+        )
     <*> genEpochNo
 
 genCostModel :: Gen Alonzo.CostModel

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -638,7 +638,7 @@ genTxBodyContent era = do
   txMetadata <- genTxMetadataInEra era
   txAuxScripts <- genTxAuxScripts era
   let txExtraKeyWits = TxExtraKeyWitnessesNone --TODO: Alonzo era: Generate witness key hashes
-  txProtocolParams <- BuildTxWith <$> Gen.maybe genValidProtocolParameters
+  txProtocolParams <- BuildTxWith <$> Gen.maybe (genValidProtocolParameters era)
   txWithdrawals <- genTxWithdrawals era
   txCertificates <- genTxCertificates era
   txUpdateProposal <- genTxUpdateProposal era
@@ -846,8 +846,8 @@ genPraosNonce = makePraosNonce <$> Gen.bytes (Range.linear 0 32)
 genMaybePraosNonce :: Gen (Maybe PraosNonce)
 genMaybePraosNonce = Gen.maybe genPraosNonce
 
-genProtocolParameters :: Gen ProtocolParameters
-genProtocolParameters = do
+genProtocolParameters :: CardanoEra era -> Gen ProtocolParameters
+genProtocolParameters _era = do
   protocolParamProtocolVersion <- (,) <$> genNat <*> genNat
   protocolParamDecentralization <- Gen.maybe genRational
   protocolParamExtraPraosEntropy <- genMaybePraosNonce
@@ -875,13 +875,13 @@ genProtocolParameters = do
   protocolParamMaxValueSize <- Gen.maybe genNat
   protocolParamCollateralPercent <- Gen.maybe genNat
   protocolParamMaxCollateralInputs <- Gen.maybe genNat
-  protocolParamUTxOCostPerByte <- Gen.maybe genLovelace
+  protocolParamUTxOCostPerByte <- fmap Just genLovelace
 
   pure ProtocolParameters {..}
 
 -- | Generate valid protocol parameters which pass validations in Cardano.Api.ProtocolParameters
-genValidProtocolParameters :: Gen ProtocolParameters
-genValidProtocolParameters =
+genValidProtocolParameters :: CardanoEra era -> Gen ProtocolParameters
+genValidProtocolParameters _era =
   ProtocolParameters
     <$> ((,) <$> genNat <*> genNat)
     <*> Gen.maybe genRational

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -126,7 +126,7 @@ import           Cardano.Api.Script (scriptInEraToRefScript)
 import           Cardano.Api.Shelley (GovernancePoll (..), GovernancePollAnswer (..), Hash (..),
                    KESPeriod (KESPeriod),
                    OperationalCertificateIssueCounter (OperationalCertificateIssueCounter),
-                   PlutusScript (PlutusScriptSerialised), ProtocolParameters (ProtocolParameters),
+                   PlutusScript (PlutusScriptSerialised), ProtocolParameters (..),
                    ReferenceScript (..), ReferenceTxInsScriptsInlineDatumsSupportedInEra (..),
                    StakeCredential (StakeCredentialByKey), StakePoolKey,
                    refInsScriptsAndInlineDatsSupportedInEra)
@@ -163,6 +163,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 {- HLINT ignore "Reduce duplication" -}
+{- HLINT ignore "Use let" -}
 
 genAddressByron :: Gen (Address ByronAddr)
 genAddressByron = makeByronAddress <$> genNetworkId
@@ -846,36 +847,37 @@ genMaybePraosNonce :: Gen (Maybe PraosNonce)
 genMaybePraosNonce = Gen.maybe genPraosNonce
 
 genProtocolParameters :: Gen ProtocolParameters
-genProtocolParameters =
-  ProtocolParameters
-    <$> ((,) <$> genNat <*> genNat)
-    <*> Gen.maybe genRational
-    <*> genMaybePraosNonce
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> genLovelace
-    <*> genLovelace
-    <*> Gen.maybe genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genEpochNo
-    <*> genNat
-    <*> genRationalInt64
-    <*> genRational
-    <*> genRational
-    <*> Gen.maybe genLovelace
-    <*> return mempty
-    --TODO: Babbage figure out how to deal with
-    -- asymmetric cost model JSON instances
-    <*> Gen.maybe genExecutionUnitPrices
-    <*> Gen.maybe genExecutionUnits
-    <*> Gen.maybe genExecutionUnits
-    <*> Gen.maybe genNat
-    <*> Gen.maybe genNat
-    <*> Gen.maybe genNat
-    <*> Gen.maybe genLovelace
+genProtocolParameters = do
+  protocolParamProtocolVersion <- (,) <$> genNat <*> genNat
+  protocolParamDecentralization <- Gen.maybe genRational
+  protocolParamExtraPraosEntropy <- genMaybePraosNonce
+  protocolParamMaxBlockHeaderSize <- genNat
+  protocolParamMaxBlockBodySize <- genNat
+  protocolParamMaxTxSize <- genNat
+  protocolParamTxFeeFixed <- genLovelace
+  protocolParamTxFeePerByte <- genLovelace
+  protocolParamMinUTxOValue <- Gen.maybe genLovelace
+  protocolParamStakeAddressDeposit <- genLovelace
+  protocolParamStakePoolDeposit <- genLovelace
+  protocolParamMinPoolCost <- genLovelace
+  protocolParamPoolRetireMaxEpoch <- genEpochNo
+  protocolParamStakePoolTargetNum <- genNat
+  protocolParamPoolPledgeInfluence <- genRationalInt64
+  protocolParamMonetaryExpansion <- genRational
+  protocolParamTreasuryCut <- genRational
+  protocolParamUTxOCostPerWord <- Gen.maybe genLovelace
+  protocolParamCostModels <- pure mempty
+  --TODO: Babbage figure out how to deal with
+  -- asymmetric cost model JSON instances
+  protocolParamPrices <- Gen.maybe genExecutionUnitPrices
+  protocolParamMaxTxExUnits <- Gen.maybe genExecutionUnits
+  protocolParamMaxBlockExUnits <- Gen.maybe genExecutionUnits
+  protocolParamMaxValueSize <- Gen.maybe genNat
+  protocolParamCollateralPercent <- Gen.maybe genNat
+  protocolParamMaxCollateralInputs <- Gen.maybe genNat
+  protocolParamUTxOCostPerByte <- Gen.maybe genLovelace
+
+  pure ProtocolParameters {..}
 
 -- | Generate valid protocol parameters which pass validations in Cardano.Api.ProtocolParameters
 genValidProtocolParameters :: Gen ProtocolParameters

--- a/cardano-api/internal/Cardano/Api/Feature.hs
+++ b/cardano-api/internal/Cardano/Api/Feature.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Cardano.Api.Feature
+  ( FeatureValue (..)
+  , FeatureInEra(..)
+  , featureInShelleyBasedEra
+  , valueOrDefault
+  , asFeatureValue
+  , asFeatureValueInShelleyBasedEra
+  , isFeatureValue
+  ) where
+
+import           Cardano.Api.Eras
+
+import           Data.Kind
+
+-- | A class for features that are supported in some eras but not others.
+class FeatureInEra (feature :: Type -> Type) where
+  -- | Determine the value to use for a feature in a given 'CardanoEra'.
+  -- Note that the negative case is the first argument, and the positive case is the second as per
+  -- the 'either' function convention.
+  featureInEra :: ()
+    => a                    -- ^ Value to use if the feature is not supported in the era
+    -> (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+    -> CardanoEra era       -- ^ Era to check
+    -> a                    -- ^ The value to use
+
+-- | Determine the value to use for a feature in a given 'ShelleyBasedEra'.
+featureInShelleyBasedEra :: ()
+  => FeatureInEra feature
+  => a
+  -> (feature era -> a)
+  -> ShelleyBasedEra era
+  -> a
+featureInShelleyBasedEra no yes = featureInEra no yes . shelleyBasedToCardanoEra
+
+-- | A value of type @'FeatureValue' feature era a@ is either:
+data FeatureValue feature era a where
+  -- | A value is available for this feature in this era
+  FeatureValue
+    :: feature era
+    -- ^ The witness that the feature is supported in this era
+    -> a
+    -- ^ The value to use
+    -> FeatureValue feature era a
+
+  -- | No value is available for this feature in this era
+  NoFeatureValue
+    :: FeatureValue feature era a
+
+deriving instance (Eq a, Eq (feature era)) => Eq (FeatureValue feature era a)
+deriving instance (Show a, Show (feature era)) => Show (FeatureValue feature era a)
+
+-- | Determine if a value is defined.
+--
+-- If the value is not defined, it could be because the feature is not supported or
+-- because the feature is supported but the value is not available.
+isFeatureValue :: FeatureValue feature era a -> Bool
+isFeatureValue = \case
+  NoFeatureValue -> False
+  FeatureValue _ _ -> True
+
+-- | Get the value if it is defined, otherwise return the default value.
+valueOrDefault :: a -> FeatureValue feature era a -> a
+valueOrDefault defaultValue = \case
+  NoFeatureValue -> defaultValue
+  FeatureValue _ a -> a
+
+-- | Attempt to construct a 'FeatureValue' from a value and era.
+-- If the feature is not supported in the era, then 'NoFeatureValue' is returned.
+asFeatureValue :: ()
+  => FeatureInEra feature
+  => a
+  -> CardanoEra era
+  -> FeatureValue feature era a
+asFeatureValue value = featureInEra NoFeatureValue (`FeatureValue` value)
+
+-- | Attempt to construct a 'FeatureValue' from a value and a shelley-based-era.
+asFeatureValueInShelleyBasedEra :: ()
+  => FeatureInEra feature
+  => a
+  -> ShelleyBasedEra era
+  -> FeatureValue feature era a
+asFeatureValueInShelleyBasedEra value = asFeatureValue value . shelleyBasedToCardanoEra

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {- HLINT ignore "Redundant ==" -}
@@ -70,11 +71,16 @@ module Cardano.Api.ProtocolParameters (
 
     -- * Data family instances
     AsType(..),
+
+    -- ** Era-dependent protocol features
+    ProtocolUTxOCostPerByteFeature(..),
+
   ) where
 
 import           Cardano.Api.Address
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
+import           Cardano.Api.Feature
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Json (toRationalJSON)
@@ -667,6 +673,31 @@ instance FromCBOR ProtocolParametersUpdate where
         <*> fromCBOR
         <*> fromCBOR
 
+-- ----------------------------------------------------------------------------
+-- Features
+--
+
+-- | A representation of whether the era supports the 'UTxO Cost Per Byte'
+-- protocol parameter.
+--
+-- The Babbage and subsequent eras support such a protocol parameter.
+--
+data ProtocolUTxOCostPerByteFeature era where
+  ProtocolUTxOCostPerByteInBabbageEra :: ProtocolUTxOCostPerByteFeature BabbageEra
+  ProtocolUTxOCostPerByteInConwayEra  :: ProtocolUTxOCostPerByteFeature ConwayEra
+
+deriving instance Eq   (ProtocolUTxOCostPerByteFeature era)
+deriving instance Show (ProtocolUTxOCostPerByteFeature era)
+
+instance FeatureInEra ProtocolUTxOCostPerByteFeature where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> yes ProtocolUTxOCostPerByteInBabbageEra
+    ConwayEra   -> yes ProtocolUTxOCostPerByteInConwayEra
 
 -- ----------------------------------------------------------------------------
 -- Praos nonce

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -74,6 +74,7 @@ module Cardano.Api.ProtocolParameters (
 
     -- ** Era-dependent protocol features
     ProtocolUTxOCostPerByteFeature(..),
+    ProtocolUTxOCostPerWordFeature(..),
 
   ) where
 
@@ -698,6 +699,27 @@ instance FeatureInEra ProtocolUTxOCostPerByteFeature where
     AlonzoEra   -> no
     BabbageEra  -> yes ProtocolUTxOCostPerByteInBabbageEra
     ConwayEra   -> yes ProtocolUTxOCostPerByteInConwayEra
+
+-- | A representation of whether the era supports the 'UTxO Cost Per Word'
+-- protocol parameter.
+--
+-- The Babbage and subsequent eras support such a protocol parameter.
+--
+data ProtocolUTxOCostPerWordFeature era where
+  ProtocolUpdateUTxOCostPerWordInAlonzoEra :: ProtocolUTxOCostPerWordFeature AlonzoEra
+
+deriving instance Eq   (ProtocolUTxOCostPerWordFeature era)
+deriving instance Show (ProtocolUTxOCostPerWordFeature era)
+
+instance FeatureInEra ProtocolUTxOCostPerWordFeature where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> yes ProtocolUpdateUTxOCostPerWordInAlonzoEra
+    BabbageEra  -> no
+    ConwayEra   -> no
 
 -- ----------------------------------------------------------------------------
 -- Praos nonce

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -294,6 +294,9 @@ module Cardano.Api (
     scriptDataSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
 
+    -- ** Era-dependent protocol features
+    ProtocolUTxOCostPerByteFeature(..),
+
     -- ** Fee calculation
     LedgerEpochInfo(..),
     transactionFee,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -296,6 +296,7 @@ module Cardano.Api (
 
     -- ** Era-dependent protocol features
     ProtocolUTxOCostPerByteFeature(..),
+    ProtocolUTxOCostPerWordFeature(..),
 
     -- ** Fee calculation
     LedgerEpochInfo(..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -277,6 +277,7 @@ module Cardano.Api (
     CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
+    FeatureInEra(..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,
@@ -861,6 +862,7 @@ import           Cardano.Api.DeserialiseAnyOf
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
+import           Cardano.Api.Feature
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/JSON.hs
@@ -8,6 +8,8 @@ module Test.Cardano.Api.Typed.JSON
   ( tests
   ) where
 
+import           Cardano.Api
+
 import           Data.Aeson (eitherDecode, encode)
 
 import           Test.Gen.Cardano.Api.Typed (genMaybePraosNonce, genProtocolParameters)
@@ -29,7 +31,8 @@ prop_roundtrip_praos_nonce_JSON = H.property $ do
 
 prop_roundtrip_protocol_parameters_JSON :: Property
 prop_roundtrip_protocol_parameters_JSON = H.property $ do
-  pp <- forAll genProtocolParameters
+  AnyCardanoEra era <- forAll $ Gen.element [minBound .. maxBound]
+  pp <- forAll (genProtocolParameters era)
   tripping pp encode eitherDecode
 
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Introduce the `FeatureInEra` type class.  This type class will be used by "feature" types to define a way to determine if that feature is supported in an era.

Introduce the `FeatureValue` type.  This type is meant to be used to define data types with era-sensitive type-safe fields.

This PR does not _yet_ use `FeatureValue` to implement type-safe fields for the `ProtocolParameter` type because doing so requires that `ProtocolParameter` take an `era` type argument, and there are challenges to doing that as this time.

The changes to introduce type-safe fields will be introduced in https://github.com/input-output-hk/cardano-api/pull/39 when some other issues have been resolved.

More explanation is made inline.

# Changelog

```yaml
- description: |
    Generate fields only if they make sense for the given era.
    Changes:
    - New `Cardano.Api.Feature` module
    - New`FeatureInEra` type class
    - New `FeatureValue` type
    - New functions:
      - `genFeatureValueInEra`
      - `featureInShelleyBasedEra`
      - `isFeatureValue`
      - `valueOrDefault`
      - `asFeatureValue`
      - `asFeatureValueInShelleyBasedEra`
    - `genProtocolParameters` and `genValidProtocolParameters` functions take additional `era` argument
  compatibility: breaking
  type: feature
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
