### PR TITLE
nix: add developper tools, cross platform and alternative GHC support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1684943340,
-        "narHash": "sha256-+mooHHdi9UnoJMcVZFH0s1UACmvH7uc1zI2Leufnh24=",
+        "lastModified": 1685707241,
+        "narHash": "sha256-3vwY0mo8lf+0n+H6g3giXtVLQeXt/l9+FlsOpfi7CwM=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "bc316188504c83a5125902867232b87342ac019f",
+        "rev": "2baceb51b8f3175e05e94fdd4780cc717aeb2a6f",
         "type": "github"
       },
       "original": {
@@ -355,11 +355,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1684887982,
-        "narHash": "sha256-FzO2mAGrJuuo8N+sri3pIkCXuIBjqVCXAGwGcm22Z4o=",
+        "lastModified": 1685665664,
+        "narHash": "sha256-vqSkKMWkWMuFvxyoaYvmH2jmQkVwiEKkY/3tIOJNe2w=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6c4d5d33891a71b6ca77f93cd995a9988c7e96d5",
+        "rev": "b0fc370d1ca399b582074a8fb614acd83ad49bc7",
         "type": "github"
       },
       "original": {
@@ -380,6 +380,7 @@
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -392,16 +393,17 @@
         "nixpkgs-2111": "nixpkgs-2111",
         "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-2211": "nixpkgs-2211",
+        "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1684936758,
-        "narHash": "sha256-nbVl7+vE2WbIUE0D6peWRmqrqzVuKAD9O4U929bQGH4=",
+        "lastModified": 1685667105,
+        "narHash": "sha256-qSd7lR/HquT2Z3NjarC1TpNd9oIoyYeQH9H8Y+kHRnU=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e02f01efb79e7c7c7934d5c73619276323cf3e38",
+        "rev": "995485b05f3ea898028ed4d497a4b7a2496302e5",
         "type": "github"
       },
       "original": {
@@ -423,6 +425,23 @@
       "original": {
         "owner": "haskell",
         "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684398654,
+        "narHash": "sha256-RW44up2BIyBBYN6tZur5f9kDDR3kr0Rd+TgPbLTfwB4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "20c6d1e731cd9c0beef7338e2fc7a8126ba9b6fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -496,11 +515,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1684223806,
-        "narHash": "sha256-IyLoP+zhuyygLtr83XXsrvKyqqLQ8FHXTiySFf4FJOI=",
+        "lastModified": 1685607784,
+        "narHash": "sha256-ZewBEw5+/3DfuBYym+3XWQZbZRFvtng1Y0tlahfhohc=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "86421fdd89b3af43fa716ccd07638f96c6ecd1e4",
+        "rev": "e4b4589168c6abc698c49faba130dda65d908051",
         "type": "github"
       },
       "original": {
@@ -755,16 +774,32 @@
     },
     "nixpkgs-2211": {
       "locked": {
-        "lastModified": 1682682915,
-        "narHash": "sha256-haR0u/j/nUvlMloYlaOYq1FMXTvkNHw+wGxc+0qXisM=",
+        "lastModified": 1685314633,
+        "narHash": "sha256-8LXBPqTQXl5ofkjpJ18JcbmLJ/lWDoMxtUwiDYv0wro=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09f1b33fcc0f59263137e23e935c1bb03ec920e4",
+        "rev": "c8a17ce7abc03c50cd072e9e6c9b389c5f61836b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1685338297,
+        "narHash": "sha256-+Aq4O0Jn1W1q927ZHc3Zn6RO7bwQGmb6O8xYoGy0KrM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6287b47dbfabbb8bfbb9b1b53d198ad58a774de4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -787,11 +822,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1682656005,
-        "narHash": "sha256-fYplYo7so1O+rSQ2/aS+SbTPwLTeoUXk4ekKNtSl4P8=",
+        "lastModified": 1685347552,
+        "narHash": "sha256-9woSppRyUFo26yUffORTzttJ+apOt8MmCv6RxpPNTU4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6806b63e824f84b0f0e60b6d660d4ae753de0477",
+        "rev": "f2f1ec390714d303cf84ba086e34e45b450dd8c4",
         "type": "github"
       },
       "original": {
@@ -1018,11 +1053,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1684886964,
-        "narHash": "sha256-LJS/l+vktoL3BpuNPhIPXc9wRLYz8wX0mWUucSYMN6U=",
+        "lastModified": 1685578319,
+        "narHash": "sha256-hUWMzqeG7286bKoB+KgUcXDUIcJAOwDsmgX2ZwOfXL4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "5a0b9fc9c77f3370e63bda25f0304dd0e5437d2d",
+        "rev": "ddaad8445e3e80c877fd8e9877ff1495d5e7d3e8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     haskellNix.url = "github:input-output-hk/haskell.nix";
-    haskellNix.inputs.tullia.follows = "tullia";
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     iohkNix.url = "github:input-output-hk/iohk-nix";
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
@@ -25,9 +24,9 @@
   outputs = inputs: let
     supportedSystems = [
       "x86_64-linux"
-      #"x86_64-darwin"
-      #"aarch64-linux"
-      #"aarch64-darwin"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
     ];
   in
     inputs.flake-utils.lib.eachSystem supportedSystems (
@@ -36,25 +35,31 @@
         # overlays...
         nixpkgs = import inputs.nixpkgs {
           overlays = with inputs; [
-            # crypto needs to come before haskell.nix.
-            # FIXME: _THIS_IS_BAD_
-            iohkNix.overlays.crypto
-            haskellNix.overlay
-            iohkNix.overlays.haskell-nix-extra
-            iohkNix.overlays.cardano-lib
-            iohkNix.overlays.utils
+            # iohkNix.overlays.crypto provide libsodium-vrf, libblst and libsecp256k1.
+            inputs.iohkNix.overlays.crypto
+            # haskellNix.overlay can be configured by later overlays, so need to come before them.
+            inputs.haskellNix.overlay
+            # configure haskell.nix to use iohk-nix crypto librairies.
+            inputs.iohkNix.overlays.haskell-nix-crypto
           ];
           inherit system;
           inherit (inputs.haskellNix) config;
         };
         inherit (nixpkgs) lib;
 
+        # see flake `variants` below for alternative compilers
+        defaultCompiler = "ghc928";
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
-        cabalProject = nixpkgs.haskell-nix.cabalProject' {
+        cabalProject = nixpkgs.haskell-nix.cabalProject' ({config, ...}: {
           src = ./.;
           name = "cardano-api";
-          compiler-nix-name = "ghc8107";
+          compiler-nix-name = lib.mkDefault defaultCompiler;
+
+          # we also want cross compilation to windows on linux (and only with default compiler).
+          crossPlatforms = p:
+            lib.optional (system == "x86_64-linux" && config.compiler-nix-name == defaultCompiler)
+            p.mingwW64;
 
           # CHaP input map, so we can find CHaP packages (needs to be more
           # recent than the index-state we set!). Can be updated with
@@ -65,51 +70,36 @@
             "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP;
           };
 
-          # tools we want in our shell
-          # TODO: removed tools to get building properly
-          shell.tools = {
-            cabal = "3.10.1.0";
-            #ghcid = "0.8.8";
-            #haskell-language-server = "latest";
-            #hlint = {};
-            #fourmolu = "0.10.1.0";
-          };
-          # Now we use pkgsBuildBuild, to make sure that even in the cross
-          # compilation setting, we don't run into issues where we pick tools
-          # for the target.
-          #shell.nativeBuildInputs = with nixpkgs.pkgsBuildBuild; [
-          #  (pkgs.python3.withPackages (ps: with ps; [sphinx sphinx_rtd_theme recommonmark sphinx-markdown-tables sphinxemoji]))
-          #  haskellPackages.implicit-hie
-          #];
+          # tools we want in our shell, from hackage
+          shell.tools =
+            {
+              cabal = "3.10.1.0";
+              ghcid = "0.8.8";
+            }
+            // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
+              # tools that work or should be used only with default compiler
+              haskell-language-server = "2.0.0.0";
+              hlint = "3.5";
+              stylish-haskell = "0.14.4.0";
+            };
+          # and from nixpkgs or other inputs
+          shell.nativeBuildInputs = with nixpkgs;
+            [
+            ]
+            ++ (with inputs.tullia.packages.${system}; [
+              # for testing tullia ci locally
+              tullia
+              nix-systems
+            ]);
+          # disable Hoogle until someone request it
           shell.withHoogle = false;
+          # Skip cross compilers for the shell
+          shell.crossPlatforms = _: [];
 
           # package customizations as needed. Where cabal.project is not
           # specific enough, or doesn't allow setting these.
           modules = [
             ({pkgs, ...}: {
-              # Use our forked libsodium from iohk-nix crypto overlay.
-              packages.cardano-crypto-class.components.library.pkgconfig = lib.mkForce [[pkgs.libsodium-vrf pkgs.secp256k1]];
-              packages.cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [[pkgs.libsodium-vrf]];
-              packages.byron-spec-chain.configureFlags = ["--ghc-option=-Werror"];
-              packages.byron-spec-ledger.configureFlags = ["--ghc-option=-Werror"];
-              packages.delegation.configureFlags = ["--ghc-option=-Werror"];
-              packages.non-integral.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-ledger-shelley.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-ledger-shelley-ma.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-ledger-shelley-ma-test.configureFlags = ["--ghc-option=-Werror"];
-              packages.small-steps.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-ledger-byron = {
-                configureFlags = ["--ghc-option=-Werror"];
-                components = {
-                  tests.cardano-ledger-byron-test = {
-                    preCheck = ''
-                      export CARDANO_MAINNET_MIRROR="${inputs.cardano-mainnet-mirror}/epochs"
-                      cp ${./eras/byron/ledger/impl/mainnet-genesis.json} ./mainnet-genesis.json
-                    '';
-                    testFlags = ["--scenario=ContinuousIntegration"];
-                  };
-                };
-              };
               packages.cardano-api = {
                 configureFlags = ["--ghc-option=-Werror"];
                 components = {
@@ -121,33 +111,16 @@
                 };
               };
             })
-            ({pkgs, ...}:
-              lib.mkIf pkgs.stdenv.hostPlatform.isUnix {
-                packages.cardano-ledger-shelley-ma-test.components.tests.cardano-ledger-shelley-ma-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-                packages.cardano-ledger-shelley-test.components.tests.cardano-ledger-shelley-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-                packages.cardano-ledger-alonzo-test.components.tests.cardano-ledger-alonzo-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-                packages.cardano-ledger-babbage-test.components.tests.cardano-ledger-babbage-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-                packages.cardano-ledger-conway-test.components.tests.cardano-ledger-conway-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-              })
-            ({pkgs, ...}:
-              lib.mkIf pkgs.stdenv.hostPlatform.isWindows {
-                packages.set-algebra.components.tests.tests.buildable = lib.mkForce false;
-                packages.plutus-preprocessor.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-test.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-shelley-ma-test.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-shelley-test.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-alonzo-test.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-babbage-test.package.buildable = lib.mkForce false;
-                packages.cardano-ledger-conway-test.package.buildable = lib.mkForce false;
-              })
           ];
-        };
+        });
         # ... and construct a flake from the cabal project
         flake =
           cabalProject.flake (
-            # we also want cross compilation to windows.
             lib.optionalAttrs (system == "x86_64-linux") {
-              #crossPlatforms = p: [p.mingwW64];
+              # on linux, build/test other supported compilers
+              variants = lib.genAttrs ["ghc8107"] (compiler-nix-name: {
+                inherit compiler-nix-name;
+              });
             }
           )
           # add cicero logic.
@@ -175,15 +148,15 @@
                     };
                   };
 
-                  command.text = config.preset.github.status.lib.reportBulk {
-                    bulk.text = ''
-                      nix eval .#hydraJobs --apply __attrNames --json |
+                  command.text = ''
+                    # filter out systems that we cannot build for:
+                    systems=$(nix eval .#packages --apply builtins.attrNames --json |
                       nix-systems -i |
-                      jq 'with_entries(select(.value))' # filter out systems that we cannot build for
-                    '';
-                    each.text = ''nix build -L .#hydraJobs."$1".required'';
-                    skippedDescription = lib.escapeShellArg "No nix builder for this system";
-                  };
+                      jq -r 'with_entries(select(.value)) | keys | .[]')
+                    targets=$(for s in $systems; do echo .#hydraJobs."$s".required; done)
+                    # shellcheck disable=SC2086
+                    nix build --keep-going $targets || nix build --keep-going -L $targets
+                  '';
 
                   memory = 1024 * 8;
                   nomad.driver = "exec";
@@ -217,15 +190,31 @@
           hydraJobs =
             nixpkgs.callPackages inputs.iohkNix.utils.ciJobsAggregates
             {
-              ciJobs = flake.hydraJobs;
+              ciJobs =
+                flake.hydraJobs
+                // {
+                  # This ensure hydra send a status for the required job (even if no change other than commit hash)
+                  revision = nixpkgs.writeText "revision" (inputs.self.rev or "dirty");
+                };
             };
           legacyPackages = rec {
-            inherit cabalProject;
+            inherit cabalProject nixpkgs;
             # also provide hydraJobs through legacyPackages to allow building without system prefix:
             inherit hydraJobs;
           };
-          # `nix develop .#profiling`: a shell with profiling enabled
-          devShells.profiling = (cabalProject.appendModule {modules = [{enableLibraryProfiling = true;}];}).shell;
+          devShells = let
+            profillingShell = p: {
+              # `nix develop .#profiling` (or `.#ghc927.profiling): a shell with profiling enabled
+              profiling = (p.appendModule {modules = [{enableLibraryProfiling = true;}];}).shell;
+            };
+          in
+            profillingShell cabalProject
+            # Additional shells for every GHC version supported by haskell.nix, eg. `nix develop .#ghc927`
+            // lib.mapAttrs (compiler-nix-name: _: let
+              p = cabalProject.appendModule {inherit compiler-nix-name;};
+            in
+              p.shell // (profillingShell p))
+            nixpkgs.haskell-nix.compiler;
           # formatter used by nix fmt
           formatter = nixpkgs.alejandra;
         }


### PR DESCRIPTION
# Description

 defaulting to ghc 9.2.8, also building for 8.10.7.
 Fix #20.

Somehow managed to lose this change from the history: https://github.com/input-output-hk/cardano-api/pull/35

# Changelog

```yaml
- description: |
    nix: add developer tools, cross platform and alternative ghc support
  compatibility: no-api-changes
  type: maintenance
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
