### PR TITLE
Add missing changelog entry for cardano-api-gen

### DIFF
--- a/cardano-api-gen/CHANGELOG.md
+++ b/cardano-api-gen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for cardano-api-gen
 
+## 8.1.1.1
+
+- Add a `HasTypeProxy` constraint to `getVerificationKey`
+  (bugfix; compatible)
+  [PR 122](https://github.com/input-output-hk/cardano-api/pull/122)
+
 ## 8.1.0.2
 
 First usable version.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add missing changelog entry for `cardano-api-gen-8.1.1.1`
  compatibility: no-api-changes
  type: maintenance
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
