### PR TITLE
Upgrade to `cardano-ledger-1.3`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -41,6 +41,3 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
-
-contraints:
-  cborg >= 0.2.9

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-05-10T10:34:57Z
-  , cardano-haskell-packages 2023-06-22T00:00:00Z
+  , hackage.haskell.org 2023-07-02T00:00:00Z
+  , cardano-haskell-packages 2023-07-02T00:00:00Z
 
 packages:
     cardano-api
@@ -41,3 +41,6 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+contraints:
+  cborg >= 0.2.9

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -234,7 +234,7 @@ library gen
                       , cardano-ledger-core >= 1.3
                       , cardano-ledger-shelley >= 1.3
                       , containers
-                      , hedgehog ^>= 1.3
+                      , hedgehog ^>= 1.1
                       , text
 
 test-suite cardano-api-test
@@ -255,7 +255,7 @@ test-suite cardano-api-test
                       , cardano-ledger-api >= 1.2.0.1
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.2
                       , containers
-                      , hedgehog ^>= 1.3
+                      , hedgehog ^>= 1.1
                       , hedgehog-quickcheck
                       , mtl
                       , QuickCheck
@@ -306,7 +306,7 @@ test-suite cardano-api-golden
                       , containers
                       , errors
                       , filepath
-                      , hedgehog ^>= 1.3
+                      , hedgehog ^>= 1.1
                       , hedgehog-extras >= 0.4.3.0
                       , microlens
                       , plutus-core ^>= 1.7

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -234,7 +234,7 @@ library gen
                       , cardano-ledger-core >= 1.3
                       , cardano-ledger-shelley >= 1.3
                       , containers
-                      , hedgehog
+                      , hedgehog ^>= 1.3
                       , text
 
 test-suite cardano-api-test
@@ -255,7 +255,7 @@ test-suite cardano-api-test
                       , cardano-ledger-api >= 1.2.0.1
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.2
                       , containers
-                      , hedgehog
+                      , hedgehog ^>= 1.3
                       , hedgehog-quickcheck
                       , mtl
                       , QuickCheck
@@ -306,7 +306,7 @@ test-suite cardano-api-golden
                       , containers
                       , errors
                       , filepath
-                      , hedgehog
+                      , hedgehog ^>= 1.3
                       , hedgehog-extras >= 0.4.3.0
                       , microlens
                       , plutus-core ^>= 1.7

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -126,17 +126,17 @@ library internal
                       , cardano-crypto-class >= 2.1.1
                       , cardano-crypto-wrapper ^>= 1.5
                       , cardano-data >= 1.0
-                      , cardano-ledger-alonzo >= 1.1.1
-                      , cardano-ledger-allegra >= 1.1
-                      , cardano-ledger-api >= 1.1
-                      , cardano-ledger-babbage >= 1.1
-                      , cardano-ledger-binary >= 1.1
-                      , cardano-ledger-byron >= 1.0
-                      , cardano-ledger-conway >= 1.1
-                      , cardano-ledger-core >= 1.2
+                      , cardano-ledger-alonzo >= 1.3
+                      , cardano-ledger-allegra >= 1.2
+                      , cardano-ledger-api >= 1.2.0.1
+                      , cardano-ledger-babbage >= 1.3
+                      , cardano-ledger-binary
+                      , cardano-ledger-byron >= 1.0.0.1
+                      , cardano-ledger-conway >= 1.3
+                      , cardano-ledger-core >= 1.3
                       , cardano-ledger-mary >= 1.1
-                      , cardano-ledger-shelley >= 1.1.1
-                      , cardano-protocol-tpraos >= 1.0.2
+                      , cardano-ledger-shelley >= 1.3
+                      , cardano-protocol-tpraos >= 1.0.3.1
                       , cardano-slotting >= 0.1
                       , cardano-strict-containers >= 0.1
                       , cborg
@@ -162,9 +162,9 @@ library internal
                       , ouroboros-network-framework
                       , ouroboros-network-protocols
                       , parsec
-                      , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>=1.5
+                      , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>= 1.7
                       , prettyprinter
-                      , prettyprinter-configurable ^>= 1.1
+                      , prettyprinter-configurable ^>= 1.7
                       , random
                       , scientific
                       , serialise
@@ -228,11 +228,11 @@ library gen
                       , cardano-binary >= 1.6 && < 1.8
                       , cardano-crypto-class ^>= 2.1
                       , cardano-crypto-test ^>= 1.5
-                      , cardano-ledger-alonzo >= 1.1
+                      , cardano-ledger-alonzo >= 1.3
                       , cardano-ledger-alonzo-test
                       , cardano-ledger-byron-test >= 1.5
-                      , cardano-ledger-core >= 1.2
-                      , cardano-ledger-shelley >= 1.1
+                      , cardano-ledger-core >= 1.3
+                      , cardano-ledger-shelley >= 1.3
                       , containers
                       , hedgehog
                       , text
@@ -252,7 +252,7 @@ test-suite cardano-api-test
                       , cardano-crypto-class ^>= 2.1
                       , cardano-crypto-test ^>= 1.5
                       , cardano-crypto-tests ^>= 2.1
-                      , cardano-ledger-api >= 1.1
+                      , cardano-ledger-api >= 1.2.0.1
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.2
                       , containers
                       , hedgehog
@@ -298,10 +298,10 @@ test-suite cardano-api-golden
                       , cardano-crypto-class
                       , cardano-data >= 1.0
                       , cardano-ledger-alonzo
-                      , cardano-ledger-api >= 1.1
+                      , cardano-ledger-api >= 1.2.0.1
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.2
                       , cardano-ledger-shelley
-                      , cardano-ledger-shelley-test >= 1.1
+                      , cardano-ledger-shelley-test >= 1.2
                       , cardano-slotting ^>= 0.1
                       , containers
                       , errors
@@ -309,8 +309,8 @@ test-suite cardano-api-golden
                       , hedgehog
                       , hedgehog-extras >= 0.4.3.0
                       , microlens
-                      , plutus-core ^>= 1.5
-                      , plutus-ledger-api ^>= 1.5
+                      , plutus-core ^>= 1.7
+                      , plutus-ledger-api ^>= 1.7
                       , tasty
                       , tasty-hedgehog
                       , time

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -234,7 +234,7 @@ library gen
                       , cardano-ledger-core >= 1.3
                       , cardano-ledger-shelley >= 1.3
                       , containers
-                      , hedgehog ^>= 1.1
+                      , hedgehog >= 1.1
                       , text
 
 test-suite cardano-api-test
@@ -255,7 +255,7 @@ test-suite cardano-api-test
                       , cardano-ledger-api >= 1.2.0.1
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.2
                       , containers
-                      , hedgehog ^>= 1.1
+                      , hedgehog >= 1.1
                       , hedgehog-quickcheck
                       , mtl
                       , QuickCheck
@@ -306,7 +306,7 @@ test-suite cardano-api-golden
                       , containers
                       , errors
                       , filepath
-                      , hedgehog ^>= 1.1
+                      , hedgehog >= 1.1
                       , hedgehog-extras >= 0.4.3.0
                       , microlens
                       , plutus-core ^>= 1.7

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -27,6 +27,7 @@ module Cardano.Api.Eras
   , anyCardanoEra
   , cardanoEraConstraints
   , InAnyCardanoEra(..)
+  , CardanoLedgerEra
 
     -- * Deprecated aliases
   , Byron
@@ -520,6 +521,14 @@ type family ShelleyLedgerEra era where
   ShelleyLedgerEra BabbageEra = Consensus.StandardBabbage
   ShelleyLedgerEra ConwayEra  = Consensus.StandardConway
 
+type family CardanoLedgerEra era where
+  CardanoLedgerEra ByronEra   = L.ByronEra   L.StandardCrypto
+  CardanoLedgerEra ShelleyEra = L.ShelleyEra L.StandardCrypto
+  CardanoLedgerEra AllegraEra = L.AllegraEra L.StandardCrypto
+  CardanoLedgerEra MaryEra    = L.MaryEra    L.StandardCrypto
+  CardanoLedgerEra AlonzoEra  = L.AlonzoEra  L.StandardCrypto
+  CardanoLedgerEra BabbageEra = L.BabbageEra L.StandardCrypto
+  CardanoLedgerEra ConwayEra  = L.ConwayEra  L.StandardCrypto
 
 -- | Lookup the lower major protocol version for the shelley based era. In other words
 -- this is the major protocol version that the era has started in.

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -294,6 +294,8 @@ estimateTransactionKeyWitnessCount TxBodyContent {
 
 type PlutusScriptBytes = ShortByteString
 
+-- TODO: Conway era - We don't really want to parameterise error
+-- types on the error for now. As a stop gap we should implement a rendering function
 data ResolvablePointers where
   ResolvablePointers ::
       ( Ledger.Era (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
@@ -45,7 +45,7 @@ data TxVotes era where
 
   TxVotes
     :: TxVotesSupportedInEra era
-    -> [(VoteChoice, VoterType, GovernanceActionIdentifier (ShelleyLedgerEra era), VotingCredential era)]
+    -> [Vote era]
     -> TxVotes era
 
 deriving instance Show (TxVotes era)

--- a/cardano-api/internal/Cardano/Api/Orphans.hs
+++ b/cardano-api/internal/Cardano/Api/Orphans.hs
@@ -7,7 +7,6 @@
 module Cardano.Api.Orphans () where
 
 import           Cardano.Binary (DecoderError (..))
-import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
 import qualified Cardano.Ledger.Crypto as Crypto
 import qualified Ouroboros.Consensus.Shelley.Ledger.Query as Consensus
 
@@ -17,11 +16,6 @@ import           Data.Aeson (ToJSON (..), object, pairs, (.=))
 import qualified Data.Aeson as Aeson
 import           Data.Data (Data)
 
-
--- FIXME: A temporary workaround for missing Eq and Data instances in plutus-ledger-api
--- TODO: remove this when plutus-ledger-api gets bumped to >=1.6.1
-deriving instance Eq Ledger.CostModelApplyError
-deriving instance Data Ledger.CostModelApplyError
 
 deriving instance Data DecoderError
 deriving instance Data CBOR.DeserialiseFailure

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -3629,11 +3629,7 @@ convGovActions sbe (TxGovernanceActions _ govActions) =
 
 convVotes :: ShelleyBasedEra era -> TxVotes era -> Seq.StrictSeq (Gov.VotingProcedure (ShelleyLedgerEra era))
 convVotes _ TxVotesNone = Seq.empty
-convVotes sbe (TxVotes _ votes) =
-  Seq.fromList
-    [ unVote $ createVotingProcedure sbe voteChoice voterType govActionIdentifier votingCred
-    | (voteChoice, voterType, govActionIdentifier, votingCred) <- votes
-    ]
+convVotes _ (TxVotes _ votes) = Seq.fromList $ map unVote votes
 
 guardShelleyTxInsOverflow :: [TxIn] -> Either TxBodyError ()
 guardShelleyTxInsOverflow txIns = do

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -31,15 +31,19 @@ module Cardano.Api.Utils
 
     -- ** Constraint solvers
   , obtainCryptoConstraints
+  , obtainEraConstraints
   , obtainEraPParamsConstraint
   , obtainEraCryptoConstraints
+  , obtainSafeToHashConstraint
   ) where
 
 import           Cardano.Api.Eras
 
+import           Cardano.Crypto.Hash.Class (HashAlgorithm)
 import           Cardano.Ledger.Core (EraCrypto)
 import qualified Cardano.Ledger.Core as Ledger
 import           Cardano.Ledger.Crypto (Crypto, StandardCrypto)
+import qualified Cardano.Ledger.Crypto as Ledger
 import           Cardano.Ledger.Shelley ()
 
 import           Control.Exception (bracket)
@@ -175,3 +179,25 @@ obtainEraPParamsConstraint ShelleyBasedEraAlonzo  f = f
 obtainEraPParamsConstraint ShelleyBasedEraBabbage f = f
 obtainEraPParamsConstraint ShelleyBasedEraConway  f = f
 
+obtainEraConstraints
+  :: ShelleyLedgerEra era ~ ledgerera
+  => ShelleyBasedEra era
+  -> ( (IsShelleyBasedEra era, Ledger.Era ledgerera) => a) -> a
+obtainEraConstraints ShelleyBasedEraShelley f = f
+obtainEraConstraints ShelleyBasedEraAllegra f = f
+obtainEraConstraints ShelleyBasedEraMary    f = f
+obtainEraConstraints ShelleyBasedEraAlonzo  f = f
+obtainEraConstraints ShelleyBasedEraBabbage f = f
+obtainEraConstraints ShelleyBasedEraConway  f = f
+
+
+obtainSafeToHashConstraint
+  :: ShelleyBasedEra era
+  -> (HashAlgorithm (Ledger.HASH (EraCrypto (ShelleyLedgerEra era))) => a)
+  -> a
+obtainSafeToHashConstraint ShelleyBasedEraShelley f = f
+obtainSafeToHashConstraint ShelleyBasedEraAllegra f = f
+obtainSafeToHashConstraint ShelleyBasedEraMary    f = f
+obtainSafeToHashConstraint ShelleyBasedEraAlonzo  f = f
+obtainSafeToHashConstraint ShelleyBasedEraBabbage f = f
+obtainSafeToHashConstraint ShelleyBasedEraConway  f = f

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -30,6 +30,7 @@ module Cardano.Api.Utils
   , bounded
 
     -- ** Constraint solvers
+  , obtainCertificateConstraints
   , obtainCryptoConstraints
   , obtainEraConstraints
   , obtainEraPParamsConstraint
@@ -45,6 +46,7 @@ import qualified Cardano.Ledger.Core as Ledger
 import           Cardano.Ledger.Crypto (Crypto, StandardCrypto)
 import qualified Cardano.Ledger.Crypto as Ledger
 import           Cardano.Ledger.Shelley ()
+import qualified Cardano.Ledger.Shelley.TxCert as Shelley
 
 import           Control.Exception (bracket)
 import           Control.Monad (when)
@@ -201,3 +203,16 @@ obtainSafeToHashConstraint ShelleyBasedEraMary    f = f
 obtainSafeToHashConstraint ShelleyBasedEraAlonzo  f = f
 obtainSafeToHashConstraint ShelleyBasedEraBabbage f = f
 obtainSafeToHashConstraint ShelleyBasedEraConway  f = f
+obtainCertificateConstraints
+
+  :: ShelleyBasedEra era
+  -> (( Shelley.ShelleyEraTxCert (ShelleyLedgerEra era)
+      , EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
+      ) => a)
+  -> a
+obtainCertificateConstraints ShelleyBasedEraShelley f = f
+obtainCertificateConstraints ShelleyBasedEraAllegra f = f
+obtainCertificateConstraints ShelleyBasedEraMary    f = f
+obtainCertificateConstraints ShelleyBasedEraAlonzo  f = f
+obtainCertificateConstraints ShelleyBasedEraBabbage f = f
+obtainCertificateConstraints ShelleyBasedEraConway  f = f

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -901,6 +901,8 @@ module Cardano.Api (
     -- ** Governance Committee
     makeCommitteeDelegationCertificate,
     makeCommitteeHotKeyUnregistrationCertificate,
+
+    ResolvablePointers(..),
   ) where
 
 import           Cardano.Api.Address

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -283,6 +283,8 @@ module Cardano.Api (
     CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
+    TxVotesSupportedInEra(..),
+    TxGovernanceActionSupportedInEra(..),
     FeatureInEra(..),
 
     -- ** Feature availability functions
@@ -300,6 +302,8 @@ module Cardano.Api (
     updateProposalSupportedInEra,
     scriptDataSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
+    votesSupportedInEra,
+    governanceActionsSupportedInEra,
 
     -- ** Era-dependent protocol features
     ProtocolUTxOCostPerByteFeature(..),

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -242,6 +242,7 @@ module Cardano.Api.Shelley
     Proposal(..),
     TxGovernanceActions(..),
     TxVotes(..),
+    Vote(..),
     GovernancePoll (..),
     GovernancePollAnswer (..),
     GovernancePollError (..),
@@ -253,6 +254,7 @@ module Cardano.Api.Shelley
     makeGoveranceActionIdentifier,
     renderGovernancePollError,
     toVotingCredential,
+    fromProposalProcedure,
     hashGovernancePoll,
     verifyPollAnswer,
 
@@ -267,6 +269,7 @@ module Cardano.Api.Shelley
     fromAlonzoCostModels,
     --TODO: arrange not to export these
     toShelleyNetwork,
+    obtainEraConstraints,
     obtainEraPParamsConstraint,
 
   ) where

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -246,7 +246,7 @@ test_ScriptExecutionError =
     , ("ScriptErrorExecutionUnitsOverflow", ScriptErrorExecutionUnitsOverflow)
     , ("ScriptErrorNotPlutusWitnessedTxIn", ScriptErrorNotPlutusWitnessedTxIn (ScriptWitnessIndexTxIn 0) scriptHash)
     , ("ScriptErrorRedeemerPointsToUnknownScriptHash", ScriptErrorRedeemerPointsToUnknownScriptHash (ScriptWitnessIndexTxIn 0))
-    , ("ScriptErrorMissingScript", ScriptErrorMissingScript (Ledger.RdmrPtr Ledger.Mint 0) Map.empty)
+    , ("ScriptErrorMissingScript", ScriptErrorMissingScript (Ledger.RdmrPtr Ledger.Mint 0) (ResolvablePointers ShelleyBasedEraBabbage Map.empty)) -- TODO CIP-1694 make work in all eras
     , ("ScriptErrorMissingCostModel", ScriptErrorMissingCostModel Alonzo.PlutusV2)
     ]
 

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Fees.ScriptExecutionError/ScriptErrorMissingScript.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Fees.ScriptExecutionError/ScriptErrorMissingScript.txt
@@ -1,2 +1,2 @@
 The redeemer pointer: RdmrPtr Mint 0 points to a Plutus script that does not exist.
-The pointers that can be resolved are: fromList []
+The pointers that can be resolved are: ResolvablePointers ShelleyBasedEraBabbage (fromList [])

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
@@ -30,13 +30,13 @@ prop_maxBound_CardanoMatchesShelley = property $ do
 
 prop_roundtrip_JSON_Shelley :: Property
 prop_roundtrip_JSON_Shelley = property $ do
-  anySbe <- forAll $ Gen.element @_ @AnyShelleyBasedEra [minBound..maxBound]
+  anySbe <- forAll $ Gen.element @_ @_ @AnyShelleyBasedEra [minBound..maxBound]
 
   H.tripping anySbe encode decode
 
 prop_roundtrip_JSON_Cardano :: Property
 prop_roundtrip_JSON_Cardano = property $ do
-  anyEra <- forAll $ Gen.element @_ @AnyCardanoEra [minBound..maxBound]
+  anyEra <- forAll $ Gen.element @_ @_ @AnyCardanoEra [minBound..maxBound]
 
   H.tripping anyEra encode decode
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
@@ -30,13 +30,13 @@ prop_maxBound_CardanoMatchesShelley = property $ do
 
 prop_roundtrip_JSON_Shelley :: Property
 prop_roundtrip_JSON_Shelley = property $ do
-  anySbe <- forAll $ Gen.element @_ @_ @AnyShelleyBasedEra [minBound..maxBound]
+  anySbe <- forAll $ Gen.element $ id @[AnyShelleyBasedEra] [minBound..maxBound]
 
   H.tripping anySbe encode decode
 
 prop_roundtrip_JSON_Cardano :: Property
 prop_roundtrip_JSON_Cardano = property $ do
-  anyEra <- forAll $ Gen.element @_ @_ @AnyCardanoEra [minBound..maxBound]
+  anyEra <- forAll $ Gen.element $ id @[AnyCardanoEra] [minBound..maxBound]
 
   H.tripping anyEra encode decode
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1687312611,
-        "narHash": "sha256-Tvq04QEK/Kkj977GM3p7KxGtOrl15ef2y6OagSS5gtM=",
+        "lastModified": 1688471493,
+        "narHash": "sha256-QeO03eNW5ZmgUS4ebSvygnWHAcSpRGz3e8UCS5Yb5i4=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "42e80e6600314053b7e0db2cb71725b9a1c8cdcf",
+        "rev": "892494f936926f63962d3066b4cfc4270a6bc12d",
         "type": "github"
       },
       "original": {
@@ -221,11 +221,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1685665664,
-        "narHash": "sha256-vqSkKMWkWMuFvxyoaYvmH2jmQkVwiEKkY/3tIOJNe2w=",
+        "lastModified": 1688516853,
+        "narHash": "sha256-BR7kmt/vblCHJUZyszWV2SDI786HmqBCZCnM37RfFd8=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "b0fc370d1ca399b582074a8fb614acd83ad49bc7",
+        "rev": "6aa31b7e500039788e62ee028fbc04d461424c02",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1685667105,
-        "narHash": "sha256-qSd7lR/HquT2Z3NjarC1TpNd9oIoyYeQH9H8Y+kHRnU=",
+        "lastModified": 1688518296,
+        "narHash": "sha256-8c6I2aRGg1mHVHHWj49sbcdbkxoXbL5d6fWcHsvwCw4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "995485b05f3ea898028ed4d497a4b7a2496302e5",
+        "rev": "0f0cbc1c42adc9dfa017ce5836abd87d652efdfb",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1685578319,
-        "narHash": "sha256-hUWMzqeG7286bKoB+KgUcXDUIcJAOwDsmgX2ZwOfXL4=",
+        "lastModified": 1688515874,
+        "narHash": "sha256-KG+rk/RcqJyRKGKBUjrTyRDjvpyrlQgW9tqBhwZzn8A=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "ddaad8445e3e80c877fd8e9877ff1495d5e7d3e8",
+        "rev": "faa8d0b836ca86e0e5f78c2cb77c0acc2dc1d585",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Propagate ledger's TxCert type family throughout the api 
  compatibility: breaking
  type: feature
```

# Context

Upgrade to `cardano-ledger-1.3` which introduced `TxCert era` and requires integration with `Certificate era`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
