### PR TITLE
Deprecate `shelleyCertificateConstraints` and `conwayCertificateConstraints`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -331,10 +331,10 @@ makeStakeAddressRegistrationCertificate :: StakeAddressRequirements era -> Certi
 makeStakeAddressRegistrationCertificate req =
   case req of
     StakeAddrRegistrationPreConway atMostEra scred ->
-      shelleyCertificateConstraints atMostEra
+      shelleyToBabbageEraConstraints atMostEra
         $ makeStakeAddressRegistrationCertificatePreConway atMostEra scred
     StakeAddrRegistrationConway cOnwards ll scred ->
-      conwayCertificateConstraints cOnwards
+      conwayEraOnwardsConstraints cOnwards
         $ makeStakeAddressRegistrationCertificatePostConway cOnwards scred ll
  where
   makeStakeAddressRegistrationCertificatePreConway :: ()
@@ -365,11 +365,11 @@ makeStakeAddressUnregistrationCertificate :: StakeAddressRequirements era -> Cer
 makeStakeAddressUnregistrationCertificate req =
   case req of
     StakeAddrRegistrationConway cOnwards ll scred ->
-      conwayCertificateConstraints cOnwards
+      conwayEraOnwardsConstraints cOnwards
         $ makeStakeAddressDeregistrationCertificatePostConway cOnwards scred ll
 
     StakeAddrRegistrationPreConway atMostEra scred ->
-      shelleyCertificateConstraints atMostEra
+      shelleyToBabbageEraConstraints atMostEra
         $ makeStakeAddressDeregistrationCertificatePreConway atMostEra scred
  where
   makeStakeAddressDeregistrationCertificatePreConway
@@ -442,12 +442,12 @@ makeStakeAddressDelegationCertificate :: StakeDelegationRequirements era -> Cert
 makeStakeAddressDelegationCertificate req =
   case req of
     StakeDelegationRequirementsConwayOnwards cOnwards scred delegatee ->
-      conwayCertificateConstraints cOnwards
+      conwayEraOnwardsConstraints cOnwards
         $ ConwayCertificate cOnwards
         $ Ledger.mkDelegTxCert (toShelleyStakeCredential scred) delegatee
 
     StakeDelegationRequirementsPreConway atMostBabbage scred pid ->
-      shelleyCertificateConstraints atMostBabbage
+      shelleyToBabbageEraConstraints atMostBabbage
         $ ShelleyRelatedCertificate atMostBabbage
         $ Ledger.mkDelegStakeTxCert (toShelleyStakeCredential scred) (unStakePoolKeyHash pid)
 
@@ -468,11 +468,11 @@ makeStakePoolRegistrationCertificate :: ()
 makeStakePoolRegistrationCertificate req =
   case req of
     StakePoolRegistrationRequirementsConwayOnwards cOnwards poolParams ->
-      conwayCertificateConstraints cOnwards
+      conwayEraOnwardsConstraints cOnwards
         $ ConwayCertificate cOnwards
         $ Ledger.mkRegPoolTxCert poolParams
     StakePoolRegistrationRequirementsPreConway atMostBab poolParams ->
-      shelleyCertificateConstraints atMostBab
+      shelleyToBabbageEraConstraints atMostBab
         $ ShelleyRelatedCertificate atMostBab
         $ Ledger.mkRegPoolTxCert poolParams
 
@@ -495,11 +495,11 @@ makeStakePoolRetirementCertificate :: ()
 makeStakePoolRetirementCertificate req =
   case req of
     StakePoolRetirementRequirementsPreConway atMostBab poolId retirementEpoch ->
-      shelleyCertificateConstraints atMostBab
+      shelleyToBabbageEraConstraints atMostBab
         $ ShelleyRelatedCertificate atMostBab
         $ Ledger.mkRetirePoolTxCert (unStakePoolKeyHash poolId) retirementEpoch
     StakePoolRetirementRequirementsConwayOnwards atMostBab poolId retirementEpoch ->
-      conwayCertificateConstraints atMostBab
+      conwayEraOnwardsConstraints atMostBab
         $ ConwayCertificate atMostBab
         $ Ledger.mkRetirePoolTxCert (unStakePoolKeyHash poolId) retirementEpoch
 
@@ -515,7 +515,7 @@ makeGenesisKeyDelegationCertificate :: GenesisKeyDelegationRequirements era -> C
 makeGenesisKeyDelegationCertificate (GenesisKeyDelegationRequirements atMostEra
                                        (GenesisKeyHash hGenKey) (GenesisDelegateKeyHash hGenDelegKey) (VrfKeyHash hVrfKey)) =
   ShelleyRelatedCertificate atMostEra
-    $ shelleyCertificateConstraints atMostEra
+    $ shelleyToBabbageEraConstraints atMostEra
     $ Ledger.ShelleyTxCertGenesisDeleg $ Ledger.GenesisDelegCert hGenKey hGenDelegKey hVrfKey
 
 data MirCertificateRequirements era where
@@ -820,12 +820,8 @@ shelleyCertificateConstraints
       , IsShelleyBasedEra era
       ) => a)
   -> a
-shelleyCertificateConstraints = \case
-  ShelleyToBabbageEraBabbage  -> id
-  ShelleyToBabbageEraAlonzo   -> id
-  ShelleyToBabbageEraMary     -> id
-  ShelleyToBabbageEraAllegra  -> id
-  ShelleyToBabbageEraShelley  -> id
+shelleyCertificateConstraints w f = shelleyToBabbageEraConstraints w f {- HLINT ignore "Eta reduce" -}
+{-# DEPRECATED shelleyCertificateConstraints "Please use 'shelleyToBabbageEraConstraints' instead." #-}
 
 conwayCertificateConstraints
   :: ConwayEraOnwards era
@@ -835,5 +831,5 @@ conwayCertificateConstraints
       , IsShelleyBasedEra era
       ) => a)
   -> a
-conwayCertificateConstraints = \case
-  ConwayEraOnwardsConway      -> id
+conwayCertificateConstraints w f = conwayEraOnwardsConstraints w f {- HLINT ignore "Eta reduce" -}
+{-# DEPRECATED conwayCertificateConstraints "Please use 'conwayEraOnwardsConstraints' instead." #-}

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -55,22 +55,22 @@ instance FeatureInEra ShelleyToBabbageEra where
     BabbageEra  -> yes ShelleyToBabbageEraBabbage
     ConwayEra   -> no
 
-type ShelleyToBabbageEraConstraints era ledgerera =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto ledgerera))
-  , C.Signable (L.VRF (L.EraCrypto ledgerera)) L.Seed
+type ShelleyToBabbageEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) ledgerera
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto ledgerera)
-  , L.Era ledgerera
-  , L.EraCrypto ledgerera ~ L.StandardCrypto
-  , L.EraPParams ledgerera
-  , L.EraTx ledgerera
-  , L.EraTxBody ledgerera
-  , L.HashAnnotated (L.TxBody ledgerera) L.EraIndependentTxBody L.StandardCrypto
-  , L.ShelleyEraTxBody ledgerera
-  , L.ShelleyEraTxCert ledgerera
-  , L.TxCert ledgerera ~ L.ShelleyTxCert ledgerera
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
   , IsShelleyBasedEra era
@@ -84,9 +84,8 @@ data AnyShelleyToBabbageEra where
 deriving instance Show AnyShelleyToBabbageEra
 
 shelleyToBabbageEraConstraints :: ()
-  => ShelleyLedgerEra era ~ ledgerera
   => ShelleyToBabbageEra era
-  -> (ShelleyToBabbageEraConstraints era ledgerera => a)
+  -> (ShelleyToBabbageEraConstraints era => a)
   -> a
 shelleyToBabbageEraConstraints = \case
   ShelleyToBabbageEraShelley -> id


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Deprecate `shelleyCertificateConstraints` and `conwayCertificateConstraints`
  compatibility: breaking
  type: feature
```

# Context

`shelleyToBabbageEraConstraints` already provides all the constraints that `shelleyCertificateConstraints`.

`conwayEraOnwardsConstraints` already provides all the constraints that `conwayCertificateConstraints`.

Deprecating these functions will reduce the size of the API.

Going forward, when needing constraints for `ShelleyToBabbageEra`, one only need to use `shelleyToBabbageEraConstraints`.

Going forward, when needing constraints for `ConwayEraOnwards`, one only need to use `conwayCertificateConstraints`.

If more constraints are needed then those constraints can be added to `shelleyCertificateConstraints` and `conwayCertificateConstraints`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
