### PR TITLE
New `queryEpoch` function

### DIFF
--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -6,6 +6,7 @@ module Cardano.Api.Query.Expr
   , queryCurrentEpochState
   , queryCurrentEra
   , queryDebugLedgerState
+  , queryEpoch
   , queryEraHistory
   , queryGenesisParameters
   , queryPoolDistribution
@@ -65,15 +66,22 @@ queryCurrentEpochState :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedCurrentEpochState era)))
-queryCurrentEpochState qeInMode qSbe =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryCurrentEpochState
+queryCurrentEpochState eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryCurrentEpochState
+
+queryEpoch :: ()
+  => EraInMode era mode
+  -> ShelleyBasedEra era
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch EpochNo))
+queryEpoch eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryEpoch
 
 queryDebugLedgerState :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedDebugLedgerState era)))
-queryDebugLedgerState qeInMode qSbe =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryDebugLedgerState
+queryDebugLedgerState eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryDebugLedgerState
 
 queryEraHistory :: ()
   => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (EraHistory CardanoMode))
@@ -84,53 +92,53 @@ queryGenesisParameters :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch GenesisParameters))
-queryGenesisParameters qeInMode qSbe =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryGenesisParameters
+queryGenesisParameters eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryGenesisParameters
 
 queryPoolDistribution :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> Maybe (Set PoolId)
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolDistribution era)))
-queryPoolDistribution qeInMode qSbe mPoolIds =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe $ QueryPoolDistribution mPoolIds
+queryPoolDistribution eraInMode sbe mPoolIds =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryPoolDistribution mPoolIds
 
 queryPoolState :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> Maybe (Set PoolId)
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolState era)))
-queryPoolState qeInMode qSbe mPoolIds =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe $ QueryPoolState mPoolIds
+queryPoolState eraInMode sbe mPoolIds =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryPoolState mPoolIds
 
 queryPparams :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch ProtocolParameters))
-queryPparams qeInMode qSbe =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryProtocolParameters
+queryPparams eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 {-# DEPRECATED queryPparams "Use queryProtocolParameters instead" #-}
 
 queryProtocolParameters :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch ProtocolParameters))
-queryProtocolParameters qeInMode qSbe =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryProtocolParameters
+queryProtocolParameters eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 
 queryProtocolParametersUpdate :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash GenesisKey) ProtocolParametersUpdate)))
-queryProtocolParametersUpdate qeInMode qSbe =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryProtocolParametersUpdate
+queryProtocolParametersUpdate eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolParametersUpdate
 
 queryProtocolState :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (ProtocolState era)))
-queryProtocolState qeInMode qSbe =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryProtocolState
+queryProtocolState eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolState
 
 queryStakeAddresses :: ()
   => EraInMode era mode
@@ -138,46 +146,46 @@ queryStakeAddresses :: ()
   -> Set StakeCredential
   -> NetworkId
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map StakeAddress Lovelace, Map StakeAddress PoolId)))
-queryStakeAddresses qeInMode qSbe stakeCredentials networkId =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe $ QueryStakeAddresses stakeCredentials networkId
+queryStakeAddresses eraInMode sbe stakeCredentials networkId =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakeAddresses stakeCredentials networkId
 
 queryStakeDelegDeposits :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> Set StakeCredential
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential Lovelace)))
-queryStakeDelegDeposits qeInMode qSbe stakeCreds =
-  queryExpr $ QueryInEra qeInMode . QueryInShelleyBasedEra qSbe $ QueryStakeDelegDeposits stakeCreds
+queryStakeDelegDeposits eraInMode sbe stakeCreds =
+  queryExpr $ QueryInEra eraInMode . QueryInShelleyBasedEra sbe $ QueryStakeDelegDeposits stakeCreds
 
 queryStakeDistribution :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash StakePoolKey) Rational)))
-queryStakeDistribution qeInMode qSbe =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe QueryStakeDistribution
+queryStakeDistribution eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryStakeDistribution
 
 queryStakePoolParameters :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> Set PoolId
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map PoolId StakePoolParameters)))
-queryStakePoolParameters qeInMode qSbe poolIds =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe $ QueryStakePoolParameters poolIds
+queryStakePoolParameters eraInMode sbe poolIds =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakePoolParameters poolIds
 
 queryStakePools :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Set PoolId)))
-queryStakePools qeInMode qSbe =
-  queryExpr $ QueryInEra qeInMode . QueryInShelleyBasedEra qSbe $ QueryStakePools
+queryStakePools eraInMode sbe =
+  queryExpr $ QueryInEra eraInMode . QueryInShelleyBasedEra sbe $ QueryStakePools
 
 queryStakeSnapshot :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> Maybe (Set PoolId)
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedStakeSnapshots era)))
-queryStakeSnapshot qeInMode qSbe mPoolIds =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe $ QueryStakeSnapshot mPoolIds
+queryStakeSnapshot eraInMode sbe mPoolIds =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakeSnapshot mPoolIds
 
 querySystemStart :: ()
   => LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError SystemStart)
@@ -189,8 +197,8 @@ queryUtxo :: ()
   -> ShelleyBasedEra era
   -> QueryUTxOFilter
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (UTxO era)))
-queryUtxo qeInMode qSbe utxoFilter =
-  queryExpr $ QueryInEra qeInMode $ QueryInShelleyBasedEra qSbe $ QueryUTxO utxoFilter
+queryUtxo eraInMode sbe utxoFilter =
+  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryUTxO utxoFilter
 
 -- | A monad expression that determines what era the node is in.
 determineEraExpr :: ()

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -856,6 +856,7 @@ module Cardano.Api (
     queryCurrentEpochState,
     queryCurrentEra,
     queryDebugLedgerState,
+    queryEpoch,
     queryEraHistory,
     queryGenesisParameters,
     queryPoolDistribution,


### PR DESCRIPTION
# Description

# Changelog

```yaml
- description: |
    New `queryEpoch` function
  compatibility: compatible
  type: feature
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
