### PR TITLE
Release cardano-api 8.8.1.0, cardano-api-gen 8.1.1.0

### DIFF
--- a/cardano-api-gen/cardano-api-gen.cabal
+++ b/cardano-api-gen/cardano-api-gen.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-api-gen
-version:                8.1.0.2
+version:                8.1.1.0
 synopsis:               Generators for the cardano api
 description:            Generators for the cardano api.
 category:               Cardano,

--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog for cardano-api
 
+## 8.8.1.0
+
+- Make it build with ghc-9.6
+  (feature; no-api-changes)
+  [PR 104](https://github.com/input-output-hk/cardano-api/pull/104)
+
+- Fix Show and Eq instances for Proposal type
+  (bugfix; no-api-changes)
+  [PR 115](https://github.com/input-output-hk/cardano-api/pull/115)
+
+- Export `withShelleyBasedEraConstraintsForLedger`
+  Use the ^>= version range operator for ledger and consensus libraries to avoid breaking changes affecting builds.
+  (feature; compatible)
+  [PR 108](https://github.com/input-output-hk/cardano-api/pull/108)
+
 ## 8.8.0.0
 
 - Add CastVerificationKeyRole StakePoolKey StakeKey instance

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-api
-version:                8.8.0.0
+version:                8.8.1.0
 synopsis:               The cardano api
 description:            The cardano api.
 category:               Cardano,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release cardano-api 8.8.1.0, cardano-api-gen 8.1.1.0
  # no-api-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: <no-api-changes|compatible|breaking>
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: maintenance
```

# Context

n/a

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
