### PR TITLE
Rename `AtMostBabbageEra` to `ShelleyToBabbageEra`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -614,15 +614,15 @@ genStakeAddressRequirements :: ShelleyBasedEra era -> Gen (StakeAddressRequireme
 genStakeAddressRequirements sbe =
   case sbe of
     ShelleyBasedEraShelley ->
-      StakeAddrRegistrationPreConway AtMostBabbageEraShelley <$> genStakeCredential
+      StakeAddrRegistrationPreConway ShelleyToBabbageEraShelley <$> genStakeCredential
     ShelleyBasedEraAllegra ->
-      StakeAddrRegistrationPreConway AtMostBabbageEraAllegra <$> genStakeCredential
+      StakeAddrRegistrationPreConway ShelleyToBabbageEraAllegra <$> genStakeCredential
     ShelleyBasedEraMary ->
-      StakeAddrRegistrationPreConway AtMostBabbageEraMary <$> genStakeCredential
+      StakeAddrRegistrationPreConway ShelleyToBabbageEraMary <$> genStakeCredential
     ShelleyBasedEraAlonzo ->
-      StakeAddrRegistrationPreConway AtMostBabbageEraAlonzo <$> genStakeCredential
+      StakeAddrRegistrationPreConway ShelleyToBabbageEraAlonzo <$> genStakeCredential
     ShelleyBasedEraBabbage ->
-      StakeAddrRegistrationPreConway AtMostBabbageEraBabbage <$> genStakeCredential
+      StakeAddrRegistrationPreConway ShelleyToBabbageEraBabbage <$> genStakeCredential
     ShelleyBasedEraConway ->
       StakeAddrRegistrationConway ConwayEraOnwardsConway <$> genLovelace <*> genStakeCredential
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -898,7 +898,7 @@ module Cardano.Api (
     determineEraExpr,
 
     -- ** Conway related
-    AtMostBabbageEra(..),
+    ShelleyToBabbageEra(..),
     ConwayEraOnwards(..),
 
     -- ** DReps


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Rename `AtMostBabbageEra` to `ShelleyToBabbageEra` and add `FeatureInEra` instances to `ShelleyToBabbageEra` and `ConwayEraOnwards`.
  compatibility: breaking
  type: feature
```

# Context

The name `ShelleyToBabbageEra` more explicitly notes the absence of `Byron` and sets up the naming convention that allows for a starting era other than `Shelley`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
