### PR TITLE
Enable CI on PRs from forks

### DIFF
--- a/.github/workflows/check-cabal-files.yml
+++ b/.github/workflows/check-cabal-files.yml
@@ -1,8 +1,8 @@
 name: Check cabal files
 
 on:
-  push:
   merge_group:
+  pull_request:
 
 jobs:
   check-cabal-files:

--- a/.github/workflows/check-git-dependencies.yml
+++ b/.github/workflows/check-git-dependencies.yml
@@ -1,8 +1,8 @@
 name: Check git dependencies
 
 on:
-  push:
   merge_group:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -1,8 +1,8 @@
 name: Check HLint
 
 on:
-  push:
   merge_group:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/check-stylish-haskell.yml
+++ b/.github/workflows/check-stylish-haskell.yml
@@ -1,8 +1,8 @@
 name: Check Stylish Haskell
 
 on:
-  push:
   merge_group:
+  pull_request:
 
 # When pushing branches (and/or updating PRs), we do want to cancel previous
 # build runs. We assume they are stale now; and do not want to spend CI time and

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,8 +1,8 @@
 name: Haskell CI
 
 on:
-  push:
   merge_group:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/markdown-links-ci-check.yml
+++ b/.github/workflows/markdown-links-ci-check.yml
@@ -1,8 +1,8 @@
 name: Check Markdown links
 
 on:
-  push:
   merge_group:
+  pull_request:
 
 jobs:
   markdown-link-check:


### PR DESCRIPTION
# Description

Enable GHA on for PRs from forks

# Changelog

```yaml
- description: |
    Enable GHA for forks' PRs
  # no-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: no-api-changes
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: maintenance
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
