### PR TITLE
Deprecate `TxGovernanceActionSupportedInEra`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -1112,15 +1112,15 @@ genGovernancePollAnswer =
 genTxGovernanceActions :: CardanoEra era -> Gen (TxGovernanceActions era)
 genTxGovernanceActions era = fromMaybe (pure TxGovernanceActionsNone) $ do
   sbe <- join $ requireShelleyBasedEra era
-  supported <- governanceActionsSupportedInEra sbe
+  supported <- featureInShelleyBasedEra Nothing Just sbe
   let proposals = Gen.list (Range.constant 0 10) $ genProposal sbe supported
   pure $ TxGovernanceActions supported <$> proposals
   where
     genProposal :: ShelleyBasedEra era
-                -> TxGovernanceActionSupportedInEra era
+                -> ConwayEraOnwards era
                 -> Gen (Proposal era)
     genProposal sbe = shelleyBasedEraConstraints sbe $ fmap Proposal . \case
-      GovernanceActionsSupportedInConwayEra -> Q.arbitrary
+      ConwayEraOnwardsConway -> Q.arbitrary
 
 genTxVotes :: CardanoEra era -> Gen (TxVotes era)
 genTxVotes era = fromMaybe (pure TxVotesNone) $ do

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -13,6 +13,7 @@ module Cardano.Api.Governance.Actions.ProposalProcedure where
 
 import           Cardano.Api.Address
 import           Cardano.Api.Eras
+import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.ProtocolParameters
@@ -43,7 +44,7 @@ data TxGovernanceActions era where
   TxGovernanceActionsNone :: TxGovernanceActions era
 
   TxGovernanceActions
-    :: TxGovernanceActionSupportedInEra era
+    :: ConwayEraOnwards era
     -> [Proposal era]
     -> TxGovernanceActions era
 
@@ -59,6 +60,7 @@ deriving instance IsShelleyBasedEra era => Eq (TxGovernanceActions era)
 data TxGovernanceActionSupportedInEra era where
 
      GovernanceActionsSupportedInConwayEra  :: TxGovernanceActionSupportedInEra ConwayEra
+{-# DEPRECATED TxGovernanceActionSupportedInEra "Use ConwayEraOnwards instead" #-}
 
 deriving instance Show (TxGovernanceActionSupportedInEra era)
 deriving instance Eq (TxGovernanceActionSupportedInEra era)
@@ -70,7 +72,7 @@ governanceActionsSupportedInEra ShelleyBasedEraMary    = Nothing
 governanceActionsSupportedInEra ShelleyBasedEraAlonzo  = Nothing
 governanceActionsSupportedInEra ShelleyBasedEraBabbage = Nothing
 governanceActionsSupportedInEra ShelleyBasedEraConway  = Just GovernanceActionsSupportedInConwayEra
-
+{-# DEPRECATED governanceActionsSupportedInEra "Use featureInShelleyBasedEra Nothing Just instead" #-}
 
 data AnyGovernanceAction = forall era. AnyGovernanceAction (Gov.GovernanceAction era)
 

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -190,6 +190,7 @@ import           Cardano.Api.Convenience.Constraints
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
+import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Governance.Actions.ProposalProcedure
 import           Cardano.Api.Governance.Actions.VotingProcedure
 import           Cardano.Api.Hash
@@ -2741,14 +2742,14 @@ fromLedgerProposalProcedure
   -> Ledger.TxBody (ShelleyLedgerEra era)
   -> TxGovernanceActions era
 fromLedgerProposalProcedure sbe body =
-  case governanceActionsSupportedInEra sbe of
-    Nothing     -> TxGovernanceActionsNone
-    Just gasice -> TxGovernanceActions gasice (getProposals gasice body)
+  case featureInShelleyBasedEra Nothing Just sbe of
+    Nothing -> TxGovernanceActionsNone
+    Just w  -> TxGovernanceActions w (getProposals w body)
   where
-    getProposals :: TxGovernanceActionSupportedInEra era
+    getProposals :: ConwayEraOnwards era
                  -> Ledger.TxBody (ShelleyLedgerEra era)
                  -> [Proposal era]
-    getProposals GovernanceActionsSupportedInConwayEra body_ = fmap Proposal . toList $ body_ ^. L.proposalProceduresTxBodyL
+    getProposals ConwayEraOnwardsConway body_ = fmap Proposal . toList $ body_ ^. L.proposalProceduresTxBodyL
 
 
 fromLedgerTxVotes :: ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxVotes era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Deprecate `TxGovernanceActionSupportedInEra`
  compatibility: breaking
  type: feature
```

# Context

`TxGovernanceActionSupportedInEra` and `ConwayEraOnwards` are near identical.

Using `ConwayEraOnwards` everywhere instead.

The deprecation and switch to `ConwayEraOnwards` serves the following purpose:

* Reduce the size of the API
* Documentation that a type, constructor or function only works from Conway era onwards.  Use of `TxGovernanceActionSupportedInEra` did not make this clear
* Reduce the amount of glue code required for different parts of the CLI to work together.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
