### PR TITLE
Add Cardano.Api.Credentials

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -53,6 +53,7 @@ library internal
                         Cardano.Api.Convenience.Constraints
                         Cardano.Api.Convenience.Construction
                         Cardano.Api.Convenience.Query
+                        Cardano.Api.Credentials
                         Cardano.Api.DeserialiseAnyOf
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast

--- a/cardano-api/internal/Cardano/Api/Credentials.hs
+++ b/cardano-api/internal/Cardano/Api/Credentials.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Api.Credentials where
+
+import           Cardano.Api.Certificate
+import           Cardano.Api.Governance.Poll (Hash (DRepKeyHash))
+import           Cardano.Api.Keys.Class
+import           Cardano.Api.ReexposeLedger
+
+-- In Conway era onways, DRep and Committee members are registered on chain via their credentials.
+-- I.E they do not have corresponding addresses.
+-- NB: DRep and Committee keys cannot be converted to addresses because addresses
+-- only have notions of payment and stake credentials, not voting credentials.
+
+
+-- ----------------------------------------------------------------------------
+-- Credential generation
+--
+
+genDRepCredentialAndKeyHash :: IO (Credential 'Voting StandardCrypto, KeyHash 'Voting StandardCrypto)
+genDRepCredentialAndKeyHash = do
+  skey <- generateSigningKey AsDRepKey
+  let vkey = getVerificationKey skey
+      DRepKeyHash kHash = verificationKeyHash vkey
+      ledgerKeyCredential = KeyHashObj kHash
+  return (ledgerKeyCredential, kHash)
+


### PR DESCRIPTION
Implement genDRepCredentialAndKeyHash

# Changelog

```yaml
- description: |
    Implement genDRepCredentialAndKeyHash
  # no-api-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: compatible
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: feature
```

# Context

Addititional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
