### PR TITLE
flake improvements

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,13 @@
           inputMap = {
             "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP;
           };
-
+          # Also currently needed to make `nix flake lock --update-input CHaP` work.
+          cabalProjectLocal = ''
+            repository cardano-haskell-packages-local
+              url: file:${inputs.CHaP}
+              secure: True
+            active-repositories: hackage.haskell.org, cardano-haskell-packages-local
+          '';
           # tools we want in our shell, from hackage
           shell.tools =
             {

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,7 @@
           );
       in
         nixpkgs.lib.recursiveUpdate flake rec {
+          project = cabalProject;
           # add a required job, that's basically all hydraJobs.
           hydraJobs =
             nixpkgs.callPackages inputs.iohkNix.utils.ciJobsAggregates


### PR DESCRIPTION
* exposes project from haskell.nix at top level
* adds work-around so `--update-input` with CHaP works as expected

# Changelog

```yaml
- description: |
    Flake improvements:
    - exposes project from haskell.nix at top level
    - adds work-around so --update-input with CHaP works as expected
  compatibility: no-api-changes
  type: maintenance
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
