### PR TITLE
Tighten era bounds of Conway specific API to `ConwayEraOnwards`

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -285,7 +285,6 @@ module Cardano.Api (
     TxCertificates(..),
     TxUpdateProposal(..),
     TxMintValue(..),
-    TxVotes(..),
     TxGovernanceActions(..),
 
     -- ** Building vs viewing transactions
@@ -310,7 +309,6 @@ module Cardano.Api (
     CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
-    TxVotesSupportedInEra(..),
     TxGovernanceActionSupportedInEra(..),
 
     -- ** Feature availability functions
@@ -328,7 +326,6 @@ module Cardano.Api (
     updateProposalSupportedInEra,
     scriptDataSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
-    votesSupportedInEra,
     governanceActionsSupportedInEra,
 
     -- ** Era-dependent protocol features
@@ -965,7 +962,6 @@ import           Cardano.Api.Fees
 import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters
 import           Cardano.Api.Governance.Actions.ProposalProcedure
-import           Cardano.Api.Governance.Actions.VotingProcedure
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.InMode

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -242,7 +242,6 @@ module Cardano.Api.Shelley
     GovernanceActionId(..),
     Proposal(..),
     TxGovernanceActions(..),
-    TxVotes(..),
     VotingProcedure(..),
     GovernancePoll(..),
     GovernancePollAnswer(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Constraint the following functions to `ConwayEraOnwards`:
    - createProposalProcedure
    - createVotingProcedure
    - eraDecodeVotingCredential
    - fromGovernanceAction
    - fromProposalProcedure
    - makeGoveranceActionId
    - toGovernanceAction
    - toVoterRole
    - toVotingCredential
  type:
    - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - documentation  # change in code docs, haddocks...
 ```

# Context

Those functions and data types were constrained to `ShelleyBasedEra` previously, but that's too lose for something that's applicable to only Conway onwards.

Those functions are now constrained to `ConwayEraOnwards` instead.

Constraining to `ConwayEraOnwards` tightly allows the CLI parser to integrate with it in a type-safe way.  This type-safety is what controls the visibility of CLI commands and options based on whether the era is Conway onwards.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
