### PR TITLE
New types and functions for committee keys and certificates

### DIFF
--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -22,6 +22,9 @@ module Cardano.Api.Certificate (
     StakePoolRelay(..),
     StakePoolMetadataReference(..),
 
+    makeCommitteeDelegationCertificate,
+    makeCommitteeHotKeyUnregistrationCertificate,
+
     -- * Special certificates
     makeMIRCertificate,
     makeGenesisKeyDelegationCertificate,
@@ -87,9 +90,18 @@ data Certificate =
    | StakePoolRetirementCertificate   PoolId EpochNo
 
      -- Special certificates
-   | GenesisKeyDelegationCertificate (Hash GenesisKey)
-                                     (Hash GenesisDelegateKey)
-                                     (Hash VrfKey)
+   | GenesisKeyDelegationCertificate
+      (Hash GenesisKey)
+      (Hash GenesisDelegateKey)
+      (Hash VrfKey)
+
+   | CommitteeDelegationCertificate
+      (Hash CommitteeColdKey)
+      (Hash CommitteeHotKey)
+
+   | CommitteeHotKeyUnregistrationCertificate
+      (Hash CommitteeColdKey)
+
    | MIRCertificate MIRPot MIRTarget
 
   deriving stock (Eq, Show)
@@ -114,6 +126,8 @@ instance HasTextEnvelope Certificate where
       StakePoolRegistrationCertificate{}      -> "Pool registration"
       StakePoolRetirementCertificate{}        -> "Pool retirement"
       GenesisKeyDelegationCertificate{}       -> "Genesis key delegation"
+      CommitteeDelegationCertificate{}               -> "Constitution Committee key delegation"
+      CommitteeHotKeyUnregistrationCertificate{}     -> "Constitution Committee hot key unregistration"
       MIRCertificate{}                        -> "MIR"
 
 -- | The 'MIRTarget' determines the target of a 'MIRCertificate'.
@@ -203,6 +217,17 @@ makeGenesisKeyDelegationCertificate :: Hash GenesisKey
                                     -> Certificate
 makeGenesisKeyDelegationCertificate = GenesisKeyDelegationCertificate
 
+makeCommitteeDelegationCertificate :: ()
+  => Hash CommitteeColdKey
+  -> Hash CommitteeHotKey
+  -> Certificate
+makeCommitteeDelegationCertificate = CommitteeDelegationCertificate
+
+makeCommitteeHotKeyUnregistrationCertificate :: ()
+  => Hash CommitteeColdKey
+  -> Certificate
+makeCommitteeHotKeyUnregistrationCertificate = CommitteeHotKeyUnregistrationCertificate
+
 makeMIRCertificate :: MIRPot -> MIRTarget -> Certificate
 makeMIRCertificate = MIRCertificate
 
@@ -251,6 +276,17 @@ toShelleyCertificate (GenesisKeyDelegationCertificate
         genesiskh
         delegatekh
         vrfkh
+
+toShelleyCertificate
+  ( CommitteeDelegationCertificate
+    (CommitteeColdKeyHash _ckh)
+    (CommitteeHotKeyHash  _hkh)
+  ) = error "TODO CIP-1694 Need ledger types for CommitteeDelegationCertificate"
+
+toShelleyCertificate
+  ( CommitteeHotKeyUnregistrationCertificate
+    (CommitteeColdKeyHash _ckh)
+  ) = error "TODO CIP-1694 Need ledger types for CommitteeHotKeyUnregistrationCertificate"
 
 toShelleyCertificate (MIRCertificate mirpot (StakeAddressesMIR amounts)) =
     Shelley.DCertMir $

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -758,6 +758,10 @@ module Cardano.Api (
     getOpCertCount,
     issueOperationalCertificate,
 
+    -- * Constitutional Committee keys
+    CommitteeColdKey,
+    CommitteeHotKey,
+
     -- * Genesis file
     -- | Types and functions needed to inspect or create a genesis file.
     GenesisKey,
@@ -877,6 +881,13 @@ module Cardano.Api (
     querySystemStart,
     queryUtxo,
     determineEraExpr,
+
+    -- * Governance
+
+    -- ** Governance Committee
+    makeCommitteeDelegationCertificate,
+    makeCommitteeHotKeyUnregistrationCertificate,
+
   ) where
 
 import           Cardano.Api.Address


### PR DESCRIPTION
New types and functions for committee keys and certificates:

* CommitteeColdKey
* CommitteeDelegationCertificate
* CommitteeHotKey
* CommitteeHotKeyUnregistrationCertificate
* GenesisKeyDelegationCertificate
* makeCommitteeDelegationCertificate
* makeCommitteeHotKeyUnregistrationCertificate

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Changelog

```yaml
- description: |
    <insert-changelog-description-here>
  # no-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: <no-api-changes|compatible|breaking>
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: <feature|bugfix|test|maintenance>
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
