### PR TITLE
Revert and test `writeLazyByteStringFileWithOwnerPermissions`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -268,7 +268,9 @@ test-suite cardano-api-test
                       , cardano-ledger-api >= 1.3
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.4
                       , containers
+                      , directory
                       , hedgehog >= 1.1
+                      , hedgehog-extras
                       , hedgehog-quickcheck
                       , mtl
                       , QuickCheck
@@ -278,6 +280,7 @@ test-suite cardano-api-test
 
   other-modules:        Test.Cardano.Api.Crypto
                         Test.Cardano.Api.Eras
+                        Test.Cardano.Api.IO
                         Test.Cardano.Api.Json
                         Test.Cardano.Api.KeysByron
                         Test.Cardano.Api.Ledger

--- a/cardano-api/internal/Cardano/Api/IO/Compat/Posix.hs
+++ b/cardano-api/internal/Cardano/Api/IO/Compat/Posix.hs
@@ -17,29 +17,24 @@ module Cardano.Api.IO.Compat.Posix
 
 #ifdef UNIX
 
-import           Cardano.Api.Error (FileError (..), fileIOExceptT)
+import           Cardano.Api.Error (FileError (..))
 import           Cardano.Api.IO.Base
 
 import           Control.Exception (IOException, bracket, bracketOnError, try)
 import           Control.Monad (forM_, when)
 import           Control.Monad.Except (ExceptT, runExceptT)
 import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Except.Extra (left)
+import           Control.Monad.Trans.Except.Extra (handleIOExceptT, left)
 import qualified Data.ByteString as BS
 import           System.Directory ()
 import           System.FilePath ((</>))
 import qualified System.IO as IO
 import           System.IO (Handle)
 import           System.Posix.Files (fileMode, getFileStatus, groupModes, intersectFileModes,
-                   nullFileMode, otherModes, ownerReadMode, setFdOwnerAndGroup, setFileMode,
-                   stdFileMode)
-# if MIN_VERSION_unix(2,8,0)
-import           System.Posix.IO (OpenFileFlags (..), OpenMode (..), closeFd, defaultFileFlags,
-                   fdToHandle, openFd)
-#else
+                   nullFileMode, otherModes, ownerModes, ownerReadMode, setFdOwnerAndGroup,
+                   setFileMode)
 import           System.Posix.IO (OpenMode (..), closeFd, defaultFileFlags, fdToHandle, openFd)
-#endif
-import           System.Posix.Types (Fd, FileMode)
+import           System.Posix.Types (FileMode)
 import           System.Posix.User (getRealUserID)
 import           Text.Printf (printf)
 
@@ -57,7 +52,7 @@ handleFileForWritingWithOwnerPermissionImpl path f = do
     -- it will be immediately turned into a Handle (which will be closed when
     -- the Handle is closed)
     bracketOnError
-      (openFileDescriptor path WriteOnly)
+      (openFd path WriteOnly (Just ownerModes) defaultFileFlags)
       closeFd
       (\fd -> setFdOwnerAndGroup fd user (-1) >> pure fd)
   case ownedFile of
@@ -67,7 +62,7 @@ handleFileForWritingWithOwnerPermissionImpl path f = do
       bracket
         (fdToHandle fd)
         IO.hClose
-        (runExceptT . fileIOExceptT path . const . f)
+        (runExceptT . handleIOExceptT (FileIOError path) . f)
 
 writeSecretsImpl :: FilePath -> [Char] -> [Char] -> (a -> BS.ByteString) -> [a] -> IO ()
 writeSecretsImpl outDir prefix suffix secretOp xs =
@@ -99,38 +94,4 @@ checkVrfFilePermissionsImpl (File vrfPrivKey) = do
   hasGroupPermissions :: FileMode -> Bool
   hasGroupPermissions fm' = fm' `hasPermission` groupModes
 
--- | Opens a file from disk.
-openFileDescriptor :: FilePath -> OpenMode -> IO Fd
-# if MIN_VERSION_unix(2,8,0)
-openFileDescriptor fp openMode =
-    openFd fp openMode fileFlags
-  where
-    fileFlags =
-      case openMode of
-        ReadOnly ->
-          defaultFileFlags
-        ReadWrite ->
-          defaultFileFlags { creat = Just stdFileMode }
-        WriteOnly ->
-          defaultFileFlags { creat = Just stdFileMode }
-
-# else
-openFileDescriptor fp openMode =
-    openFd fp openMode fMode fileFlags
-  where
-    (fMode, fileFlags) =
-      case openMode of
-        ReadOnly ->
-          ( Nothing
-          , defaultFileFlags
-          )
-        ReadWrite ->
-          ( Just stdFileMode
-          , defaultFileFlags
-          )
-        WriteOnly ->
-          ( Just stdFileMode
-          , defaultFileFlags
-          )
-# endif
 #endif

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Api.IO
+  ( tests
+  ) where
+
+import           Cardano.Api
+import           Cardano.Api.IO
+
+import           Control.Monad.Except
+import           System.Directory (removeFile)
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+import           Hedgehog.Internal.Property
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog
+
+prop_createVrfFileWithOwnerPermissions :: Property
+prop_createVrfFileWithOwnerPermissions =
+  H.propertyOnce . H.moduleWorkspace "help" $ \ws -> do
+    file <- H.noteTempFile ws "file"
+
+    result <- liftIO $ writeLazyByteStringFileWithOwnerPermissions (File file) ""
+
+    case result of
+      Left err -> failWith Nothing $ displayError @(FileError ()) err
+      Right () -> return ()
+
+    fResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)
+
+    case fResult of
+      Left err -> failWith Nothing $ show err
+      Right () -> liftIO (removeFile file) >> success
+
+tests :: TestTree
+tests = testGroup "Test.Cardano.Api.IO"
+  [ testProperty "Create VRF File with Owner Permissions" prop_createVrfFileWithOwnerPermissions
+  ]

--- a/cardano-api/test/cardano-api-test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test/cardano-api-test.hs
@@ -6,6 +6,7 @@ import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncod
 
 import qualified Test.Cardano.Api.Crypto
 import qualified Test.Cardano.Api.Eras
+import qualified Test.Cardano.Api.IO
 import qualified Test.Cardano.Api.Json
 import qualified Test.Cardano.Api.KeysByron
 import qualified Test.Cardano.Api.Ledger
@@ -35,6 +36,7 @@ tests =
   testGroup "Cardano.Api"
     [ Test.Cardano.Api.Crypto.tests
     , Test.Cardano.Api.Eras.tests
+    , Test.Cardano.Api.IO.tests
     , Test.Cardano.Api.Json.tests
     , Test.Cardano.Api.KeysByron.tests
     , Test.Cardano.Api.Ledger.tests


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Revert and test `writeLazyByteStringFileWithOwnerPermissions`
  compatibility: compatible
  type: bugfix
```

# Context

Unfortunately `writeLazyByteStringFileWithOwnerPermissions` did not have a regression test (the regression test was in the `cardano-node` repository which made it possible for a bug to be introduced during a GHC upgrade.  This reverts that change and regression, but unfortunately means the code won't compile with `ghc-8.6` anymore.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
