### PR TITLE
Improved feature ergonomics

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -59,6 +59,8 @@ library internal
                         Cardano.Api.Eras
                         Cardano.Api.Error
                         Cardano.Api.Feature
+                        Cardano.Api.Feature.ConwayEraOnwards
+                        Cardano.Api.Feature.ShelleyToBabbageEra
                         Cardano.Api.Fees
                         Cardano.Api.Genesis
                         Cardano.Api.GenesisParameters

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -7,8 +7,11 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Test.Gen.Cardano.Api.Typed
-  ( genFeatureValueInEra
+  ( genFeaturedInEra
+  , genMaybeFeaturedInEra
 
   , genAddressByron
   , genAddressInEra
@@ -731,16 +734,25 @@ genTxBody era = do
     Left err -> fail (displayError err)
     Right txBody -> pure txBody
 
--- | Generate a 'FeatureValue' for the given 'CardanoEra' with the provided generator.
-genFeatureValueInEra :: ()
+-- | Generate a 'Featured' for the given 'CardanoEra' with the provided generator.
+genFeaturedInEra :: ()
+  => Alternative f
+  => feature era
+  -> f a
+  -> f (Featured feature era a)
+genFeaturedInEra witness gen =
+  Featured witness <$> gen
+
+-- | Generate a 'Featured' for the given 'CardanoEra' with the provided generator.
+genMaybeFeaturedInEra :: ()
   => FeatureInEra feature
   => Alternative f
   => f a
   -> CardanoEra era
-  -> f (FeatureValue feature era a)
-genFeatureValueInEra gen =
-  featureInEra (pure NoFeatureValue) $ \witness ->
-    pure NoFeatureValue <|> fmap (FeatureValue witness) gen
+  -> f (Maybe (Featured feature era a))
+genMaybeFeaturedInEra gen =
+  featureInEra (pure Nothing) $ \witness ->
+    pure Nothing <|> fmap Just (genFeaturedInEra witness gen)
 
 genTxScriptValidity :: CardanoEra era -> Gen (TxScriptValidity era)
 genTxScriptValidity era = case txScriptValiditySupportedInCardanoEra era of

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -122,7 +122,6 @@ import           Cardano.Api hiding (txIns)
 import qualified Cardano.Api as Api
 import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness),
                    WitnessNetworkIdOrByronAddress (..))
-import           Cardano.Api.Feature
 import           Cardano.Api.Script (scriptInEraToRefScript)
 import           Cardano.Api.Shelley (GovernancePoll (..), GovernancePollAnswer (..), Hash (..),
                    KESPeriod (KESPeriod),

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -66,10 +66,6 @@ module Cardano.Api.Certificate (
     -- * Data family instances
     AsType(..),
 
-    -- * GADTs for Conway/Shelley differences
-    ShelleyToBabbageEra(..),
-    ConwayEraOnwards(..),
-
     -- * Internal functions
     filterUnRegCreds,
     selectStakeCredential,
@@ -79,7 +75,8 @@ import           Cardano.Api.Address
 import           Cardano.Api.DRepMetadata
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
-import           Cardano.Api.Feature
+import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Governance.Actions.VotingProcedure
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Praos
@@ -315,42 +312,6 @@ data DRepMetadataReference =
 -- ----------------------------------------------------------------------------
 -- Constructor functions
 --
-
-data ConwayEraOnwards era where
-  ConwayEraOnwardsConway :: ConwayEraOnwards ConwayEra
-
-deriving instance Show (ConwayEraOnwards era)
-deriving instance Eq (ConwayEraOnwards era)
-
-instance FeatureInEra ConwayEraOnwards where
-  featureInEra no yes = \case
-    ByronEra    -> no
-    ShelleyEra  -> no
-    AllegraEra  -> no
-    MaryEra     -> no
-    AlonzoEra   -> no
-    BabbageEra  -> no
-    ConwayEra   -> yes ConwayEraOnwardsConway
-
-data ShelleyToBabbageEra era where
-  ShelleyToBabbageEraShelley :: ShelleyToBabbageEra ShelleyEra
-  ShelleyToBabbageEraAllegra :: ShelleyToBabbageEra AllegraEra
-  ShelleyToBabbageEraMary :: ShelleyToBabbageEra MaryEra
-  ShelleyToBabbageEraAlonzo :: ShelleyToBabbageEra AlonzoEra
-  ShelleyToBabbageEraBabbage :: ShelleyToBabbageEra BabbageEra
-
-deriving instance Show (ShelleyToBabbageEra era)
-deriving instance Eq (ShelleyToBabbageEra era)
-
-instance FeatureInEra ShelleyToBabbageEra where
-  featureInEra no yes = \case
-    ByronEra    -> no
-    ShelleyEra  -> yes ShelleyToBabbageEraShelley
-    AllegraEra  -> yes ShelleyToBabbageEraAllegra
-    MaryEra     -> yes ShelleyToBabbageEraMary
-    AlonzoEra   -> yes ShelleyToBabbageEraAlonzo
-    BabbageEra  -> yes ShelleyToBabbageEraBabbage
-    ConwayEra   -> no
 
 data StakeAddressRequirements era where
   StakeAddrRegistrationConway

--- a/cardano-api/internal/Cardano/Api/Feature.hs
+++ b/cardano-api/internal/Cardano/Api/Feature.hs
@@ -1,64 +1,46 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Cardano.Api.Feature
-  ( FeatureValue (..)
-  , valueOrDefault
-  , asFeatureValue
-  , asFeatureValueInShelleyBasedEra
-  , isFeatureValue
+  ( Featured (..)
+  , asFeaturedInEra
+  , asFeaturedInShelleyBasedEra
   ) where
 
 import           Cardano.Api.Eras
 
--- | A value of type @'FeatureValue' feature era a@ is either:
-data FeatureValue feature era a where
-  -- | A value is available for this feature in this era
-  FeatureValue
+-- | A value only if the feature is supported in this era
+data Featured feature era a where
+  Featured
     :: feature era
     -- ^ The witness that the feature is supported in this era
     -> a
     -- ^ The value to use
-    -> FeatureValue feature era a
+    -> Featured feature era a
 
-  -- | No value is available for this feature in this era
-  NoFeatureValue
-    :: FeatureValue feature era a
+deriving instance (Eq a, Eq (feature era)) => Eq (Featured feature era a)
+deriving instance (Show a, Show (feature era)) => Show (Featured feature era a)
 
-deriving instance (Eq a, Eq (feature era)) => Eq (FeatureValue feature era a)
-deriving instance (Show a, Show (feature era)) => Show (FeatureValue feature era a)
-
--- | Determine if a value is defined.
---
--- If the value is not defined, it could be because the feature is not supported or
--- because the feature is supported but the value is not available.
-isFeatureValue :: FeatureValue feature era a -> Bool
-isFeatureValue = \case
-  NoFeatureValue -> False
-  FeatureValue _ _ -> True
-
--- | Get the value if it is defined, otherwise return the default value.
-valueOrDefault :: a -> FeatureValue feature era a -> a
-valueOrDefault defaultValue = \case
-  NoFeatureValue -> defaultValue
-  FeatureValue _ a -> a
+instance Functor (Featured feature era) where
+  fmap f (Featured feature a) = Featured feature (f a)
 
 -- | Attempt to construct a 'FeatureValue' from a value and era.
 -- If the feature is not supported in the era, then 'NoFeatureValue' is returned.
-asFeatureValue :: ()
+asFeaturedInEra :: ()
   => FeatureInEra feature
   => a
   -> CardanoEra era
-  -> FeatureValue feature era a
-asFeatureValue value = featureInEra NoFeatureValue (`FeatureValue` value)
+  -> Maybe (Featured feature era a)
+asFeaturedInEra value = featureInEra Nothing (Just . flip Featured value)
 
 -- | Attempt to construct a 'FeatureValue' from a value and a shelley-based-era.
-asFeatureValueInShelleyBasedEra :: ()
+asFeaturedInShelleyBasedEra :: ()
   => FeatureInEra feature
   => a
   -> ShelleyBasedEra era
-  -> FeatureValue feature era a
-asFeatureValueInShelleyBasedEra value = asFeatureValue value . shelleyBasedToCardanoEra
+  -> Maybe (Featured feature era a)
+asFeaturedInShelleyBasedEra value = asFeaturedInEra value . shelleyBasedToCardanoEra

--- a/cardano-api/internal/Cardano/Api/Feature.hs
+++ b/cardano-api/internal/Cardano/Api/Feature.hs
@@ -6,8 +6,6 @@
 
 module Cardano.Api.Feature
   ( FeatureValue (..)
-  , FeatureInEra(..)
-  , featureInShelleyBasedEra
   , valueOrDefault
   , asFeatureValue
   , asFeatureValueInShelleyBasedEra
@@ -15,38 +13,6 @@ module Cardano.Api.Feature
   ) where
 
 import           Cardano.Api.Eras
-
-import           Data.Kind
-
--- | A class for features that are supported in some eras but not others.
-class FeatureInEra (feature :: Type -> Type) where
-  -- | Determine the value to use for a feature in a given 'CardanoEra'.
-  -- Note that the negative case is the first argument, and the positive case is the second as per
-  -- the 'either' function convention.
-  featureInEra :: ()
-    => a                    -- ^ Value to use if the feature is not supported in the era
-    -> (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
-    -> CardanoEra era       -- ^ Era to check
-    -> a                    -- ^ The value to use
-
-instance FeatureInEra ShelleyBasedEra where
-  featureInEra no yes = \case
-    ByronEra    -> no
-    ShelleyEra  -> yes ShelleyBasedEraShelley
-    AllegraEra  -> yes ShelleyBasedEraAllegra
-    MaryEra     -> yes ShelleyBasedEraMary
-    AlonzoEra   -> yes ShelleyBasedEraAlonzo
-    BabbageEra  -> yes ShelleyBasedEraBabbage
-    ConwayEra   -> yes ShelleyBasedEraConway
-
--- | Determine the value to use for a feature in a given 'ShelleyBasedEra'.
-featureInShelleyBasedEra :: ()
-  => FeatureInEra feature
-  => a
-  -> (feature era -> a)
-  -> ShelleyBasedEra era
-  -> a
-featureInShelleyBasedEra no yes = featureInEra no yes . shelleyBasedToCardanoEra
 
 -- | A value of type @'FeatureValue' feature era a@ is either:
 data FeatureValue feature era a where

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -11,7 +11,6 @@ module Cardano.Api.Feature.ConwayEraOnwards
   ) where
 
 import           Cardano.Api.Eras
-import           Cardano.Api.Feature
 
 data ConwayEraOnwards era where
   ConwayEraOnwardsConway :: ConwayEraOnwards ConwayEra

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Feature.ConwayEraOnwards
+  ( ConwayEraOnwards(..)
+  ) where
+
+import           Cardano.Api.Eras
+import           Cardano.Api.Feature
+
+data ConwayEraOnwards era where
+  ConwayEraOnwardsConway :: ConwayEraOnwards ConwayEra
+
+deriving instance Show (ConwayEraOnwards era)
+deriving instance Eq (ConwayEraOnwards era)
+
+instance FeatureInEra ConwayEraOnwards where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> yes ConwayEraOnwardsConway

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Feature.ShelleyToBabbageEra
+  ( ShelleyToBabbageEra(..)
+  ) where
+
+import           Cardano.Api.Eras
+import           Cardano.Api.Feature
+
+data ShelleyToBabbageEra era where
+  ShelleyToBabbageEraShelley :: ShelleyToBabbageEra ShelleyEra
+  ShelleyToBabbageEraAllegra :: ShelleyToBabbageEra AllegraEra
+  ShelleyToBabbageEraMary :: ShelleyToBabbageEra MaryEra
+  ShelleyToBabbageEraAlonzo :: ShelleyToBabbageEra AlonzoEra
+  ShelleyToBabbageEraBabbage :: ShelleyToBabbageEra BabbageEra
+
+deriving instance Show (ShelleyToBabbageEra era)
+deriving instance Eq (ShelleyToBabbageEra era)
+
+instance FeatureInEra ShelleyToBabbageEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToBabbageEraShelley
+    AllegraEra  -> yes ShelleyToBabbageEraAllegra
+    MaryEra     -> yes ShelleyToBabbageEraMary
+    AlonzoEra   -> yes ShelleyToBabbageEraAlonzo
+    BabbageEra  -> yes ShelleyToBabbageEraBabbage
+    ConwayEra   -> no

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -11,7 +11,6 @@ module Cardano.Api.Feature.ShelleyToBabbageEra
   ) where
 
 import           Cardano.Api.Eras
-import           Cardano.Api.Feature
 
 data ShelleyToBabbageEra era where
   ShelleyToBabbageEraShelley :: ShelleyToBabbageEra ShelleyEra

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -5,12 +5,19 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Api.Feature.ShelleyToBabbageEra
   ( ShelleyToBabbageEra(..)
+  , shelleyToBabbageEraConstraints
+  , shelleyToBabbageEraToCardanoEra
+  , shelleyToBabbageEraToShelleyBasedEra
   ) where
 
 import           Cardano.Api.Eras
+
+import           Cardano.Crypto.Hash.Class (HashAlgorithm)
+import qualified Cardano.Ledger.Api as L
 
 data ShelleyToBabbageEra era where
   ShelleyToBabbageEraShelley :: ShelleyToBabbageEra ShelleyEra
@@ -31,3 +38,30 @@ instance FeatureInEra ShelleyToBabbageEra where
     AlonzoEra   -> yes ShelleyToBabbageEraAlonzo
     BabbageEra  -> yes ShelleyToBabbageEraBabbage
     ConwayEra   -> no
+
+type ShelleyToBabbageEraConstraints era =
+  ( L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  )
+
+shelleyToBabbageEraConstraints
+  :: ShelleyToBabbageEra era
+  -> (ShelleyToBabbageEraConstraints era => a)
+  -> a
+shelleyToBabbageEraConstraints = \case
+  ShelleyToBabbageEraShelley -> id
+  ShelleyToBabbageEraAllegra -> id
+  ShelleyToBabbageEraMary    -> id
+  ShelleyToBabbageEraAlonzo  -> id
+  ShelleyToBabbageEraBabbage -> id
+
+shelleyToBabbageEraToCardanoEra :: ShelleyToBabbageEra era -> CardanoEra era
+shelleyToBabbageEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToBabbageEraToShelleyBasedEra
+
+shelleyToBabbageEraToShelleyBasedEra :: ShelleyToBabbageEra era -> ShelleyBasedEra era
+shelleyToBabbageEraToShelleyBasedEra = \case
+  ShelleyToBabbageEraShelley -> ShelleyBasedEraShelley
+  ShelleyToBabbageEraAllegra -> ShelleyBasedEraAllegra
+  ShelleyToBabbageEraMary    -> ShelleyBasedEraMary
+  ShelleyToBabbageEraAlonzo  -> ShelleyBasedEraAlonzo
+  ShelleyToBabbageEraBabbage -> ShelleyBasedEraBabbage

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -82,7 +82,6 @@ module Cardano.Api.ProtocolParameters (
 import           Cardano.Api.Address
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
-import           Cardano.Api.Feature
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Json (toRationalJSON)

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -28,9 +28,11 @@ module Cardano.Api (
 
     -- * Feature support
     FeatureInEra(..),
-    FeatureValue(..),
     maybeFeatureInEra,
     featureInShelleyBasedEra,
+    Featured(..),
+    asFeaturedInEra,
+    asFeaturedInShelleyBasedEra,
 
     -- * Features
     ShelleyToBabbageEra(..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -26,6 +26,16 @@ module Cardano.Api (
     cardanoEraConstraints,
     InAnyCardanoEra(..),
 
+    -- * Feature support
+    FeatureInEra(..),
+    FeatureValue(..),
+    maybeFeatureInEra,
+    featureInShelleyBasedEra,
+
+    -- * Features
+    ShelleyToBabbageEra(..),
+    ConwayEraOnwards(..),
+
     -- ** Shelley-based eras
     ShelleyBasedEra(..),
     IsShelleyBasedEra(..),
@@ -268,10 +278,6 @@ module Cardano.Api (
     BuildTx,
     ViewTx,
 
-    -- ** Era-based transaction body features
-    ShelleyToBabbageEra(..),
-    ConwayEraOnwards(..),
-
     -- ** Era-dependent transaction body features
     CollateralSupportedInEra(..),
     MultiAssetSupportedInEra(..),
@@ -291,7 +297,6 @@ module Cardano.Api (
     TxTotalAndReturnCollateralSupportedInEra(..),
     TxVotesSupportedInEra(..),
     TxGovernanceActionSupportedInEra(..),
-    FeatureInEra(..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -268,6 +268,10 @@ module Cardano.Api (
     BuildTx,
     ViewTx,
 
+    -- ** Era-based transaction body features
+    ShelleyToBabbageEra(..),
+    ConwayEraOnwards(..),
+
     -- ** Era-dependent transaction body features
     CollateralSupportedInEra(..),
     MultiAssetSupportedInEra(..),
@@ -903,10 +907,6 @@ module Cardano.Api (
     queryUtxo,
     determineEraExpr,
 
-    -- ** Conway related
-    ShelleyToBabbageEra(..),
-    ConwayEraOnwards(..),
-
     -- ** DReps
     DRepKey,
     DRepMetadata,
@@ -939,6 +939,8 @@ import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
+import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -36,7 +36,13 @@ module Cardano.Api (
 
     -- * Features
     ShelleyToBabbageEra(..),
+    shelleyToBabbageEraConstraints,
+    shelleyToBabbageEraToCardanoEra,
+    shelleyToBabbageEraToShelleyBasedEra,
     ConwayEraOnwards(..),
+    conwayEraOnwardsConstraints,
+    conwayEraOnwardsToCardanoEra,
+    conwayEraOnwardsToShelleyBasedEra,
 
     -- ** Shelley-based eras
     ShelleyBasedEra(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Improved feature ergonomics
    New:
    - `Featured`
    - `asFeaturedInEra`
    - `asFeaturedInShelleyBasedEra`
    - `genFeaturedInEra`
    - `genMaybeFeaturedInEra`
    - `conwayEraOnwardsToCardanoEra`
    - `conwayEraOnwardsToCardanoEra`
    - `conwayEraOnwardsToShelleyBasedEra`
    - `shelleyToBabbageEraConstraints`
    - `shelleyToBabbageEraToCardanoEra`
    - `shelleyToBabbageEraToShelleyBasedEra`
    Deprecated:
    - `FeatureValue` Use `Maybe Featured` instead
    - `isFeatureValue`
    - `valueOrDefault`
    - `asFeatureValue`
    - `asFeatureValueInShelleyBasedEra`
  compatibility: breaking
  type: feature
```

# Context

Note, the following is an example only.  We do not have to do the described refactoring until we need it.

Currently we define era-sensitive features like this:

```
data CollateralSupportedInEra era where

     CollateralInAlonzoEra  :: CollateralSupportedInEra AlonzoEra
     CollateralInBabbageEra :: CollateralSupportedInEra BabbageEra
     CollateralInConwayEra  :: CollateralSupportedInEra ConwayEra

deriving instance Eq   (CollateralSupportedInEra era)
deriving instance Show (CollateralSupportedInEra era)

collateralSupportedInEra :: CardanoEra era
                         -> Maybe (CollateralSupportedInEra era)
collateralSupportedInEra ByronEra   = Nothing
collateralSupportedInEra ShelleyEra = Nothing
collateralSupportedInEra AllegraEra = Nothing
collateralSupportedInEra MaryEra    = Nothing
collateralSupportedInEra AlonzoEra  = Just CollateralInAlonzoEra
collateralSupportedInEra BabbageEra = Just CollateralInBabbageEra
collateralSupportedInEra ConwayEra = Just CollateralInConwayEra
```

And then separately define era-sensitive values like this:

```
data TxInsCollateral era where

     TxInsCollateralNone :: TxInsCollateral era

     TxInsCollateral     :: CollateralSupportedInEra era
                         -> [TxIn] -- Only key witnesses, no scripts.
                         -> TxInsCollateral era

deriving instance Eq   (TxInsCollateral era)
deriving instance Show (TxInsCollateral era)
```

The `TxInsCollateral` can only be used with the witness `CollateralSupportedInEra era` which can only be constructed within certain eras.

This PR proposes to define  like this instead:

```
data CollateralSupportedInEra era where

     CollateralInAlonzoEra  :: CollateralSupportedInEra AlonzoEra
     CollateralInBabbageEra :: CollateralSupportedInEra BabbageEra
     CollateralInConwayEra  :: CollateralSupportedInEra ConwayEra

deriving instance Eq   (CollateralSupportedInEra era)
deriving instance Show (CollateralSupportedInEra era)

collateralSupportedInEra :: CardanoEra era
                         -> Maybe (CollateralSupportedInEra era)
collateralSupportedInEra ByronEra   = Nothing
collateralSupportedInEra ShelleyEra = Nothing
collateralSupportedInEra AllegraEra = Nothing
collateralSupportedInEra MaryEra    = Nothing
collateralSupportedInEra AlonzoEra  = Just CollateralInAlonzoEra
collateralSupportedInEra BabbageEra = Just CollateralInBabbageEra
collateralSupportedInEra ConwayEra = Just CollateralInConwayEra
```

Then the definitions of `data TxInsCollateral era` is unnecessary.  Once could just use `Maybe (Featured CollateralSupportedInEra era [TxIn]`.  Just like `TxInsCollateral` the value can be absent, but using `Nothing` instead of `TxInsCollateralNone`.

`Featured CollateralSupportedInEra era [TxIn]` is better than `data TxInsCollateral era` in that the former can express that the value is required, which also forces the era to be one that the era supports.  This will be useful in defining `run` commands where the arguments are required which currently cannot be done without defining additional types.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
