### PR TITLE
For `stylish-haskell`, skip files that contain `CPP`

### DIFF
--- a/.github/workflows/check-stylish-haskell.yml
+++ b/.github/workflows/check-stylish-haskell.yml
@@ -55,7 +55,11 @@ jobs:
 
         for x in $(git ls-tree --full-tree --name-only -r HEAD ${{ env.STYLISH_HASKELL_PATHS }}); do
           if [ "${x##*.}" == "hs" ]; then
-            stylish-haskell -i $x
+            if grep -qE '^#' $x; then
+              echo "$x contains CPP.  Skipping."
+            else
+              stylish-haskell -i $x
+            fi
           fi
         done
 
@@ -68,7 +72,11 @@ jobs:
         git fetch origin ${{ github.base_ref }} --unshallow
         for x in $(git diff --name-only origin/${{ github.base_ref }}..HEAD ${{ env.STYLISH_HASKELL_PATHS }}); do
           if [ "${x##*.}" == "hs" ]; then
-            stylish-haskell -i $x
+            if grep -qE '^#' $x; then
+              echo "$x contains CPP.  Skipping."
+            else
+              stylish-haskell -i $x
+            fi
           fi
         done
 

--- a/.github/workflows/check-stylish-haskell.yml
+++ b/.github/workflows/check-stylish-haskell.yml
@@ -27,7 +27,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2022-12-30"
+      CABAL_CACHE_VERSION: "2023-07-12"
 
       STYLISH_HASKELL_VERSION: "0.14.4.0"
 

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -22,7 +22,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2022-12-30"
+      CABAL_CACHE_VERSION: "2023-07-12"
 
     concurrency:
       group: >

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-06-30"
+      CABAL_CACHE_VERSION: "2023-07-12"
 
     concurrency:
       group: >

--- a/scripts/githooks/haskell-style-lint
+++ b/scripts/githooks/haskell-style-lint
@@ -4,12 +4,16 @@
 #
 # To set this script as your pre-commit hook, use the following command:
 #
-# ln -s $(git-root)/scripts/githooks/haskell-style-lint $(git-root)/.git/hooks/pre-commit
+# ln -s $(git-root)/scripts/githooks/haskell-style-lint $(git rev-parse --git-dir)/hooks/pre-commit
 #
 
 for x in $(git diff --staged --name-only --diff-filter=ACM | tr '\n' ' '); do
   if [ "${x##*.}" = "hs" ]; then
-    stylish-haskell -i "$x"
+    if grep -qE '^#' "$x"; then
+      echo "$x contains CPP.  Skipping."
+    else
+      stylish-haskell -i "$x"
+    fi
     # fail on linting issues
     hlint "$x"
   fi


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    For `stylish-haskell`, skip files that contain `CPP`
  compatibility: no-api-changes
  type: maintenance
```

# Context

`stylish-haskell` does not work on files that contain `CPP` and its use on such files can corrupt them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
