### PR TITLE
Make changelog options configurable

### DIFF
--- a/.cardano-dev.yaml
+++ b/.cardano-dev.yaml
@@ -1,5 +1,17 @@
-version: 
+version: 2
 main-branch: main
 release-branch:
   prefix: release/
   suffix: .x
+changelog:
+  # Determine which PR changelog options are available and which end up in the changelog
+  options:
+    compatibility:
+      breaking: add
+      compatible: add
+      no-api-changes: add
+    type:
+      feature: add
+      bugfix: add
+      test: skip
+      maintenance: skip

--- a/.cardano-dev.yaml
+++ b/.cardano-dev.yaml
@@ -6,12 +6,13 @@ release-branch:
 changelog:
   # Determine which PR changelog options are available and which end up in the changelog
   options:
-    compatibility:
+    type:
+      feature: add # that's for backwards compatibility with prevous PRs, remove this option after a release
       breaking: add
       compatible: add
-      no-api-changes: add
-    type:
-      feature: add
+      optimisation: add
+      improvement: add
       bugfix: add
       test: skip
       maintenance: skip
+      documentation: skip

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,21 +3,21 @@
 ```yaml
 - description: |
     <insert-changelog-description-here>
-  # no-api-changes: the API has not changed
-  # compatible: the API has changed but is non-breaking
-  # breaking: the API has changed in a breaking way
-  compatibility: <no-api-changes|compatible|breaking>
-  # feature: the change implements a new feature in the API
-  # bugfix: the change fixes a bug in the API
-  # test: the change fixes modifies tests
-  # maintenance: the change involves something other than the API
-  # If more than one is applicable, it may be put into a list.
-  type: <feature|bugfix|test|maintenance>
+# uncomment types applicable to the change:
+  type:
+  # - breaking       # the API has changed in a breaking way
+  # - compatible     # the API has changed but is non-breaking
+  # - optimisation   # measurable performance improvements
+  # - improvement    # QoL changes e.g. refactoring
+  # - bugfix         # fixes a defect
+  # - test           # fixes/modifies tests
+  # - maintenance    # not directly related to the code
+  # - documentation  # change in code docs, haddocks...
 ```
 
 # Context
 
-Addititional context for the PR goes here.
+Additional context for the PR goes here.
 
 If the PR fixes a particular issue please provide a
 [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
@@ -30,7 +30,9 @@ to the issue.
 - [ ] New tests are added if needed and existing tests are updated.  These may include:
   - golden tests
   - property tests
-  - roundtrip tests
+  - round trip tests
+  - integration tests
+  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
 - [ ] The version bounds in `.cabal` files are updated
 - [ ] CI passes. See note on CI.  The following CI checks are required:
   - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
@@ -39,7 +41,9 @@ to the issue.
 - [ ] The changelog section in the PR is updated to describe the change
 - [ ] Self-reviewed the diff
 
-# Note on CI
+<!-- 
+### Note on CI ###
 If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
-You will need to get someone with write privileges.  Please contact IOG node developers to do this
-for you.
+You will need to get someone with write privileges. Please contact IOG node developers to do this
+for you. 
+-->

--- a/.github/workflows/check-pr-changelog.yml
+++ b/.github/workflows/check-pr-changelog.yml
@@ -54,14 +54,11 @@ jobs:
             }
 
             let isCompatibilityValid = false;
-            const validCompatibilityValues = Object.keys(config.changelog.options.compatibility);
-            if (Array.isArray(changelog.compatibility) && !!changelog.compatibility) {
-              isCompatibilityValid = changelog.compatibility.every(value => validCompatibilityValues.includes(value));
-            } else {
-              isCompatibilityValid = validCompatibilityValues.includes(changelog.compatibility);
+            if (!changelog.compatibility) {
+              isCompatibilityValid = true;
             }
             if (!isCompatibilityValid) {
-              console.error(`PR changelog has invalid compatibility: ${changelog.compatibility}\nExpected one, or more of: ${validCompatibilityValues}`)
+              console.error('Changelog field "compatibility" is deprecated and no longer used. Please remove it.');
             }
 
             let isTypeValid = false;

--- a/.github/workflows/check-pr-changelog.yml
+++ b/.github/workflows/check-pr-changelog.yml
@@ -8,6 +8,8 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         if: ${{ github.event_name != 'merge_group' }}
         with:
@@ -24,6 +26,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const yaml = require('js-yaml');
+            const fs   = require('fs');
 
             const prDescription = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -43,8 +46,15 @@ jobs:
               process.exit(1);
             }
 
+            try {
+              config = yaml.load(fs.readFileSync('.cardano-dev.yaml', 'utf8'));
+            } catch (e) {
+              console.error('Failed to load .cardano-dev.yaml config:', e);
+              process.exit(1);
+            }
+
             let isCompatibilityValid = false;
-            const validCompatibilityValues = ['no-api-changes', 'compatible', 'breaking'];
+            const validCompatibilityValues = Object.keys(config.changelog.options.compatibility);
             if (Array.isArray(changelog.compatibility) && !!changelog.compatibility) {
               isCompatibilityValid = changelog.compatibility.every(value => validCompatibilityValues.includes(value));
             } else {
@@ -55,7 +65,7 @@ jobs:
             }
 
             let isTypeValid = false;
-            const validTypeValues = ['feature', 'bugfix', 'test', 'maintenance'];;
+            const validTypeValues = Object.keys(config.changelog.options.type);
             if (Array.isArray(changelog.type) && !!changelog.type) {
               isTypeValid = changelog.type.every(value => validTypeValues.includes(value));
             } else {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add configurable compatibility and type
# uncomment types applicable to the change:
  type:
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes, e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - documentation  # change in code docs, haddocks...
```

# Context

Enables support for https://github.com/input-output-hk/cardano-dev/pull/7

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
