### PR TITLE
New `Cardano.Api.Query.Expr` module

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -87,6 +87,7 @@ library internal
                         Cardano.Api.Protocol
                         Cardano.Api.ProtocolParameters
                         Cardano.Api.Query
+                        Cardano.Api.Query.Expr
                         Cardano.Api.Script
                         Cardano.Api.ScriptData
                         Cardano.Api.SerialiseBech32

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE GADTs #-}
+
+module Cardano.Api.Query.Expr
+  ( queryChainBlockNo
+  , queryChainPoint
+  , queryCurrentEra
+  , queryEraHistory
+  , queryPparams
+  , queryStakeDelegDeposits
+  , queryStakePools
+  , querySystemStart
+  , queryUtxo
+  , determineEraExpr
+  ) where
+
+import           Cardano.Api.Address
+import           Cardano.Api.Block
+import           Cardano.Api.Certificate
+import           Cardano.Api.Eras
+import           Cardano.Api.IPC
+import           Cardano.Api.IPC.Monad
+import           Cardano.Api.Modes
+import           Cardano.Api.ProtocolParameters
+import           Cardano.Api.Query
+import           Cardano.Api.Value
+
+import           Cardano.Slotting.Slot
+import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as Consensus
+
+import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
+import           Data.Map (Map)
+import           Data.Set (Set)
+
+queryChainBlockNo :: ()
+  => LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (WithOrigin BlockNo))
+queryChainBlockNo =
+  queryExpr QueryChainBlockNo
+
+queryChainPoint :: ()
+  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError ChainPoint)
+queryChainPoint =
+  queryExpr $ QueryChainPoint CardanoMode
+
+queryCurrentEra :: ()
+  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
+queryCurrentEra =
+  queryExpr $ QueryCurrentEra CardanoModeIsMultiEra
+
+queryEraHistory :: ()
+  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (EraHistory CardanoMode))
+queryEraHistory =
+  queryExpr $ QueryEraHistory CardanoModeIsMultiEra
+
+queryPparams :: ()
+  => EraInMode era mode
+  -> ShelleyBasedEra era
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch ProtocolParameters))
+queryPparams qeInMode qSbe =
+  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryProtocolParameters
+
+queryStakeDelegDeposits :: ()
+  => EraInMode era mode
+  -> ShelleyBasedEra era
+  -> Set StakeCredential
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential Lovelace)))
+queryStakeDelegDeposits qeInMode qSbe stakeCreds =
+  queryExpr $ QueryInEra qeInMode . QueryInShelleyBasedEra qSbe $ QueryStakeDelegDeposits stakeCreds
+
+queryStakePools :: ()
+  => EraInMode era mode
+  -> ShelleyBasedEra era
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Set PoolId)))
+queryStakePools qeInMode qSbe =
+  queryExpr $ QueryInEra qeInMode . QueryInShelleyBasedEra qSbe $ QueryStakePools
+
+querySystemStart :: ()
+  => LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError SystemStart)
+querySystemStart =
+  queryExpr QuerySystemStart
+
+queryUtxo :: ()
+  => EraInMode era mode
+  -> ShelleyBasedEra era
+  -> QueryUTxOFilter
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (UTxO era)))
+queryUtxo qeInMode qSbe utxoFilter =
+  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe $ QueryUTxO utxoFilter
+
+-- | A monad expression that determines what era the node is in.
+determineEraExpr :: ()
+  => ConsensusModeParams mode
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
+determineEraExpr cModeParams = runExceptT $
+  case consensusModeOnly cModeParams of
+    ByronMode -> pure $ AnyCardanoEra ByronEra
+    ShelleyMode -> pure $ AnyCardanoEra ShelleyEra
+    CardanoMode -> ExceptT queryCurrentEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -813,7 +813,6 @@ module Cardano.Api (
     LocalStateQueryExpr,
     executeLocalStateQueryExpr,
     queryExpr,
-    determineEraExpr,
 
     chainPointToSlotNo,
     chainPointToHeaderHash,
@@ -850,6 +849,18 @@ module Cardano.Api (
 
     -- ** CLI option parsing
     bounded,
+
+    -- ** Query expressions
+    queryChainBlockNo,
+    queryChainPoint,
+    queryCurrentEra,
+    queryEraHistory,
+    queryPparams,
+    queryStakeDelegDeposits,
+    queryStakePools,
+    querySystemStart,
+    queryUtxo,
+    determineEraExpr,
   ) where
 
 import           Cardano.Api.Address
@@ -880,11 +891,12 @@ import           Cardano.Api.LedgerEvent
 import           Cardano.Api.LedgerState
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
-import           Cardano.Api.Orphans ()
 import           Cardano.Api.OperationalCertificate
+import           Cardano.Api.Orphans ()
 import           Cardano.Api.Protocol
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query hiding (LedgerState (..))
+import           Cardano.Api.Query.Expr
 import           Cardano.Api.Script
 import           Cardano.Api.ScriptData
 import           Cardano.Api.SerialiseBech32


### PR DESCRIPTION
# Description

This module exports our query API as functions.  It is intended to replace our query API as the public API.

Having functions as our public API rather than data allows us to export non-primitive functions as well as afford us the ability to refactor our query data types without breaking user code.

# Changelog

```yaml
- description: |
    This module exports our query API as functions.  It is intended to replace our query API as the public API.

    Having functions as our public API rather than data allows us to export non-primitive functions as well as
    afford us the ability to refactor our query data types without breaking user code
  compatibility: compatible
  type: feature
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
