### PR TITLE
Support more constraints for Conway witnesses

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -93,6 +93,7 @@ library internal
                         Cardano.Api.ProtocolParameters
                         Cardano.Api.Query
                         Cardano.Api.Query.Expr
+                        Cardano.Api.Query.Types
                         Cardano.Api.ReexposeLedger
                         Cardano.Api.Script
                         Cardano.Api.ScriptData

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -15,9 +15,13 @@ module Cardano.Api.Feature.ConwayEraOnwards
   ) where
 
 import           Cardano.Api.Eras
+import           Cardano.Api.Query.Types
 
+import           Cardano.Binary
 import           Cardano.Crypto.Hash.Class (HashAlgorithm)
 import qualified Cardano.Ledger.Api as L
+
+import           Data.Aeson
 
 data ConwayEraOnwards era where
   ConwayEraOnwardsConway :: ConwayEraOnwards ConwayEra
@@ -36,9 +40,13 @@ instance FeatureInEra ConwayEraOnwards where
     ConwayEra   -> yes ConwayEraOnwardsConway
 
 type ConwayEraOnwardsConstraints era =
-  ( L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  ( FromCBOR (DebugLedgerState era)
   , HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , IsShelleyBasedEra era
   , L.ConwayEraTxBody (ShelleyLedgerEra era)
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , ToJSON (DebugLedgerState era)
   )
 
 conwayEraOnwardsConstraints

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -9,6 +9,7 @@
 
 module Cardano.Api.Feature.ConwayEraOnwards
   ( ConwayEraOnwards(..)
+  , AnyConwayEraOnwards(..)
   , conwayEraOnwardsConstraints
   , conwayEraOnwardsToCardanoEra
   , conwayEraOnwardsToShelleyBasedEra
@@ -38,6 +39,11 @@ instance FeatureInEra ConwayEraOnwards where
     AlonzoEra   -> no
     BabbageEra  -> no
     ConwayEra   -> yes ConwayEraOnwardsConway
+
+data AnyConwayEraOnwards where
+  AnyConwayEraOnwards :: ConwayEraOnwards era -> AnyConwayEraOnwards
+
+deriving instance Show AnyConwayEraOnwards
 
 type ConwayEraOnwardsConstraints era =
   ( FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -9,6 +9,7 @@
 
 module Cardano.Api.Feature.ShelleyToBabbageEra
   ( ShelleyToBabbageEra(..)
+  , AnyShelleyToBabbageEra(..)
   , shelleyToBabbageEraConstraints
   , shelleyToBabbageEraToCardanoEra
   , shelleyToBabbageEraToShelleyBasedEra
@@ -51,6 +52,11 @@ type ShelleyToBabbageEraConstraints era =
   , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
   , ToJSON (DebugLedgerState era)
   )
+
+data AnyShelleyToBabbageEra where
+  AnyShelleyToBabbageEra :: ShelleyToBabbageEra era -> AnyShelleyToBabbageEra
+
+deriving instance Show AnyShelleyToBabbageEra
 
 shelleyToBabbageEraConstraints
   :: ShelleyToBabbageEra era

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -15,9 +15,13 @@ module Cardano.Api.Feature.ShelleyToBabbageEra
   ) where
 
 import           Cardano.Api.Eras
+import           Cardano.Api.Query.Types
 
+import           Cardano.Binary
 import           Cardano.Crypto.Hash.Class (HashAlgorithm)
 import qualified Cardano.Ledger.Api as L
+
+import           Data.Aeson
 
 data ShelleyToBabbageEra era where
   ShelleyToBabbageEraShelley :: ShelleyToBabbageEra ShelleyEra
@@ -40,8 +44,12 @@ instance FeatureInEra ShelleyToBabbageEra where
     ConwayEra   -> no
 
 type ShelleyToBabbageEraConstraints era =
-  ( L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  ( FromCBOR (DebugLedgerState era)
   , HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , IsShelleyBasedEra era
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , ToJSON (DebugLedgerState era)
   )
 
 shelleyToBabbageEraConstraints

--- a/cardano-api/internal/Cardano/Api/Query/Types.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Types.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Api.Query.Types
+  ( DebugLedgerState(..)
+  , toDebugLedgerStatePair
+  ) where
+
+import           Cardano.Api.Eras
+
+import           Cardano.Binary
+import           Cardano.Ledger.Binary
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import qualified Cardano.Ledger.Shelley.API as Shelley
+import qualified Cardano.Ledger.Shelley.Core as Core
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
+import qualified Ouroboros.Consensus.Cardano.Block as Consensus
+
+import           Data.Aeson (ToJSON (..), object, (.=))
+import qualified Data.Aeson as Aeson
+import           Data.Typeable
+
+data DebugLedgerState era where
+  DebugLedgerState ::
+    ( ShelleyLedgerEra era ~ ledgerera
+    )
+    => Shelley.NewEpochState ledgerera
+    -> DebugLedgerState era
+
+instance
+    ( Typeable era
+    , Core.EraTxOut (ShelleyLedgerEra era)
+    , Core.EraGovernance (ShelleyLedgerEra era)
+    , DecCBOR (Shelley.StashedAVVMAddresses (ShelleyLedgerEra era))
+    ) => FromCBOR (DebugLedgerState era) where
+  fromCBOR = DebugLedgerState <$>
+    (fromCBOR :: Plain.Decoder s (Shelley.NewEpochState (ShelleyLedgerEra era)))
+
+-- TODO: Shelley based era class!
+instance ( IsShelleyBasedEra era
+         , ShelleyLedgerEra era ~ ledgerera
+         , Consensus.ShelleyBasedEra ledgerera
+         ) => ToJSON (DebugLedgerState era) where
+  toJSON = object . toDebugLedgerStatePair
+  toEncoding = Aeson.pairs . mconcat . toDebugLedgerStatePair
+
+toDebugLedgerStatePair ::
+  ( ShelleyLedgerEra era ~ ledgerera
+  , Consensus.ShelleyBasedEra ledgerera
+  , Aeson.KeyValue a
+  ) => DebugLedgerState era -> [a]
+toDebugLedgerStatePair (DebugLedgerState newEpochS) =
+    let !nesEL = Shelley.nesEL newEpochS
+        !nesBprev = Shelley.nesBprev newEpochS
+        !nesBcur = Shelley.nesBcur newEpochS
+        !nesEs = Shelley.nesEs newEpochS
+        !nesRu = Shelley.nesRu newEpochS
+        !nesPd = Shelley.nesPd newEpochS
+    in  [ "lastEpoch" .= nesEL
+        , "blocksBefore" .= nesBprev
+        , "blocksCurrent" .= nesBcur
+        , "stateBefore" .= nesEs
+        , "possibleRewardUpdate" .= nesRu
+        , "stakeDistrib" .= nesPd
+        ]

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -36,10 +36,12 @@ module Cardano.Api (
 
     -- * Features
     ShelleyToBabbageEra(..),
+    AnyShelleyToBabbageEra(..),
     shelleyToBabbageEraConstraints,
     shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
     ConwayEraOnwards(..),
+    AnyConwayEraOnwards(..),
     conwayEraOnwardsConstraints,
     conwayEraOnwardsToCardanoEra,
     conwayEraOnwardsToShelleyBasedEra,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Support more constraints for Conway witnesses
    - `conwayEraOnwardsConstraints`
    - `shelleyToBabbageEraConstraints`
    New types:
    - AnyConwayEraOnwards
    - AnyShelleyToBabbageEra
  compatibility: compatible
  type: feature
```

# Context

The `Cardano.Api.Query.Types` module was introduce to break cyclic module dependency.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
