### PR TITLE
Fix committee hot keys

### DIFF
--- a/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
@@ -674,8 +674,6 @@ instance CastVerificationKeyRole GenesisKey PaymentKey where
 -- Constitutional Committee Hot Keys
 --
 
-type KeyRoleCommitteeHotKey = Shelley.Genesis -- TODO CIP-1694 this should be a newtype Shelley.CommitteeHotKey
-
 data CommitteeHotKey
 
 instance HasTypeProxy CommitteeHotKey where
@@ -685,7 +683,7 @@ instance HasTypeProxy CommitteeHotKey where
 instance Key CommitteeHotKey where
 
     newtype VerificationKey CommitteeHotKey =
-        CommitteeHotVerificationKey (Shelley.VKey KeyRoleCommitteeHotKey StandardCrypto)
+        CommitteeHotVerificationKey (Shelley.VKey Shelley.CommitteeHotKey StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey CommitteeHotKey)
       deriving newtype (ToCBOR, FromCBOR)
@@ -736,7 +734,7 @@ instance SerialiseAsRawBytes (SigningKey CommitteeHotKey) where
 
 
 newtype instance Hash CommitteeHotKey =
-    CommitteeHotKeyHash (Shelley.KeyHash KeyRoleCommitteeHotKey StandardCrypto)
+    CommitteeHotKeyHash (Shelley.KeyHash Shelley.CommitteeHotKey StandardCrypto)
   deriving stock (Eq, Ord)
   deriving (Show, IsString) via UsingRawBytesHex (Hash CommitteeHotKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash CommitteeHotKey)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix committee hot keys
  compatibility: breaking
  type: feature
```

# Context

The API previously used genesis delegate keys as the backend because the ledger implementation for committee hot keys weren't ready yet.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
