### PR TITLE
Expose shelleyCertificateConstraints and conwayCertificateConstraints

### DIFF
--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -67,6 +67,8 @@ module Cardano.Api.Certificate (
     AsType(..),
 
     -- * Internal functions
+    shelleyCertificateConstraints,
+    conwayCertificateConstraints,
     filterUnRegCreds,
     selectStakeCredential,
   ) where
@@ -816,6 +818,7 @@ shelleyCertificateConstraints
   -> (( Ledger.ShelleyEraTxCert (ShelleyLedgerEra era)
       , EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
       , Ledger.TxCert (ShelleyLedgerEra era) ~ Ledger.ShelleyTxCert (ShelleyLedgerEra era)
+      , IsShelleyBasedEra era
       ) => a)
   -> a
 shelleyCertificateConstraints ShelleyToBabbageEraBabbage f = f
@@ -829,6 +832,7 @@ conwayCertificateConstraints
   -> (( Ledger.ConwayEraTxCert (ShelleyLedgerEra era)
       , EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
       , Ledger.TxCert (ShelleyLedgerEra era) ~ Ledger.ConwayTxCert (ShelleyLedgerEra era)
+      , IsShelleyBasedEra era
       ) => a)
   -> a
 conwayCertificateConstraints ConwayEraOnwardsConway f = f

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -268,13 +268,17 @@ module Cardano.Api.Shelley
     shelleyPayAddrToPlutusPubKHash,
     toConsensusGenTx,
     fromAlonzoCostModels,
-    --TODO: arrange not to export these
+    -- TODO: arrange not to export these
     toShelleyNetwork,
     obtainCryptoConstraints,
     obtainEraConstraints,
     obtainEraPParamsConstraint,
     obtainEraCryptoConstraints,
     fromShelleyPoolParams,
+
+    -- Era based
+    shelleyCertificateConstraints,
+    conwayCertificateConstraints,
 
   ) where
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Expose shelleyCertificateConstraints and conwayCertificateConstraints
  # no-api-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: compatible
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: feature
```

# Context

Addititional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
