### PR TITLE
Revert to use `testProperty` now that it isn't deprecated anymore

### DIFF
--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Ledger.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Ledger.hs
@@ -7,8 +7,8 @@ import           Test.Cardano.Ledger.Core.Arbitrary ()
 import qualified Hedgehog.Extras.Aeson as H
 import           Test.Golden.Cardano.Api.Genesis (exampleShelleyGenesis)
 import           Test.Tasty (TestTree)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 test_golden_ShelleyGenesis :: TestTree
-test_golden_ShelleyGenesis = testPropertyNamed "golden ShelleyGenesis"  "golden ShelleyGenesis" $
+test_golden_ShelleyGenesis = testProperty "golden ShelleyGenesis" $
   H.goldenTestJsonValuePretty exampleShelleyGenesis "test/cardano-api-golden/files/golden/ShelleyGenesis"

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Typed/Script.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Typed/Script.hs
@@ -26,7 +26,7 @@ import           Hedgehog ((===))
 import qualified Hedgehog as H
 import           Hedgehog.Extras.Aeson
 import           Test.Tasty (TestTree)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -91,55 +91,48 @@ goldenPath = "test/cardano-api-golden/files/golden/Script"
 
 test_golden_SimpleScriptV1_All :: TestTree
 test_golden_SimpleScriptV1_All =
-  testPropertyNamed "golden SimpleScriptV1 All" "golden SimpleScriptV1 All" $
-    goldenTestJsonValuePretty exampleSimpleScriptV1_All
-                              (goldenPath </> "SimpleV1/all")
+  testProperty "golden SimpleScriptV1 All" $
+    goldenTestJsonValuePretty exampleSimpleScriptV1_All (goldenPath </> "SimpleV1/all")
 
 test_golden_SimpleScriptV1_Any :: TestTree
 test_golden_SimpleScriptV1_Any =
-  testPropertyNamed "golden SimpleScriptV1 Any" "golden SimpleScriptV1 Any" $
-    goldenTestJsonValuePretty exampleSimpleScriptV1_Any
-                              (goldenPath </> "SimpleV1/any")
+  testProperty "golden SimpleScriptV1 Any" $
+    goldenTestJsonValuePretty exampleSimpleScriptV1_Any (goldenPath </> "SimpleV1/any")
 
 test_golden_SimpleScriptV1_MofN :: TestTree
 test_golden_SimpleScriptV1_MofN =
-  testPropertyNamed "golden SimpleScriptV1 MofN"    "golden SimpleScriptV1 MofN" $
-    goldenTestJsonValuePretty exampleSimpleScriptV1_MofN
-                              (goldenPath </> "SimpleV1/atleast")
+  testProperty "golden SimpleScriptV1 MofN" $
+    goldenTestJsonValuePretty exampleSimpleScriptV1_MofN (goldenPath </> "SimpleV1/atleast")
 
 test_golden_SimpleScriptV2_All :: TestTree
 test_golden_SimpleScriptV2_All =
-  testPropertyNamed "golden SimpleScriptV2 All" "golden SimpleScriptV2 All" $
-    goldenTestJsonValuePretty exampleSimpleScriptV2_All
-                              (goldenPath </> "SimpleV2/all")
+  testProperty "golden SimpleScriptV2 All" $
+    goldenTestJsonValuePretty exampleSimpleScriptV2_All (goldenPath </> "SimpleV2/all")
 
 test_golden_SimpleScriptV2_Any :: TestTree
 test_golden_SimpleScriptV2_Any =
-  testPropertyNamed "golden SimpleScriptV2 Any" "golden SimpleScriptV2 Any" $
-    goldenTestJsonValuePretty exampleSimpleScriptV2_Any
-                              (goldenPath </> "SimpleV2/any")
+  testProperty "golden SimpleScriptV2 Any" $
+    goldenTestJsonValuePretty exampleSimpleScriptV2_Any (goldenPath </> "SimpleV2/any")
 
 test_golden_SimpleScriptV2_MofN :: TestTree
 test_golden_SimpleScriptV2_MofN =
-  testPropertyNamed "golden SimpleScriptV2 MofN" "golden SimpleScriptV2 MofN" $
-    goldenTestJsonValuePretty exampleSimpleScriptV2_MofN
-                              (goldenPath </> "SimpleV2/atleast")
+  testProperty "golden SimpleScriptV2 MofN" $
+    goldenTestJsonValuePretty exampleSimpleScriptV2_MofN (goldenPath </> "SimpleV2/atleast")
 
 test_roundtrip_SimpleScript_JSON :: TestTree
 test_roundtrip_SimpleScript_JSON =
-  testPropertyNamed "roundtrip SimpleScript JSON" "roundtrip SimpleScript JSON" . H.property $ do
+  testProperty "roundtrip SimpleScript JSON" . H.property $ do
     mss <- H.forAll genSimpleScript
     H.tripping mss encode eitherDecode
 
 test_roundtrip_ScriptData :: TestTree
 test_roundtrip_ScriptData =
-  testPropertyNamed "roundtrip ScriptData" "roundtrip ScriptData" . H.property $ do
+  testProperty "roundtrip ScriptData" . H.property $ do
     sData <- H.forAll genHashableScriptData
     sData === fromAlonzoData (toAlonzoData @L.Alonzo sData)
 
 test_roundtrip_HashableScriptData_JSON :: TestTree
 test_roundtrip_HashableScriptData_JSON =
-  testPropertyNamed "roundtrip HashableScriptData"  "roundtrip HashableScriptData" . H.property $ do
+  testProperty "roundtrip HashableScriptData" . H.property $ do
     sData <- H.forAll genHashableScriptData
     H.tripping sData scriptDataToJsonDetailedSchema scriptDataFromJsonDetailedSchema
-

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
@@ -13,7 +13,7 @@ import           Hedgehog (Property, forAll, property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 --------------------------------------------------------------------------------
 -- Bounded instances
@@ -48,8 +48,8 @@ prop_toJSON_CardanoMatchesShelley = property $ do
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Json"
-  [ testPropertyNamed "maxBound cardano matches shelley"           "maxBound cardano matches shelley"           prop_maxBound_CardanoMatchesShelley
-  , testPropertyNamed "roundtrip JSON shelley"                     "roundtrip JSON shelley"                     prop_roundtrip_JSON_Shelley
-  , testPropertyNamed "roundtrip JSON cardano"                     "roundtrip JSON cardano"                     prop_roundtrip_JSON_Cardano
-  , testPropertyNamed "toJSON cardano matches shelley"             "toJSON cardano matches shelley"             prop_toJSON_CardanoMatchesShelley
+  [ testProperty "maxBound cardano matches shelley" prop_maxBound_CardanoMatchesShelley
+  , testProperty "roundtrip JSON shelley"           prop_roundtrip_JSON_Shelley
+  , testProperty "roundtrip JSON cardano"           prop_roundtrip_JSON_Cardano
+  , testProperty "toJSON cardano matches shelley"   prop_toJSON_CardanoMatchesShelley
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -18,7 +18,7 @@ import           Test.Gen.Cardano.Api.Typed
 import           Hedgehog (Property, forAll, tripping)
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -87,12 +87,12 @@ prop_json_roundtrip_scriptdata_detailed_json = H.property $ do
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Json"
-  [ testPropertyNamed "json roundtrip alonzo genesis"           "json roundtrip alonzo genesis"           prop_json_roundtrip_alonzo_genesis
-  , testPropertyNamed "json roundtrip utxo"                     "json roundtrip utxo"                     prop_json_roundtrip_utxo
-  , testPropertyNamed "json roundtrip reference scripts"        "json roundtrip reference scripts"        prop_json_roundtrip_reference_scripts
-  , testPropertyNamed "json roundtrip txoutvalue"               "json roundtrip txoutvalue"               prop_json_roundtrip_txoutvalue
-  , testPropertyNamed "json roundtrip txout tx context"         "json roundtrip txout tx context"         prop_json_roundtrip_txout_tx_context
-  , testPropertyNamed "json roundtrip txout utxo context"       "json roundtrip txout utxo context"       prop_json_roundtrip_txout_utxo_context
-  , testPropertyNamed "json roundtrip eraInMode"                "json roundtrip eraInMode"                prop_json_roundtrip_eraInMode
-  , testPropertyNamed "json roundtrip scriptdata detailed json" "json roundtrip scriptdata detailed json" prop_json_roundtrip_scriptdata_detailed_json
+  [ testProperty "json roundtrip alonzo genesis"           prop_json_roundtrip_alonzo_genesis
+  , testProperty "json roundtrip utxo"                     prop_json_roundtrip_utxo
+  , testProperty "json roundtrip reference scripts"        prop_json_roundtrip_reference_scripts
+  , testProperty "json roundtrip txoutvalue"               prop_json_roundtrip_txoutvalue
+  , testProperty "json roundtrip txout tx context"         prop_json_roundtrip_txout_tx_context
+  , testProperty "json roundtrip txout utxo context"       prop_json_roundtrip_txout_utxo_context
+  , testProperty "json roundtrip eraInMode"                prop_json_roundtrip_eraInMode
+  , testProperty "json roundtrip scriptdata detailed json" prop_json_roundtrip_scriptdata_detailed_json
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/KeysByron.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/KeysByron.hs
@@ -13,7 +13,7 @@ import           Hedgehog (Property)
 import qualified Hedgehog as H
 import           Test.Hedgehog.Roundtrip.CBOR (trippingCbor)
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -24,5 +24,5 @@ prop_roundtrip_byron_key_CBOR = H.property $ do
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.KeysByron"
-  [ testPropertyNamed "roundtrip byron key CBOR" "roundtrip byron key CBOR" prop_roundtrip_byron_key_CBOR
+  [ testProperty "roundtrip byron key CBOR" prop_roundtrip_byron_key_CBOR
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Ledger.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Ledger.hs
@@ -23,7 +23,7 @@ import qualified Hedgehog as H
 import           Hedgehog.Gen.QuickCheck (arbitrary)
 import           Hedgehog.Internal.Property
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 -- Keep this here to make sure serialiseAddr/deserialiseAddr are working.
 -- They are defined in the Shelley executable spec and have been wrong at
@@ -66,7 +66,7 @@ prop_roundtrip_scriptdata_plutusdata = H.property $ do
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Ledger"
-  [ testPropertyNamed "roundtrip Address CBOR" "roundtrip Address CBOR" prop_roundtrip_Address_CBOR
-  , testPropertyNamed "roundtrip ScriptData" "roundtrip ScriptData" prop_roundtrip_scriptdata_plutusdata
-  , testPropertyNamed "script data bytes preserved" "script data bytes preserved" prop_original_scriptdata_bytes_preserved
+  [ testProperty "roundtrip Address CBOR" prop_roundtrip_Address_CBOR
+  , testProperty "roundtrip ScriptData" prop_roundtrip_scriptdata_plutusdata
+  , testProperty "script data bytes preserved" prop_original_scriptdata_bytes_preserved
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Metadata.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Metadata.hs
@@ -22,7 +22,7 @@ import qualified Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 -- ----------------------------------------------------------------------------
 -- Golden / unit tests
@@ -169,17 +169,17 @@ prop_metadata_bytes_chunks =
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Metadata"
-  [ testPropertyNamed "golden 1"                             "golden 1"                             prop_golden_1
-  , testPropertyNamed "golden 2"                             "golden 2"                             prop_golden_2
-  , testPropertyNamed "golden 3"                             "golden 3"                             prop_golden_3
-  , testPropertyNamed "golden 4"                             "golden 4"                             prop_golden_4
-  , testPropertyNamed "golden 5"                             "golden 5"                             prop_golden_5
-  , testPropertyNamed "golden 6"                             "golden 6"                             prop_golden_6
-  , testPropertyNamed "golden 7"                             "golden 7"                             prop_golden_7
-  , testPropertyNamed "golden 8"                             "golden 8"                             prop_golden_8
-  , testPropertyNamed "noschema json roundtrip via metadata" "noschema json roundtrip via metadata" prop_noschema_json_roundtrip_via_metadata
-  , testPropertyNamed "schema json roundtrip via metadata"   "schema json roundtrip via metadata"   prop_schema_json_roundtrip_via_metadata
-  , testPropertyNamed "metadata roundtrip via schema json"   "metadata roundtrip via schema json"   prop_metadata_roundtrip_via_schema_json
-  , testPropertyNamed "valid & rountrip text chunks"         "valid & roundtrip text chunks"        prop_metadata_text_chunks
-  , testPropertyNamed "valid & rountrip bytes chunks"        "valid & roundtrip bytes chunks"       prop_metadata_bytes_chunks
+  [ testProperty "golden 1"                             prop_golden_1
+  , testProperty "golden 2"                             prop_golden_2
+  , testProperty "golden 3"                             prop_golden_3
+  , testProperty "golden 4"                             prop_golden_4
+  , testProperty "golden 5"                             prop_golden_5
+  , testProperty "golden 6"                             prop_golden_6
+  , testProperty "golden 7"                             prop_golden_7
+  , testProperty "golden 8"                             prop_golden_8
+  , testProperty "noschema json roundtrip via metadata" prop_noschema_json_roundtrip_via_metadata
+  , testProperty "schema json roundtrip via metadata"   prop_schema_json_roundtrip_via_metadata
+  , testProperty "metadata roundtrip via schema json"   prop_metadata_roundtrip_via_schema_json
+  , testProperty "valid & rountrip text chunks"         prop_metadata_text_chunks
+  , testProperty "valid & rountrip bytes chunks"        prop_metadata_bytes_chunks
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Address.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Address.hs
@@ -15,7 +15,7 @@ import           Test.Cardano.Api.Typed.Orphans ()
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -58,8 +58,8 @@ prop_roundtrip_shelley_address_JSON =
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.Address"
-  [ testPropertyNamed "roundtrip shelley address" "roundtrip shelley address" prop_roundtrip_shelley_address
-  , testPropertyNamed "roundtrip byron address"   "roundtrip byron address" prop_roundtrip_byron_address
-  , testPropertyNamed "roundtrip byron address JSON"   "roundtrip byron address JSON" prop_roundtrip_byron_address_JSON
-  , testPropertyNamed "roundtrip shelley address JSON"   "roundtrip shelley address JSON" prop_roundtrip_shelley_address_JSON
+  [ testProperty "roundtrip shelley address"      prop_roundtrip_shelley_address
+  , testProperty "roundtrip byron address"        prop_roundtrip_byron_address
+  , testProperty "roundtrip byron address JSON"   prop_roundtrip_byron_address_JSON
+  , testProperty "roundtrip shelley address JSON" prop_roundtrip_shelley_address_JSON
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Bech32.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Bech32.hs
@@ -9,7 +9,7 @@ import           Test.Gen.Cardano.Api.Typed (genAddressShelley, genStakeAddress)
 import           Hedgehog (Property)
 import           Test.Hedgehog.Roundtrip.Bech32 (roundtrip_Bech32)
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 prop_roundtrip_Address_Shelley :: Property
 prop_roundtrip_Address_Shelley = roundtrip_Bech32 AsShelleyAddress genAddressShelley
@@ -19,6 +19,6 @@ prop_roundtrip_StakeAddress = roundtrip_Bech32 AsStakeAddress genStakeAddress
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.Bech32"
-  [ testPropertyNamed "roundtrip Address Shelley" "roundtrip Address Shelley" prop_roundtrip_Address_Shelley
-  , testPropertyNamed "roundtrip StakeAddress"    "roundtrip StakeAddress"    prop_roundtrip_StakeAddress
+  [ testProperty "roundtrip Address Shelley" prop_roundtrip_Address_Shelley
+  , testProperty "roundtrip StakeAddress"    prop_roundtrip_StakeAddress
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/CBOR.hs
@@ -21,7 +21,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Test.Hedgehog.Roundtrip.CBOR as H
 import           Test.Hedgehog.Roundtrip.CBOR
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -191,35 +191,35 @@ prop_roundtrip_GovernancePollAnswer_CBOR = property $ do
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.CBOR"
-  [ testPropertyNamed "roundtrip witness CBOR"                               "roundtrip witness CBOR"                               prop_roundtrip_witness_CBOR
-  , testPropertyNamed "roundtrip operational certificate CBOR"               "roundtrip operational certificate CBOR"               prop_roundtrip_operational_certificate_CBOR
-  , testPropertyNamed "roundtrip operational certificate issue counter CBOR" "roundtrip operational certificate issue counter CBOR" prop_roundtrip_operational_certificate_issue_counter_CBOR
-  , testPropertyNamed "roundtrip verification key byron CBOR"                "roundtrip verification key byron CBOR"                prop_roundtrip_verification_key_byron_CBOR
-  , testPropertyNamed "roundtrip signing key byron CBOR"                     "roundtrip signing key byron CBOR"                     prop_roundtrip_signing_key_byron_CBOR
-  , testPropertyNamed "roundtrip verification key payment CBOR"              "roundtrip verification key payment CBOR"              prop_roundtrip_verification_key_payment_CBOR
-  , testPropertyNamed "roundtrip signing key payment CBOR"                   "roundtrip signing key payment CBOR"                   prop_roundtrip_signing_key_payment_CBOR
-  , testPropertyNamed "roundtrip verification key stake CBOR"                "roundtrip verification key stake CBOR"                prop_roundtrip_verification_key_stake_CBOR
-  , testPropertyNamed "roundtrip signing key stake CBOR"                     "roundtrip signing key stake CBOR"                     prop_roundtrip_signing_key_stake_CBOR
-  , testPropertyNamed "roundtrip verification key genesis CBOR"              "roundtrip verification key genesis CBOR"              prop_roundtrip_verification_key_genesis_CBOR
-  , testPropertyNamed "roundtrip signing key genesis CBOR"                   "roundtrip signing key genesis CBOR"                   prop_roundtrip_signing_key_genesis_CBOR
-  , testPropertyNamed "roundtrip verification key genesis delegate CBOR"     "roundtrip verification key genesis delegate CBOR"     prop_roundtrip_verification_key_genesis_delegate_CBOR
-  , testPropertyNamed "roundtrip signing key genesis delegate CBOR"          "roundtrip signing key genesis delegate CBOR"          prop_roundtrip_signing_key_genesis_delegate_CBOR
-  , testPropertyNamed "roundtrip verification key stake pool CBOR"           "roundtrip verification key stake pool CBOR"           prop_roundtrip_verification_key_stake_pool_CBOR
-  , testPropertyNamed "roundtrip signing key stake pool CBOR"                "roundtrip signing key stake pool CBOR"                prop_roundtrip_signing_key_stake_pool_CBOR
-  , testPropertyNamed "roundtrip verification key vrf CBOR"                  "roundtrip verification key vrf CBOR"                  prop_roundtrip_verification_key_vrf_CBOR
-  , testPropertyNamed "roundtrip signing key vrf CBOR"                       "roundtrip signing key vrf CBOR"                       prop_roundtrip_signing_key_vrf_CBOR
-  , testPropertyNamed "roundtrip verification key kes CBOR"                  "roundtrip verification key kes CBOR"                  prop_roundtrip_verification_key_kes_CBOR
-  , testPropertyNamed "roundtrip signing key kes CBOR"                       "roundtrip signing key kes CBOR"                       prop_roundtrip_signing_key_kes_CBOR
-  , testPropertyNamed "roundtrip script SimpleScriptV1 CBOR"                 "roundtrip script SimpleScriptV1 CBOR"                 prop_roundtrip_script_SimpleScriptV1_CBOR
-  , testPropertyNamed "roundtrip script SimpleScriptV2 CBOR"                 "roundtrip script SimpleScriptV2 CBOR"                 prop_roundtrip_script_SimpleScriptV2_CBOR
-  , testPropertyNamed "roundtrip script PlutusScriptV1 CBOR"                 "roundtrip script PlutusScriptV1 CBOR"                 prop_roundtrip_script_PlutusScriptV1_CBOR
-  , testPropertyNamed "roundtrip script PlutusScriptV2 CBOR"                 "roundtrip script PlutusScriptV2 CBOR"                 prop_roundtrip_script_PlutusScriptV2_CBOR
-  , testPropertyNamed "roundtrip UpdateProposal CBOR"                        "roundtrip UpdateProposal CBOR"                        prop_roundtrip_UpdateProposal_CBOR
-  , testPropertyNamed "roundtrip ScriptData CBOR"                            "roundtrip ScriptData CBOR"                            prop_roundtrip_ScriptData_CBOR
-  , testPropertyNamed "roundtrip txbody CBOR"                                "roundtrip txbody CBOR"                                prop_roundtrip_txbody_CBOR
-  , testPropertyNamed "roundtrip Tx Cddl"                                    "roundtrip Tx Cddl"                                    prop_roundtrip_Tx_Cddl
-  , testPropertyNamed "roundtrip TxWitness Cddl"                             "roundtrip TxWitness Cddl"                             prop_roundtrip_TxWitness_Cddl
-  , testPropertyNamed "roundtrip tx CBOR"                                    "roundtrip tx CBOR"                                    prop_roundtrip_tx_CBOR
-  , testPropertyNamed "roundtrip GovernancePoll CBOR"                        "roundtrip GovernancePoll CBOR"                        prop_roundtrip_GovernancePoll_CBOR
-  , testPropertyNamed "roundtrip GovernancePollAnswer CBOR"                  "roundtrip GovernancePollAnswer CBOR"                  prop_roundtrip_GovernancePollAnswer_CBOR
+  [ testProperty "roundtrip witness CBOR"                               prop_roundtrip_witness_CBOR
+  , testProperty "roundtrip operational certificate CBOR"               prop_roundtrip_operational_certificate_CBOR
+  , testProperty "roundtrip operational certificate issue counter CBOR" prop_roundtrip_operational_certificate_issue_counter_CBOR
+  , testProperty "roundtrip verification key byron CBOR"                prop_roundtrip_verification_key_byron_CBOR
+  , testProperty "roundtrip signing key byron CBOR"                     prop_roundtrip_signing_key_byron_CBOR
+  , testProperty "roundtrip verification key payment CBOR"              prop_roundtrip_verification_key_payment_CBOR
+  , testProperty "roundtrip signing key payment CBOR"                   prop_roundtrip_signing_key_payment_CBOR
+  , testProperty "roundtrip verification key stake CBOR"                prop_roundtrip_verification_key_stake_CBOR
+  , testProperty "roundtrip signing key stake CBOR"                     prop_roundtrip_signing_key_stake_CBOR
+  , testProperty "roundtrip verification key genesis CBOR"              prop_roundtrip_verification_key_genesis_CBOR
+  , testProperty "roundtrip signing key genesis CBOR"                   prop_roundtrip_signing_key_genesis_CBOR
+  , testProperty "roundtrip verification key genesis delegate CBOR"     prop_roundtrip_verification_key_genesis_delegate_CBOR
+  , testProperty "roundtrip signing key genesis delegate CBOR"          prop_roundtrip_signing_key_genesis_delegate_CBOR
+  , testProperty "roundtrip verification key stake pool CBOR"           prop_roundtrip_verification_key_stake_pool_CBOR
+  , testProperty "roundtrip signing key stake pool CBOR"                prop_roundtrip_signing_key_stake_pool_CBOR
+  , testProperty "roundtrip verification key vrf CBOR"                  prop_roundtrip_verification_key_vrf_CBOR
+  , testProperty "roundtrip signing key vrf CBOR"                       prop_roundtrip_signing_key_vrf_CBOR
+  , testProperty "roundtrip verification key kes CBOR"                  prop_roundtrip_verification_key_kes_CBOR
+  , testProperty "roundtrip signing key kes CBOR"                       prop_roundtrip_signing_key_kes_CBOR
+  , testProperty "roundtrip script SimpleScriptV1 CBOR"                 prop_roundtrip_script_SimpleScriptV1_CBOR
+  , testProperty "roundtrip script SimpleScriptV2 CBOR"                 prop_roundtrip_script_SimpleScriptV2_CBOR
+  , testProperty "roundtrip script PlutusScriptV1 CBOR"                 prop_roundtrip_script_PlutusScriptV1_CBOR
+  , testProperty "roundtrip script PlutusScriptV2 CBOR"                 prop_roundtrip_script_PlutusScriptV2_CBOR
+  , testProperty "roundtrip UpdateProposal CBOR"                        prop_roundtrip_UpdateProposal_CBOR
+  , testProperty "roundtrip ScriptData CBOR"                            prop_roundtrip_ScriptData_CBOR
+  , testProperty "roundtrip txbody CBOR"                                prop_roundtrip_txbody_CBOR
+  , testProperty "roundtrip Tx Cddl"                                    prop_roundtrip_Tx_Cddl
+  , testProperty "roundtrip TxWitness Cddl"                             prop_roundtrip_TxWitness_Cddl
+  , testProperty "roundtrip tx CBOR"                                    prop_roundtrip_tx_CBOR
+  , testProperty "roundtrip GovernancePoll CBOR"                        prop_roundtrip_GovernancePoll_CBOR
+  , testProperty "roundtrip GovernancePollAnswer CBOR"                  prop_roundtrip_GovernancePollAnswer_CBOR
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Envelope.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Envelope.hs
@@ -13,7 +13,7 @@ import           Test.Cardano.Api.Typed.Orphans ()
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -111,20 +111,20 @@ roundtrip_SigningKey_envelope roletoken =
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.Envelope"
-  [ testPropertyNamed "roundtrip ByronVerificationKey envelope"           "roundtrip ByronVerificationKey envelope"           prop_roundtrip_ByronVerificationKey_envelope
-  , testPropertyNamed "roundtrip ByronSigningKey envelope"                "roundtrip ByronSigningKey envelope"                prop_roundtrip_ByronSigningKey_envelope
-  , testPropertyNamed "roundtrip PaymentVerificationKey envelope"         "roundtrip PaymentVerificationKey envelope"         prop_roundtrip_PaymentVerificationKey_envelope
-  , testPropertyNamed "roundtrip PaymentSigningKey envelope"              "roundtrip PaymentSigningKey envelope"              prop_roundtrip_PaymentSigningKey_envelope
-  , testPropertyNamed "roundtrip StakeVerificationKey envelope"           "roundtrip StakeVerificationKey envelope"           prop_roundtrip_StakeVerificationKey_envelope
-  , testPropertyNamed "roundtrip StakeSigningKey envelope"                "roundtrip StakeSigningKey envelope"                prop_roundtrip_StakeSigningKey_envelope
-  , testPropertyNamed "roundtrip StakePoolVerificationKey envelope"       "roundtrip StakePoolVerificationKey envelope"       prop_roundtrip_StakePoolVerificationKey_envelope
-  , testPropertyNamed "roundtrip StakePoolSigningKey envelope"            "roundtrip StakePoolSigningKey envelope"            prop_roundtrip_StakePoolSigningKey_envelope
-  , testPropertyNamed "roundtrip GenesisVerificationKey envelope"         "roundtrip GenesisVerificationKey envelope"         prop_roundtrip_GenesisVerificationKey_envelope
-  , testPropertyNamed "roundtrip GenesisSigningKey envelope"              "roundtrip GenesisSigningKey envelope"              prop_roundtrip_GenesisSigningKey_envelope
-  , testPropertyNamed "roundtrip GenesisDelegateVerificationKey envelope" "roundtrip GenesisDelegateVerificationKey envelope" prop_roundtrip_GenesisDelegateVerificationKey_envelope
-  , testPropertyNamed "roundtrip GenesisDelegateSigningKey envelope"      "roundtrip GenesisDelegateSigningKey envelope"      prop_roundtrip_GenesisDelegateSigningKey_envelope
-  , testPropertyNamed "roundtrip KesVerificationKey envelope"             "roundtrip KesVerificationKey envelope"             prop_roundtrip_KesVerificationKey_envelope
-  , testPropertyNamed "roundtrip KesSigningKey envelope"                  "roundtrip KesSigningKey envelope"                  prop_roundtrip_KesSigningKey_envelope
-  , testPropertyNamed "roundtrip VrfVerificationKey envelope"             "roundtrip VrfVerificationKey envelope"             prop_roundtrip_VrfVerificationKey_envelope
-  , testPropertyNamed "roundtrip VrfSigningKey envelope"                  "roundtrip VrfSigningKey envelope"                  prop_roundtrip_VrfSigningKey_envelope
+  [ testProperty "roundtrip ByronVerificationKey envelope"           prop_roundtrip_ByronVerificationKey_envelope
+  , testProperty "roundtrip ByronSigningKey envelope"                prop_roundtrip_ByronSigningKey_envelope
+  , testProperty "roundtrip PaymentVerificationKey envelope"         prop_roundtrip_PaymentVerificationKey_envelope
+  , testProperty "roundtrip PaymentSigningKey envelope"              prop_roundtrip_PaymentSigningKey_envelope
+  , testProperty "roundtrip StakeVerificationKey envelope"           prop_roundtrip_StakeVerificationKey_envelope
+  , testProperty "roundtrip StakeSigningKey envelope"                prop_roundtrip_StakeSigningKey_envelope
+  , testProperty "roundtrip StakePoolVerificationKey envelope"       prop_roundtrip_StakePoolVerificationKey_envelope
+  , testProperty "roundtrip StakePoolSigningKey envelope"            prop_roundtrip_StakePoolSigningKey_envelope
+  , testProperty "roundtrip GenesisVerificationKey envelope"         prop_roundtrip_GenesisVerificationKey_envelope
+  , testProperty "roundtrip GenesisSigningKey envelope"              prop_roundtrip_GenesisSigningKey_envelope
+  , testProperty "roundtrip GenesisDelegateVerificationKey envelope" prop_roundtrip_GenesisDelegateVerificationKey_envelope
+  , testProperty "roundtrip GenesisDelegateSigningKey envelope"      prop_roundtrip_GenesisDelegateSigningKey_envelope
+  , testProperty "roundtrip KesVerificationKey envelope"             prop_roundtrip_KesVerificationKey_envelope
+  , testProperty "roundtrip KesSigningKey envelope"                  prop_roundtrip_KesSigningKey_envelope
+  , testProperty "roundtrip VrfVerificationKey envelope"             prop_roundtrip_VrfVerificationKey_envelope
+  , testProperty "roundtrip VrfSigningKey envelope"                  prop_roundtrip_VrfSigningKey_envelope
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/JSON.hs
@@ -20,7 +20,7 @@ import           Hedgehog (Property, forAll, tripping)
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -39,6 +39,6 @@ prop_roundtrip_protocol_parameters_JSON = H.property $ do
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.JSON"
-  [ testPropertyNamed "roundtrip praos nonce JSON"         "roundtrip praos nonce JSON"         prop_roundtrip_praos_nonce_JSON
-  , testPropertyNamed "roundtrip protocol parameters JSON" "roundtrip protocol parameters JSON" prop_roundtrip_protocol_parameters_JSON
+  [ testProperty "roundtrip praos nonce JSON"         prop_roundtrip_praos_nonce_JSON
+  , testProperty "roundtrip protocol parameters JSON" prop_roundtrip_protocol_parameters_JSON
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Ord.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Ord.hs
@@ -12,7 +12,7 @@ import           Test.Cardano.Api.Metadata (genTxMetadataValue)
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -56,10 +56,10 @@ prop_ord_distributive_ScriptData =
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.Ord"
-  [ testPropertyNamed "ord distributive TxId"         "ord distributive TxId"           prop_ord_distributive_TxId
-  , testPropertyNamed "ord distributive TxIn"         "ord distributive TxIn"           prop_ord_distributive_TxIn
-  , testPropertyNamed "ord distributive Address"      "ord distributive Address"        prop_ord_distributive_Address
-  , testPropertyNamed "ord distributive StakeAddress" "ord distributive StakeAddress"   prop_ord_distributive_StakeAddress
-  , testPropertyNamed "ord distributive TxMetadata"   "ord distributive TxMetadata"     prop_ord_distributive_TxMetadata
-  , testPropertyNamed "ord distributive ScriptData"   "ord distributive ScriptData"     prop_ord_distributive_ScriptData
+  [ testProperty "ord distributive TxId"         prop_ord_distributive_TxId
+  , testProperty "ord distributive TxIn"         prop_ord_distributive_TxIn
+  , testProperty "ord distributive Address"      prop_ord_distributive_Address
+  , testProperty "ord distributive StakeAddress" prop_ord_distributive_StakeAddress
+  , testProperty "ord distributive TxMetadata"   prop_ord_distributive_TxMetadata
+  , testProperty "ord distributive ScriptData"   prop_ord_distributive_ScriptData
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/RawBytes.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/RawBytes.hs
@@ -13,7 +13,7 @@ import           Test.Cardano.Api.Typed.Orphans ()
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -96,17 +96,17 @@ roundtrip_verification_key_hash_raw roletoken =
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.RawBytes"
-  [ testPropertyNamed "roundtrip shelley address raw"                      "roundtrip shelley address raw"                       prop_roundtrip_shelley_address_raw
-  , testPropertyNamed "roundtrip byron address raw"                        "roundtrip byron address raw"                         prop_roundtrip_byron_address_raw
-  , testPropertyNamed "roundtrip stake address raw"                        "roundtrip stake address raw"                         prop_roundtrip_stake_address_raw
-  , testPropertyNamed "roundtrip script hash raw"                          "roundtrip script hash raw"                           prop_roundtrip_script_hash_raw
-  , testPropertyNamed "roundtrip verification ByronKey hash raw"           "roundtrip verification ByronKey hash raw"            prop_roundtrip_verification_ByronKey_hash_raw
-  , testPropertyNamed "roundtrip verification PaymentKey hash raw"         "roundtrip verification PaymentKey hash raw"          prop_roundtrip_verification_PaymentKey_hash_raw
-  , testPropertyNamed "roundtrip verification StakeKey hash raw"           "roundtrip verification StakeKey hash raw"            prop_roundtrip_verification_StakeKey_hash_raw
-  , testPropertyNamed "roundtrip verification StakePoolKey hash raw"       "roundtrip verification StakePoolKey hash raw"        prop_roundtrip_verification_StakePoolKey_hash_raw
-  , testPropertyNamed "roundtrip verification GenesisKey hash raw"         "roundtrip verification GenesisKey hash raw"          prop_roundtrip_verification_GenesisKey_hash_raw
-  , testPropertyNamed "roundtrip verification GenesisDelegateKey hash raw" "roundtrip verification GenesisDelegateKey hash raw"  prop_roundtrip_verification_GenesisDelegateKey_hash_raw
-  , testPropertyNamed "roundtrip verification KesKey hash raw"             "roundtrip verification KesKey hash raw"              prop_roundtrip_verification_KesKey_hash_raw
-  , testPropertyNamed "roundtrip verification VrfKey hash raw"             "roundtrip verification VrfKey hash raw"              prop_roundtrip_verification_VrfKey_hash_raw
-  , testPropertyNamed "roundtrip verification GenesisUTxOKey hash raw"     "roundtrip verification GenesisUTxOKey hash raw"      prop_roundtrip_verification_GenesisUTxOKey_hash_raw
+  [ testProperty "roundtrip shelley address raw"                      prop_roundtrip_shelley_address_raw
+  , testProperty "roundtrip byron address raw"                        prop_roundtrip_byron_address_raw
+  , testProperty "roundtrip stake address raw"                        prop_roundtrip_stake_address_raw
+  , testProperty "roundtrip script hash raw"                          prop_roundtrip_script_hash_raw
+  , testProperty "roundtrip verification ByronKey hash raw"           prop_roundtrip_verification_ByronKey_hash_raw
+  , testProperty "roundtrip verification PaymentKey hash raw"         prop_roundtrip_verification_PaymentKey_hash_raw
+  , testProperty "roundtrip verification StakeKey hash raw"           prop_roundtrip_verification_StakeKey_hash_raw
+  , testProperty "roundtrip verification StakePoolKey hash raw"       prop_roundtrip_verification_StakePoolKey_hash_raw
+  , testProperty "roundtrip verification GenesisKey hash raw"         prop_roundtrip_verification_GenesisKey_hash_raw
+  , testProperty "roundtrip verification GenesisDelegateKey hash raw" prop_roundtrip_verification_GenesisDelegateKey_hash_raw
+  , testProperty "roundtrip verification KesKey hash raw"             prop_roundtrip_verification_KesKey_hash_raw
+  , testProperty "roundtrip verification VrfKey hash raw"             prop_roundtrip_verification_VrfKey_hash_raw
+  , testProperty "roundtrip verification GenesisUTxOKey hash raw"     prop_roundtrip_verification_GenesisUTxOKey_hash_raw
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
@@ -17,7 +17,7 @@ import           Test.Cardano.Api.Typed.Orphans ()
 import           Hedgehog (MonadTest, Property, annotateShow, failure, (===))
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -76,5 +76,5 @@ prop_roundtrip_txbodycontent_txouts =
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.TxBody"
-  [ testPropertyNamed "roundtrip txbodycontent txouts" "roundtrip txbodycontent txouts" prop_roundtrip_txbodycontent_txouts
+  [ testProperty "roundtrip txbodycontent txouts" prop_roundtrip_txbodycontent_txouts
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Value.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Value.hs
@@ -15,7 +15,7 @@ import           Test.Gen.Cardano.Api.Typed (genAssetName, genValueDefault, genV
 
 import           Hedgehog (Property, forAll, property, tripping, (===))
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testPropertyNamed)
+import           Test.Tasty.Hedgehog (testProperty)
 
 prop_roundtrip_Value_JSON :: Property
 prop_roundtrip_Value_JSON =
@@ -85,9 +85,9 @@ prop_roundtrip_AssetName_JSONKey =
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Typed.Value"
-  [ testPropertyNamed "roundtrip Value JSON"              "roundtrip Value JSON"              prop_roundtrip_Value_JSON
-  , testPropertyNamed "roundtrip Value flatten unflatten" "roundtrip Value flatten unflatten" prop_roundtrip_Value_flatten_unflatten
-  , testPropertyNamed "roundtrip Value unflatten flatten" "roundtrip Value unflatten flatten" prop_roundtrip_Value_unflatten_flatten
-  , testPropertyNamed "roundtrip AssetName JSON"          "roundtrip AssetName JSON"          prop_roundtrip_AssetName_JSON
-  , testPropertyNamed "roundtrip AssetName JSONKey"       "roundtrip AssetName JSONKey"       prop_roundtrip_AssetName_JSONKey
+  [ testProperty "roundtrip Value JSON"              prop_roundtrip_Value_JSON
+  , testProperty "roundtrip Value flatten unflatten" prop_roundtrip_Value_flatten_unflatten
+  , testProperty "roundtrip Value unflatten flatten" prop_roundtrip_Value_unflatten_flatten
+  , testProperty "roundtrip AssetName JSON"          prop_roundtrip_AssetName_JSON
+  , testProperty "roundtrip AssetName JSONKey"       prop_roundtrip_AssetName_JSONKey
   ]


### PR DESCRIPTION
# Description

# Changelog

```yaml
- description: |
    Revert to use `testProperty`
  compatibility: no-api-changes
  type: test
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
