### PR TITLE
Workaround for --override-input CHaP

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,13 @@
           inputMap = {
             "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP;
           };
-
+          # Also currently needed to make `nix flake lock --update-input CHaP` work.
+          cabalProjectLocal = ''
+            repository cardano-haskell-packages-local
+              url: file:${inputs.CHaP}
+              secure: True
+            active-repositories: hackage.haskell.org, cardano-haskell-packages-local
+          '';
           # tools we want in our shell, from hackage
           shell.tools =
             {


### PR DESCRIPTION
This helps haskell.nix find the package source correctly.  In particular new packages that are not in the main CHaP branch yet will be loaded correctly.

To try it out you will need a local CHaP, this can be build with:

```
git clone git@github.com:input-output-hk/cardano-haskell-packages.git
cd cardano-haskell-packages
nix develop -c foliage build -j 0 --write-metadata
```

That will make a `cardano-haskell-packages/_repo` dir with the CHaP repository including any new packages.  To use from a directory containing this `cardano-api` branch run:

```
nix build --override-input CHaP path:/home/hamish/iohk/cardano-haskell-packages/_repo .\#hydraJobs.required
```

Make sure to use `path:` and the full path to the `_repo` directory.