### PR TITLE
Rename `era` to `sbe` when type is `ShelleyBasedEra`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -402,8 +402,8 @@ data AnyShelleyBasedEra where
 deriving instance Show AnyShelleyBasedEra
 
 instance Eq AnyShelleyBasedEra where
-    AnyShelleyBasedEra era == AnyShelleyBasedEra era' =
-      case testEquality era era' of
+    AnyShelleyBasedEra sbe == AnyShelleyBasedEra sbe' =
+      case testEquality sbe sbe' of
         Nothing   -> False
         Just Refl -> True -- since no constructors share types
 
@@ -435,7 +435,7 @@ instance Enum AnyShelleyBasedEra where
             <> " does not correspond to any known enumerated era."
 
 instance ToJSON AnyShelleyBasedEra where
-   toJSON (AnyShelleyBasedEra era) = toJSON era
+   toJSON (AnyShelleyBasedEra sbe) = toJSON sbe
 
 instance FromJSON AnyShelleyBasedEra where
    parseJSON = withText "AnyShelleyBasedEra"
@@ -534,14 +534,13 @@ type family CardanoLedgerEra era where
 -- | Lookup the lower major protocol version for the shelley based era. In other words
 -- this is the major protocol version that the era has started in.
 eraProtVerLow :: ShelleyBasedEra era -> L.Version
-eraProtVerLow era =
-  case era of
-    ShelleyBasedEraShelley -> L.eraProtVerLow @L.Shelley
-    ShelleyBasedEraAllegra -> L.eraProtVerLow @L.Allegra
-    ShelleyBasedEraMary    -> L.eraProtVerLow @L.Mary
-    ShelleyBasedEraAlonzo  -> L.eraProtVerLow @L.Alonzo
-    ShelleyBasedEraBabbage -> L.eraProtVerLow @L.Babbage
-    ShelleyBasedEraConway  -> L.eraProtVerLow @L.Conway
+eraProtVerLow = \case
+  ShelleyBasedEraShelley -> L.eraProtVerLow @L.Shelley
+  ShelleyBasedEraAllegra -> L.eraProtVerLow @L.Allegra
+  ShelleyBasedEraMary    -> L.eraProtVerLow @L.Mary
+  ShelleyBasedEraAlonzo  -> L.eraProtVerLow @L.Alonzo
+  ShelleyBasedEraBabbage -> L.eraProtVerLow @L.Babbage
+  ShelleyBasedEraConway  -> L.eraProtVerLow @L.Conway
 
 requireShelleyBasedEra :: ()
   => Applicative m

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -928,8 +928,8 @@ toLedgerUpdate :: forall era ledgerera.
                => ShelleyBasedEra era
                -> UpdateProposal
                -> Either ProtocolParametersConversionError (Ledger.Update ledgerera)
-toLedgerUpdate era (UpdateProposal ppup epochno) =
-  (`Ledger.Update` epochno) <$> toLedgerProposedPPUpdates era ppup
+toLedgerUpdate sbe (UpdateProposal ppup epochno) =
+  (`Ledger.Update` epochno) <$> toLedgerProposedPPUpdates sbe ppup
 
 
 toLedgerProposedPPUpdates :: forall era ledgerera.
@@ -938,8 +938,8 @@ toLedgerProposedPPUpdates :: forall era ledgerera.
                           => ShelleyBasedEra era
                           -> Map (Hash GenesisKey) ProtocolParametersUpdate
                           -> Either ProtocolParametersConversionError (Ledger.ProposedPPUpdates ledgerera)
-toLedgerProposedPPUpdates era m =
-  Ledger.ProposedPPUpdates . Map.mapKeysMonotonic (\(GenesisKeyHash kh) -> kh) <$> traverse (toLedgerPParamsUpdate era) m
+toLedgerProposedPPUpdates sbe m =
+  Ledger.ProposedPPUpdates . Map.mapKeysMonotonic (\(GenesisKeyHash kh) -> kh) <$> traverse (toLedgerPParamsUpdate sbe) m
 
 toLedgerPParamsUpdate :: ShelleyBasedEra era
                       -> ProtocolParametersUpdate
@@ -1120,8 +1120,8 @@ fromLedgerUpdate :: forall era ledgerera.
                  => ShelleyBasedEra era
                  -> Ledger.Update ledgerera
                  -> UpdateProposal
-fromLedgerUpdate era (Ledger.Update ppup epochno) =
-    UpdateProposal (fromLedgerProposedPPUpdates era ppup) epochno
+fromLedgerUpdate sbe (Ledger.Update ppup epochno) =
+    UpdateProposal (fromLedgerProposedPPUpdates sbe ppup) epochno
 
 
 fromLedgerProposedPPUpdates :: forall era ledgerera.
@@ -1130,8 +1130,8 @@ fromLedgerProposedPPUpdates :: forall era ledgerera.
                             => ShelleyBasedEra era
                             -> Ledger.ProposedPPUpdates ledgerera
                             -> Map (Hash GenesisKey) ProtocolParametersUpdate
-fromLedgerProposedPPUpdates era =
-    Map.map (fromLedgerPParamsUpdate era)
+fromLedgerProposedPPUpdates sbe =
+    Map.map (fromLedgerPParamsUpdate sbe)
   . Map.mapKeysMonotonic GenesisKeyHash
   . (\(Ledger.ProposedPPUpdates ppup) -> ppup)
 

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -1101,8 +1101,8 @@ toShelleyScript (ScriptInEra langInEra (PlutusScript PlutusScriptV3
 fromShelleyBasedScript  :: ShelleyBasedEra era
                         -> Ledger.Script (ShelleyLedgerEra era)
                         -> ScriptInEra era
-fromShelleyBasedScript era script =
-  case era of
+fromShelleyBasedScript sbe script =
+  case sbe of
     ShelleyBasedEraShelley ->
       ScriptInEra SimpleScriptInShelley
         . SimpleScript $ fromShelleyMultiSig script

--- a/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
@@ -198,7 +198,7 @@ deserialiseWitnessLedgerCddl
   :: ShelleyBasedEra era
   -> TextEnvelopeCddl
   -> Either TextEnvelopeCddlError (KeyWitness era)
-deserialiseWitnessLedgerCddl era TextEnvelopeCddl{teCddlRawCBOR,teCddlDescription} =
+deserialiseWitnessLedgerCddl sbe TextEnvelopeCddl{teCddlRawCBOR,teCddlDescription} =
   --TODO: Parse these into types because this will increase code readability and
   -- will make it easier to keep track of the different Cddl descriptions via
   -- a single sum data type.
@@ -206,13 +206,13 @@ deserialiseWitnessLedgerCddl era TextEnvelopeCddl{teCddlRawCBOR,teCddlDescriptio
     "Key BootstrapWitness ShelleyEra" -> do
       w <- first TextEnvelopeCddlErrCBORDecodingError
              $ CBOR.decodeFullAnnotator
-               (eraProtVerLow era) "Shelley Witness" CBOR.decCBOR (LBS.fromStrict teCddlRawCBOR)
-      Right $ ShelleyBootstrapWitness era w
+               (eraProtVerLow sbe) "Shelley Witness" CBOR.decCBOR (LBS.fromStrict teCddlRawCBOR)
+      Right $ ShelleyBootstrapWitness sbe w
     "Key Witness ShelleyEra" -> do
       w <- first TextEnvelopeCddlErrCBORDecodingError
              $ CBOR.decodeFullAnnotator
-               (eraProtVerLow era) "Shelley Witness" CBOR.decCBOR (LBS.fromStrict teCddlRawCBOR)
-      Right $ ShelleyKeyWitness era w
+               (eraProtVerLow sbe) "Shelley Witness" CBOR.decCBOR (LBS.fromStrict teCddlRawCBOR)
+      Right $ ShelleyKeyWitness sbe w
     _ -> Left TextEnvelopeCddlUnknownKeyWitness
 
 writeTxFileTextEnvelopeCddl


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Rename `era` to `sbe` when type is `ShelleyBasedEra`
  compatibility: no-api-changes
  type: maintenance
```

# Context

It can be confusing when `era` has the type `ShelleyBasedEra era` because it is also used for values of the type `CardanoEra era`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
