### PR TITLE
Backport: Add era phantom type parameter to Certificate

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -594,7 +594,7 @@ genTxCertificates era =
         ]
 
 -- TODO: Add remaining certificates
-genCertificate :: Gen Certificate
+genCertificate :: Gen (Certificate era)
 genCertificate =
   Gen.choice
     [ StakeAddressRegistrationCertificate <$> genStakeCredential

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -67,7 +68,7 @@ queryStateForBalancedTx
   -> CardanoEra era
   -> NetworkId
   -> [TxIn]
-  -> [Certificate]
+  -> [Certificate era]
   -> IO (Either QueryConvenienceError ( UTxO era
                                       , ProtocolParameters
                                       , EraHistory CardanoMode

--- a/cardano-api/internal/Cardano/Api/LedgerEvent.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerEvent.hs
@@ -19,7 +19,6 @@ where
 
 import           Cardano.Api.Address (StakeCredential, fromShelleyStakeCredential)
 import           Cardano.Api.Block (EpochNo)
-import           Cardano.Api.Certificate (Certificate)
 import           Cardano.Api.Keys.Shelley (Hash (StakePoolKeyHash), StakePoolKey)
 import           Cardano.Api.Value (Lovelace, fromShelleyDeltaLovelace, fromShelleyLovelace)
 
@@ -60,9 +59,9 @@ import           Data.SOP.Strict
 
 data LedgerEvent
   = -- | The given pool is being registered for the first time on chain.
-    PoolRegistration Certificate
+    PoolRegistration
   | -- | The given pool already exists and is being re-registered.
-    PoolReRegistration Certificate
+    PoolReRegistration
   | -- | Incremental rewards are being computed.
     IncrementalRewardsDistribution EpochNo (Map StakeCredential (Set (Reward StandardCrypto)))
   | -- | Reward distribution has completed.

--- a/cardano-api/internal/Cardano/Api/SerialiseTextEnvelope.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseTextEnvelope.hs
@@ -11,6 +11,7 @@
 --
 module Cardano.Api.SerialiseTextEnvelope
   ( HasTextEnvelope(..)
+  , textEnvelopeTypeInEra
   , TextEnvelope(..)
   , TextEnvelopeType(..)
   , TextEnvelopeDescr(..)
@@ -33,6 +34,7 @@ module Cardano.Api.SerialiseTextEnvelope
   , AsType(..)
   ) where
 
+import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.IO
@@ -165,6 +167,13 @@ class SerialiseAsCBOR a => HasTextEnvelope a where
     textEnvelopeDefaultDescr :: a -> TextEnvelopeDescr
     textEnvelopeDefaultDescr _ = ""
 
+textEnvelopeTypeInEra :: ()
+  => HasTextEnvelope (f era)
+  => CardanoEra era
+  -> AsType (f era)
+  -> TextEnvelopeType
+textEnvelopeTypeInEra _ =
+  textEnvelopeType
 
 serialiseToTextEnvelope :: forall a. HasTextEnvelope a
                         => Maybe TextEnvelopeDescr -> a -> TextEnvelope

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -1688,7 +1688,7 @@ data TxCertificates build era where
      TxCertificatesNone :: TxCertificates build era
 
      TxCertificates     :: CertificatesSupportedInEra era
-                        -> [Certificate]
+                        -> [Certificate era]
                         -> BuildTxWith build
                              (Map StakeCredential (Witness WitCtxStake era))
                         -> TxCertificates build era

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -23,6 +23,7 @@ module Cardano.Api (
     IsCardanoEra(..),
     AnyCardanoEra(..),
     anyCardanoEra,
+    cardanoEraConstraints,
     InAnyCardanoEra(..),
 
     -- ** Shelley-based eras
@@ -554,6 +555,7 @@ module Cardano.Api (
     TextEnvelopeType(..),
     TextEnvelopeDescr,
     TextEnvelopeError(..),
+    textEnvelopeTypeInEra,
     textEnvelopeRawCBOR,
     textEnvelopeToJSON,
     serialiseToTextEnvelope,
@@ -845,6 +847,9 @@ module Cardano.Api (
 
     -- ** CLI option parsing
     bounded,
+
+    requireShelleyBasedEra,
+    withShelleyBasedEraConstraintsForLedger,
   ) where
 
 import           Cardano.Api.Address
@@ -874,8 +879,8 @@ import           Cardano.Api.LedgerEvent
 import           Cardano.Api.LedgerState
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
-import           Cardano.Api.Orphans ()
 import           Cardano.Api.OperationalCertificate
+import           Cardano.Api.Orphans ()
 import           Cardano.Api.Protocol
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query hiding (LedgerState (..))


### PR DESCRIPTION
# Description

Backport https://github.com/input-output-hk/cardano-api/pull/83

# Changelog

```yaml
- description: |
    Backport:
    - Parameterise `Certificate` type with phantom `era` type argument
    - Additional `CardanoEra era` argument for:
      - `makeMIRCertificate`
      - `makeStakeAddressDeregistrationCertificate`
      - `makeStakeAddressPoolDelegationCertificate`
      - `makeStakeAddressRegistrationCertificate`
      - `makeStakePoolRegistrationCertificate`
      - `makeStakePoolRetirementCertificate`
    - New functions:
      - `cardanoEraConstraints`
      - `textEnvelopeTypeInEra`
    - Delete `Certificate` constructor arguments from:
      - `PoolRegistration`
      - `PoolReRegistration`
  compatibility: breaking
  type: feature
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
