### PR TITLE
Unified `ShelleyBasedEra` constraint summoning

### DIFF
--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -171,7 +171,7 @@ getBlockTxs (ByronBlock Consensus.ByronBlock { Consensus.byronBlockRaw }) =
             }
         } -> map ByronTx txs
 getBlockTxs (ShelleyBlock era Consensus.ShelleyBlock{Consensus.shelleyBlockRaw}) =
-    obtainConsensusShelleyCompatibleEra era $
+    withShelleyBasedEraConstraintForConsensus era $
       getShelleyBlockTxs era shelleyBlockRaw
 
 
@@ -185,19 +185,6 @@ getShelleyBlockTxs :: forall era ledgerera blockheader.
 getShelleyBlockTxs era (Ledger.Block _header txs) =
   [ ShelleyTx era txinblock
   | txinblock <- toList (Ledger.fromTxSeq txs) ]
-
-obtainConsensusShelleyCompatibleEra
-  :: forall era ledgerera a.
-     ShelleyLedgerEra era ~ ledgerera
-  => ShelleyBasedEra era
-  -> (Consensus.ShelleyCompatible (ConsensusProtocol era) ledgerera => a)
-  -> a
-obtainConsensusShelleyCompatibleEra ShelleyBasedEraShelley f = f
-obtainConsensusShelleyCompatibleEra ShelleyBasedEraAllegra f = f
-obtainConsensusShelleyCompatibleEra ShelleyBasedEraMary    f = f
-obtainConsensusShelleyCompatibleEra ShelleyBasedEraAlonzo  f = f
-obtainConsensusShelleyCompatibleEra ShelleyBasedEraBabbage f = f
-obtainConsensusShelleyCompatibleEra ShelleyBasedEraConway f = f
 
 -- ----------------------------------------------------------------------------
 -- Block in a consensus mode

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -52,6 +54,8 @@ module Cardano.Api.Eras
 
     -- * Assertions on era
   , requireShelleyBasedEra
+
+  , withShelleyBasedEraConstraintsForLedger
   ) where
 
 import           Cardano.Api.HasTypeProxy
@@ -535,3 +539,22 @@ requireShelleyBasedEra era =
   case cardanoEraStyle era of
     LegacyByronEra -> pure Nothing
     ShelleyBasedEra sbe -> pure (Just sbe)
+
+withShelleyBasedEraConstraintsForLedger :: ()
+  => ShelleyLedgerEra era ~ ledgerera
+  => ShelleyBasedEra era
+  ->  ( ()
+      => L.EraCrypto ledgerera ~ L.StandardCrypto
+      => L.EraTx ledgerera
+      => L.EraTxBody ledgerera
+      => L.Era ledgerera
+      => a
+      )
+  -> a
+withShelleyBasedEraConstraintsForLedger = \case
+  ShelleyBasedEraShelley -> id
+  ShelleyBasedEraAllegra -> id
+  ShelleyBasedEraMary    -> id
+  ShelleyBasedEraAlonzo  -> id
+  ShelleyBasedEraBabbage -> id
+  ShelleyBasedEraConway  -> id

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -1494,7 +1494,7 @@ nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (Vr
                                 decodeCurrentEpochState sbe serCurrEpochState
 
   let snapshot :: ShelleyAPI.SnapShot Shelley.StandardCrypto
-      snapshot = ShelleyAPI.ssStakeMark $ obtainIsStandardCrypto sbe $ ShelleyAPI.esSnapshots cEstate
+      snapshot = ShelleyAPI.ssStakeMark $ withShelleyBasedEraConstraintsForLedger sbe $ ShelleyAPI.esSnapshots cEstate
       markSnapshotPoolDistr :: Map (SL.KeyHash 'SL.StakePool Shelley.StandardCrypto) (SL.IndividualPoolStake Shelley.StandardCrypto)
       markSnapshotPoolDistr = ShelleyAPI.unPoolDistr . ShelleyAPI.calculatePoolDistr $ snapshot
 
@@ -1575,19 +1575,6 @@ isLeadingSlotsPraos slotRangeOfInterest poolid snapshotPoolDistr eNonce vrfSkey 
               certifiedNatValue = vrfLeaderValue (Proxy @Shelley.StandardCrypto) rho
 
   Right $ Set.filter isLeader slotRangeOfInterest
-
-obtainIsStandardCrypto
-  :: ShelleyLedgerEra era ~ ledgerera
-  => ShelleyBasedEra era
-  -> (Core.EraCrypto ledgerera ~ Shelley.StandardCrypto => a)
-  -> a
-obtainIsStandardCrypto ShelleyBasedEraShelley f = f
-obtainIsStandardCrypto ShelleyBasedEraAllegra f = f
-obtainIsStandardCrypto ShelleyBasedEraMary    f = f
-obtainIsStandardCrypto ShelleyBasedEraAlonzo  f = f
-obtainIsStandardCrypto ShelleyBasedEraBabbage f = f
-obtainIsStandardCrypto ShelleyBasedEraConway  f = f
-
 
 -- | Return the slots at which a particular stake pool operator is
 -- expected to mint a block.


### PR DESCRIPTION
# Description

`withShelleyBasedEraConstraintForConsensus` replaces locally defined `obtainConsensusShelleyCompatibleEra`.

`withShelleyBasedEraConstraintsForLedger` replaces locally defined:
* `obtainEraTx`
* `withLedgerConstraints`
* `obtainIsStandardCrypto`
* `obtainConstraints`
* `getLedgerEraConstraint`
* `getCBORConstraint`

# Changelog

```yaml
- description: |
    Unified `ShelleyBasedEra` constraint summoning
  compatibility: no-api-changes
  type: maintenance
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
