### PR TITLE
New version `cardano-api-8.9.0.0`

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog for cardano-api
 
+## 8.9.0.0
+
+- Expose more functionality from cardano-api
+  (feature; compatible)
+  [PR 130](https://github.com/input-output-hk/cardano-api/pull/130)
+
+- Rename `AtMostBabbageEra` to `ShelleyToBabbageEra` and add `FeatureInEra` instances to `ShelleyToBabbageEra` and `ConwayEraOnwards`.
+  (feature; breaking)
+  [PR 127](https://github.com/input-output-hk/cardano-api/pull/127)
+
+- Incorporate remaining conway certificate types into cardano-api
+  (feature; breaking)
+  [PR 119](https://github.com/input-output-hk/cardano-api/pull/119)
+
+- Wire up remaining Conway governance actions
+  (feature; compatible)
+  [PR 112](https://github.com/input-output-hk/cardano-api/pull/112)
+
+- Fix ghc version CPP
+  (bugfix; compatible)
+  [PR 123](https://github.com/input-output-hk/cardano-api/pull/123)
+
 ## 8.8.1.1
 
 - Add a HasTypeProxy constraint to getVerificationKey
@@ -20,6 +42,11 @@
   Use the ^>= version range operator for ledger and consensus libraries to avoid breaking changes affecting builds.
   (feature; compatible)
   [PR 108](https://github.com/input-output-hk/cardano-api/pull/108)
+
+- -  Update to the latest ledger and consensus
+  -  Introduce CommitteeKey
+  (feature; breaking)
+  [PR 99](https://github.com/input-output-hk/cardano-api/pull/99)
 
 ## 8.8.0.0
 

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-api
-version:                8.8.1.1
+version:                8.9.0.0
 synopsis:               The cardano api
 description:            The cardano api.
 category:               Cardano,


### PR DESCRIPTION
Do not merge until rebased an more meaningful changes are included.

# Changelog

```yaml
- description: |
    New version `cardano-api-8.9.0.0`
  compatibility: no-api-changes
  type: maintenance
```

# Context

New release for query constitution feature.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
