### PR TITLE
Deprecate `TxVotesSupportedInEra`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -1124,11 +1124,10 @@ genTxGovernanceActions era = fromMaybe (pure TxGovernanceActionsNone) $ do
 
 genTxVotes :: CardanoEra era -> Gen (TxVotes era)
 genTxVotes era = fromMaybe (pure TxVotesNone) $ do
-  sbe <- join $ requireShelleyBasedEra era
-  supported <- votesSupportedInEra sbe
-  let votes = Gen.list (Range.constant 0 10) $ genVote sbe
-  pure $ TxVotes supported <$> votes
+  w <- featureInEra Nothing Just era
+  let votes = Gen.list (Range.constant 0 10) $ genVote w
+  pure $ TxVotes w <$> votes
   where
-    genVote :: ShelleyBasedEra era -> Gen (VotingProcedure era)
-    genVote sbe = obtainEraConstraints sbe $ VotingProcedure <$> Q.arbitrary
+    genVote :: ConwayEraOnwards era -> Gen (VotingProcedure era)
+    genVote w = conwayEraOnwardsConstraints w $ VotingProcedure <$> Q.arbitrary
 

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -189,4 +189,3 @@ fromProposalProcedure sbe (Proposal pp) =
   , StakeKeyHash (shelleyBasedEraConstraints sbe (Gov.pProcReturnAddr pp))
   , shelleyBasedEraConstraints sbe $ fromGovernanceAction sbe (Gov.pProcGovernanceAction pp)
   )
-

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
@@ -17,6 +17,7 @@ module Cardano.Api.Governance.Actions.VotingProcedure where
 
 import           Cardano.Api.Address
 import           Cardano.Api.Eras
+import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.Script
@@ -47,7 +48,7 @@ data TxVotes era where
   TxVotesNone :: TxVotes era
 
   TxVotes
-    :: TxVotesSupportedInEra era
+    :: ConwayEraOnwards era
     -> [VotingProcedure era]
     -> TxVotes era
 
@@ -61,10 +62,10 @@ deriving instance Eq (TxVotes era)
 --
 data TxVotesSupportedInEra era where
      VotesSupportedInConwayEra  :: TxVotesSupportedInEra ConwayEra
+{-# DEPRECATED TxVotesSupportedInEra "Use ConwayEraOnwards instead" #-}
 
 deriving instance Show (TxVotesSupportedInEra era)
 deriving instance Eq (TxVotesSupportedInEra era)
-
 
 votesSupportedInEra :: ShelleyBasedEra  era -> Maybe (TxVotesSupportedInEra era)
 votesSupportedInEra ShelleyBasedEraShelley = Nothing
@@ -73,7 +74,7 @@ votesSupportedInEra ShelleyBasedEraMary    = Nothing
 votesSupportedInEra ShelleyBasedEraAlonzo  = Nothing
 votesSupportedInEra ShelleyBasedEraBabbage = Nothing
 votesSupportedInEra ShelleyBasedEraConway  = Just VotesSupportedInConwayEra
-
+{-# DEPRECATED votesSupportedInEra "Use conwayEraOnwardsConstraints instead" #-}
 
 newtype GovernanceActionId ledgerera = GovernanceActionId
   { unGovernanceActionId :: Ledger.GovernanceActionId (EraCrypto ledgerera)

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -190,6 +190,7 @@ import           Cardano.Api.Convenience.Constraints
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
+import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Governance.Actions.ProposalProcedure
 import           Cardano.Api.Governance.Actions.VotingProcedure
 import           Cardano.Api.Hash
@@ -2753,14 +2754,14 @@ fromLedgerProposalProcedure sbe body =
 
 fromLedgerTxVotes :: ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxVotes era
 fromLedgerTxVotes sbe body =
-  case votesSupportedInEra sbe of
-    Nothing    -> TxVotesNone
-    Just vsice -> TxVotes vsice (getVotes vsice body)
+  case featureInShelleyBasedEra Nothing Just sbe of
+    Nothing -> TxVotesNone
+    Just w  -> TxVotes w (getVotes w body)
   where
-    getVotes :: TxVotesSupportedInEra era
+    getVotes :: ConwayEraOnwards era
              -> Ledger.TxBody (ShelleyLedgerEra era)
              -> [VotingProcedure era]
-    getVotes VotesSupportedInConwayEra body_ = fmap VotingProcedure . toList $ body_ ^. L.votingProceduresTxBodyL
+    getVotes ConwayEraOnwardsConway body_ = fmap VotingProcedure . toList $ body_ ^. L.votingProceduresTxBodyL
 
 fromLedgerTxIns
   :: forall era.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Deprecate `TxVotesSupportedInEra`
  compatibility: breaking
  type: feature
```

# Context

`TxVotesSupportedInEra` and `ConwayEraOnwards` are near identical.

Using `ConwayEraOnwards` everywhere instead.

The deprecation and switch to `ConwayEraOnwards` serves the following purpose:

* Reduce the size of the API
* Documentation that a type, constructor or function only works from Conway era onwards.  Use of `TxVotesSupportedInEra` did not make this clear
* Reduce the amount of glue code required for different parts of the CLI to work together.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
