### PR TITLE
Remove `aarch64-linux` and `aarch64-darwin` to fix eval

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,8 @@
     supportedSystems = [
       "x86_64-linux"
       "x86_64-darwin"
-      "aarch64-linux"
-      "aarch64-darwin"
+      # "aarch64-linux" - disable these temporarily because the build is broken
+      # "aarch64-darwin" - disable these temporarily because the build is broken
     ];
   in
     inputs.flake-utils.lib.eachSystem supportedSystems (


### PR DESCRIPTION
# Description

Remove aarch64-linux and aarch64-darwin to fix eval.

These should be enabled again when possible.

# Changelog

```yaml
- description: |
    Remove aarch64-linux and aarch64-darwin to fix eval
  compatibility: no-api-changes
  type: maintenance
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
