### PR TITLE
Add parent feature constraints. New `IsShelleyToBabbageEra` and `ConwayEraOnwards` type classes

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
@@ -68,6 +68,7 @@ type ShelleyBasedEraConstraints era ledgerera =
   , L.ShelleyEraTxBody ledgerera
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
   , IsShelleyBasedEra era
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -9,6 +9,7 @@
 
 module Cardano.Api.Feature.ConwayEraOnwards
   ( ConwayEraOnwards(..)
+  , IsConwayEraOnwards(..)
   , AnyConwayEraOnwards(..)
   , conwayEraOnwardsConstraints
   , conwayEraOnwardsToCardanoEra
@@ -35,11 +36,17 @@ import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 import           Data.Aeson
 import           Data.Typeable (Typeable)
 
+class IsShelleyBasedEra era => IsConwayEraOnwards era where
+  conwayEraOnwards :: ConwayEraOnwards era
+
 data ConwayEraOnwards era where
   ConwayEraOnwardsConway :: ConwayEraOnwards ConwayEra
 
 deriving instance Show (ConwayEraOnwards era)
 deriving instance Eq (ConwayEraOnwards era)
+
+instance IsConwayEraOnwards ConwayEra where
+  conwayEraOnwards = ConwayEraOnwardsConway
 
 instance FeatureInEra ConwayEraOnwards where
   featureInEra no yes = \case
@@ -75,7 +82,9 @@ type ConwayEraOnwardsConstraints era ledgerera =
   , L.TxCert ledgerera ~ L.ConwayTxCert ledgerera
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
   , IsShelleyBasedEra era
+  , IsConwayEraOnwards era
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -9,13 +9,14 @@
 
 module Cardano.Api.Feature.ShelleyToBabbageEra
   ( ShelleyToBabbageEra(..)
+  , IsShelleyToBabbageEra(..)
   , AnyShelleyToBabbageEra(..)
   , shelleyToBabbageEraConstraints
   , shelleyToBabbageEraToCardanoEra
   , shelleyToBabbageEraToShelleyBasedEra
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
 import           Cardano.Api.Query.Types
 
@@ -35,6 +36,9 @@ import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 import           Data.Aeson
 import           Data.Typeable (Typeable)
 
+class IsShelleyBasedEra era => IsShelleyToBabbageEra era where
+  shelleyToBabbageEra :: ShelleyToBabbageEra era
+
 data ShelleyToBabbageEra era where
   ShelleyToBabbageEraShelley :: ShelleyToBabbageEra ShelleyEra
   ShelleyToBabbageEraAllegra :: ShelleyToBabbageEra AllegraEra
@@ -44,6 +48,21 @@ data ShelleyToBabbageEra era where
 
 deriving instance Show (ShelleyToBabbageEra era)
 deriving instance Eq (ShelleyToBabbageEra era)
+
+instance IsShelleyToBabbageEra ShelleyEra where
+  shelleyToBabbageEra = ShelleyToBabbageEraShelley
+
+instance IsShelleyToBabbageEra AllegraEra where
+  shelleyToBabbageEra = ShelleyToBabbageEraAllegra
+
+instance IsShelleyToBabbageEra MaryEra where
+  shelleyToBabbageEra = ShelleyToBabbageEraMary
+
+instance IsShelleyToBabbageEra AlonzoEra where
+  shelleyToBabbageEra = ShelleyToBabbageEraAlonzo
+
+instance IsShelleyToBabbageEra BabbageEra where
+  shelleyToBabbageEra = ShelleyToBabbageEraBabbage
 
 instance FeatureInEra ShelleyToBabbageEra where
   featureInEra no yes = \case
@@ -73,7 +92,9 @@ type ShelleyToBabbageEraConstraints era =
   , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
   , IsShelleyBasedEra era
+  , IsShelleyToBabbageEra era
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -36,11 +36,14 @@ module Cardano.Api (
 
     -- * Features
     ShelleyToBabbageEra(..),
+    IsShelleyToBabbageEra(..),
     AnyShelleyToBabbageEra(..),
     shelleyToBabbageEraConstraints,
     shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
+
     ConwayEraOnwards(..),
+    IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
     conwayEraOnwardsConstraints,
     conwayEraOnwardsToCardanoEra,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add parent feature constraints. New `IsShelleyToBabbageEra` and `ConwayEraOnwards` type classes.
  compatibility: compatible
  type: feature
```

# Context

This means that `shelleyBasedEraConstraints` gives you all the constraints that `cardanoEraConstraints` gives so you don't have to call both functions.

Likewise:

* `shelleyToBabbageEraConstraints` gives you all the constraints of both `shelleyBasedEraConstraints` and `cardanoEraConstraints`.

* `conwayEraOnwardsConstraints` gives you all the constraints of both `shelleyBasedEraConstraints` and `cardanoEraConstraints`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
