### PR TITLE
handleFileForWritingWithOwnerPermissionImpl: Fix permisions

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -268,7 +268,9 @@ test-suite cardano-api-test
                       , cardano-ledger-api >= 1.3
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.4
                       , containers
+                      , directory
                       , hedgehog >= 1.1
+                      , hedgehog-extras
                       , hedgehog-quickcheck
                       , mtl
                       , QuickCheck
@@ -278,6 +280,7 @@ test-suite cardano-api-test
 
   other-modules:        Test.Cardano.Api.Crypto
                         Test.Cardano.Api.Eras
+                        Test.Cardano.Api.IO
                         Test.Cardano.Api.Json
                         Test.Cardano.Api.KeysByron
                         Test.Cardano.Api.Ledger

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-api
-version:                8.10.0.0
+version:                8.10.1.0
 synopsis:               The cardano api
 description:            The cardano api.
 category:               Cardano,
@@ -196,11 +196,11 @@ library
                         Cardano.Api.ChainSync.ClientPipelined
                         Cardano.Api.Crypto.Ed25519Bip32
                         Cardano.Api.Shelley
-                        -- TODO: Eliminate Cardano.Api.Ledger when 
-                        -- cardano-api only depends on modules 
-                        -- exposed by cardano-api-ledger  
-                        Cardano.Api.Ledger 
- 
+                        -- TODO: Eliminate Cardano.Api.Ledger when
+                        -- cardano-api only depends on modules
+                        -- exposed by cardano-api-ledger
+                        Cardano.Api.Ledger
+
 
   build-depends:        bytestring
                       , cardano-api:internal

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Api.IO
+  ( tests
+  ) where
+
+import           Cardano.Api
+import           Cardano.Api.IO
+
+import           Control.Monad.Except (runExceptT)
+import           Control.Monad.IO.Class (liftIO)
+import           System.Directory (removeFile)
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+import           Hedgehog.Internal.Property
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog
+
+prop_createVrfFileWithOwnerPermissions :: Property
+prop_createVrfFileWithOwnerPermissions =
+  H.propertyOnce . H.moduleWorkspace "help" $ \ws -> do
+    file <- H.noteTempFile ws "file"
+
+    result <- liftIO $ writeLazyByteStringFileWithOwnerPermissions (File file) ""
+
+    case result of
+      Left err -> failWith Nothing $ displayError @(FileError ()) err
+      Right () -> return ()
+
+    fResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)
+
+    case fResult of
+      Left err -> failWith Nothing $ show err
+      Right () -> liftIO (removeFile file) >> success
+
+tests :: TestTree
+tests = testGroup "Test.Cardano.Api.IO"
+  [ testProperty "Create VRF File with Owner Permissions" prop_createVrfFileWithOwnerPermissions
+  ]

--- a/cardano-api/test/cardano-api-test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test/cardano-api-test.hs
@@ -6,6 +6,7 @@ import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncod
 
 import qualified Test.Cardano.Api.Crypto
 import qualified Test.Cardano.Api.Eras
+import qualified Test.Cardano.Api.IO
 import qualified Test.Cardano.Api.Json
 import qualified Test.Cardano.Api.KeysByron
 import qualified Test.Cardano.Api.Ledger
@@ -35,6 +36,7 @@ tests =
   testGroup "Cardano.Api"
     [ Test.Cardano.Api.Crypto.tests
     , Test.Cardano.Api.Eras.tests
+    , Test.Cardano.Api.IO.tests
     , Test.Cardano.Api.Json.tests
     , Test.Cardano.Api.KeysByron.tests
     , Test.Cardano.Api.Ledger.tests


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix permissions of file written using handleFileForWritingWithOwnerPermissionImpl
  compatibility: no-api-changes
  type: bugfix
```
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff
