### PR TITLE
Fix ghc version CPP

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -747,26 +747,26 @@ genWitnesses era =
                           (genShelleyKeyWitness era)
       return $ bsWits ++ keyWits
 
-genVerificationKey ::
-#if __GLASGOW_HASKELL__ >= 902
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.6 complains if its not
--- present.
-    (Key keyrole, HasTypeProxy keyrole) =>
-#else
-    Key keyrole =>
+genVerificationKey :: ()
+#if MIN_VERSION_base(4,17,0)
+    -- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.6 complains if its not
+    -- present.
+    => HasTypeProxy keyrole
 #endif
-    AsType keyrole -> Gen (VerificationKey keyrole)
+    => Key keyrole
+    => AsType keyrole
+    -> Gen (VerificationKey keyrole)
 genVerificationKey roletoken = getVerificationKey <$> genSigningKey roletoken
 
-genVerificationKeyHash ::
-#if __GLASGOW_HASKELL__ >= 902
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.6 complains if its not
--- present.
-    (Key keyrole, HasTypeProxy keyrole) =>
-#else
-    Key keyrole =>
+genVerificationKeyHash :: ()
+#if MIN_VERSION_base(4,17,0)
+    -- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.6 complains if its not
+    -- present.
+    => HasTypeProxy keyrole
 #endif
-    AsType keyrole -> Gen (Hash keyrole)
+    => Key keyrole
+    => AsType keyrole
+    -> Gen (Hash keyrole)
 genVerificationKeyHash roletoken =
   verificationKeyHash <$> genVerificationKey roletoken
 

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -1104,8 +1104,9 @@ makeTransactionBodyAutoBalance systemstart history pparams poolids stakeDelegDep
                 returnCollateral = fromShelleyLovelace . Ledger.rationalToCoinViaFloor $ amt % 100
 
             case (txReturnCollateral, txTotalCollateral) of
-#if __GLASGOW_HASKELL__ < 902
--- For ghc-9.2, this pattern match is redundant, but ghc-8.10 will complain if its missing.
+#if MIN_VERSION_base(4,16,0)
+#else
+              -- For ghc-9.2, this pattern match is redundant, but ghc-8.10 will complain if its missing.
               (rc@TxReturnCollateral{}, tc@TxTotalCollateral{}) ->
                 (rc, tc)
 #endif

--- a/cardano-api/internal/Cardano/Api/Keys/Class.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Class.hs
@@ -45,14 +45,15 @@ class (Eq (VerificationKey keyrole),
     data SigningKey keyrole :: Type
 
     -- | Get the corresponding verification key from a signing key.
-    getVerificationKey ::
-#if __GLASGOW_HASKELL__ >= 902
--- GHC 8.10 considers this constraint redundant but ghc-9.6 complains if its not present.
--- More annoyingly, absence of this constraint does not manifest in this repo, but in
--- `cardano-cli` :facepalm:.
-        HasTypeProxy keyrole =>
+    getVerificationKey :: ()
+#if MIN_VERSION_base(4,17,0)
+        -- GHC 8.10 considers this constraint redundant but ghc-9.6 complains if its not present.
+        -- More annoyingly, absence of this constraint does not manifest in this repo, but in
+        -- `cardano-cli` :facepalm:.
+        => HasTypeProxy keyrole
 #endif
-        SigningKey keyrole -> VerificationKey keyrole
+        => SigningKey keyrole
+        -> VerificationKey keyrole
 
     -- | Generate a 'SigningKey' deterministically, given a 'Crypto.Seed'. The
     -- required size of the seed is given by 'deterministicSigningKeySeedSize'.

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Envelope.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Envelope.hs
@@ -90,15 +90,15 @@ prop_roundtrip_VrfSigningKey_envelope =
 
 -- -----------------------------------------------------------------------------
 
-roundtrip_VerificationKey_envelope ::
-#if __GLASGOW_HASKELL__ >= 902
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.2 and above complains if its
--- not present.
-    (Key keyrole, HasTypeProxy keyrole) =>
-#else
-    Key keyrole =>
+roundtrip_VerificationKey_envelope :: ()
+#if MIN_VERSION_base(4,17,0)
+    -- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.2 and above complains if its
+    -- not present.
+    => HasTypeProxy keyrole
 #endif
-    AsType keyrole -> Property
+    => Key keyrole
+    => AsType keyrole
+    -> Property
 roundtrip_VerificationKey_envelope roletoken =
   H.property $ do
     vkey <- H.forAll (genVerificationKey roletoken)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/RawBytes.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/RawBytes.hs
@@ -84,14 +84,16 @@ roundtrip_raw_bytes asType g =
     v <- H.forAll g
     H.tripping v serialiseToRawBytes (deserialiseFromRawBytes asType)
 
-roundtrip_verification_key_hash_raw
-#if __GLASGOW_HASKELL__ < 902
-  :: (Key keyrole, Eq (Hash keyrole), Show (Hash keyrole))
-#else
+roundtrip_verification_key_hash_raw :: ()
+#if MIN_VERSION_base(4,17,0)
   -- GHC 9.2 and above needs an extra constraint.
-  :: (Key keyrole, Eq (Hash keyrole), Show (Hash keyrole), HasTypeProxy keyrole)
+  => HasTypeProxy keyrole
 #endif
-  => AsType keyrole -> Property
+  => Key keyrole
+  => Eq (Hash keyrole)
+  => Show (Hash keyrole)
+  => AsType keyrole
+  -> Property
 roundtrip_verification_key_hash_raw roletoken =
   H.property $ do
     vKey <- H.forAll $ genVerificationKey roletoken


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix ghc version CPP
  compatibility: compatible
  type: bugfix
```

# Context

This is necessary to compile `cardano-cli` with `ghc-9.2.x`.

Moreover, `__GLASGOW_HASKELL__` seemed to be working unreliably for me, so it has been switched to use `MIN_VERSION_base` instead.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
