### PR TITLE
Fix changelog workflow failure when other PR paragraphs are removed

### DIFF
--- a/.github/workflows/check-pr-changelog.yml
+++ b/.github/workflows/check-pr-changelog.yml
@@ -31,15 +31,17 @@ jobs:
               pull_number: context.issue.number
             });
 
-            const changelogRegex = /# Changelog([\s\S]*?)(?=\n#[^#])/;
+            const changelogRegex = /# Changelog[\s\S]*?```yaml([\s\S]*?)```/;
             const changelogMatch = prDescription.data.body.match(changelogRegex);
-            const changelogContent = changelogMatch ? changelogMatch [1].trim() : '';
+            const yamlContent = changelogMatch ? changelogMatch[1].trim() : '';
+            yamlContent || console.error('Failed to find changelog YAML section in the "Changelog" paragraph');
 
-            const yamlRegex = /```yaml([\s\S]*?)```/;
-            const yamlMatch = changelogContent.match(yamlRegex);
-            const yamlContent = yamlMatch ? yamlMatch[1].trim() : '';
-
-            changelog = yaml.load(yamlContent)[0]
+            try {
+              changelog = yaml.load(yamlContent)[0];
+            } catch (e) {
+              console.error('Failed to parse YAML changelog as array:', yamlContent);
+              process.exit(1);
+            }
 
             let isCompatibilityValid = false;
             const validCompatibilityValues = ['no-api-changes', 'compatible', 'breaking'];


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix changelog workflow failure when other PR paragraphs are removed
  # no-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: compatible
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: maintenance

```
# Context

n/a

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.

