### PR TITLE
Fix EraCast Certificate instance

### DIFF
--- a/cardano-api/internal/Cardano/Api/Address.hs
+++ b/cardano-api/internal/Cardano/Api/Address.hs
@@ -376,8 +376,8 @@ instance IsShelleyBasedEra era => FromJSON (AddressInEra era) where
     pure $ anyAddressInShelleyBasedEra addressAny
 
 instance EraCast AddressInEra where
-  eraCast toEra' (AddressInEra addressTypeInEra address) = AddressInEra
-    <$> eraCast toEra' addressTypeInEra
+  eraCast toEra' fromEra' (AddressInEra addressTypeInEra address) = AddressInEra
+    <$> eraCast toEra' fromEra' addressTypeInEra
     <*> pure address
 
 parseAddressAny :: Parsec.Parser AddressAny
@@ -467,7 +467,7 @@ instance IsCardanoEra era => SerialiseAddress (AddressInEra era) where
       rightToMaybe . anyAddressInEra cardanoEra =<< deserialiseAddress AsAddressAny t
 
 instance EraCast (AddressTypeInEra addrtype) where
-  eraCast toEra' v = case v of
+  eraCast toEra' _ v = case v of
     ByronAddressInAnyEra -> pure ByronAddressInAnyEra
     ShelleyAddressInEra previousEra ->
       case cardanoEraStyle toEra' of

--- a/cardano-api/internal/Cardano/Api/EraCast.hs
+++ b/cardano-api/internal/Cardano/Api/EraCast.hs
@@ -11,8 +11,7 @@ import           Cardano.Api.Eras (CardanoEra (..), IsCardanoEra)
 import           Data.Kind (Type)
 
 data EraCastError = forall fromEra toEra value.
-  ( IsCardanoEra fromEra
-  , IsCardanoEra toEra
+  ( IsCardanoEra toEra
   , Show value
   ) =>
     EraCastError
@@ -22,7 +21,8 @@ data EraCastError = forall fromEra toEra value.
     }
 
 class EraCast (f :: Type -> Type) where
-  eraCast :: (IsCardanoEra fromEra, IsCardanoEra toEra)
+  eraCast :: IsCardanoEra toEra
           => CardanoEra toEra
+          -> CardanoEra fromEra
           -> f fromEra
           -> Either EraCastError (f toEra)

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -357,7 +357,7 @@ newtype UTxO era = UTxO { unUTxO :: Map TxIn (TxOut CtxUTxO era) }
   deriving (Eq, Show)
 
 instance EraCast UTxO where
-  eraCast toEra' (UTxO m) = UTxO <$> forM m (eraCast toEra')
+  eraCast toEra' fromEra' (UTxO m) = UTxO <$> forM m (eraCast toEra' fromEra')
 
 data UTxOInAnyEra where
   UTxOInAnyEra :: CardanoEra era

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -1376,11 +1376,11 @@ instance IsCardanoEra era => FromJSON (ReferenceScript era) where
         ReferenceScript refSupInEra <$> o .: "referenceScript"
 
 instance EraCast ReferenceScript where
-  eraCast toEra = \case
+  eraCast toEra fromEra' = \case
     ReferenceScriptNone -> pure ReferenceScriptNone
     v@(ReferenceScript (_ :: ReferenceTxInsScriptsInlineDatumsSupportedInEra fromEra) scriptInAnyLang) ->
       case refInsScriptsAndInlineDatsSupportedInEra toEra of
-        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Nothing -> Left $ EraCastError v fromEra' toEra
         Just supportedInEra -> Right $ ReferenceScript supportedInEra scriptInAnyLang
 
 data ReferenceTxInsScriptsInlineDatumsSupportedInEra era where

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -376,12 +376,12 @@ deriving instance Eq   (TxOut ctx era)
 deriving instance Show (TxOut ctx era)
 
 instance EraCast (TxOut ctx) where
-  eraCast toEra (TxOut addressInEra txOutValue txOutDatum referenceScript) =
+  eraCast toEra fromEra' (TxOut addressInEra txOutValue txOutDatum referenceScript) =
     TxOut
-      <$> eraCast toEra addressInEra
-      <*> eraCast toEra txOutValue
-      <*> eraCast toEra txOutDatum
-      <*> eraCast toEra referenceScript
+      <$> eraCast toEra fromEra' addressInEra
+      <*> eraCast toEra fromEra' txOutValue
+      <*> eraCast toEra fromEra' txOutDatum
+      <*> eraCast toEra fromEra' referenceScript
 
 data TxOutInAnyEra where
      TxOutInAnyEra :: CardanoEra era
@@ -1366,14 +1366,14 @@ data TxOutValue era where
      TxOutValue   :: MultiAssetSupportedInEra era -> Value -> TxOutValue era
 
 instance EraCast TxOutValue where
-  eraCast toEra v = case v of
+  eraCast toEra fromEra' v = case v of
     TxOutAdaOnly _previousEra lovelace ->
       case multiAssetSupportedInEra toEra of
         Left adaOnly -> Right $ TxOutAdaOnly adaOnly lovelace
         Right multiAssetSupp -> Right $ TxOutValue multiAssetSupp $ lovelaceToValue lovelace
     TxOutValue  (_ :: MultiAssetSupportedInEra fromEra) value  ->
       case multiAssetSupportedInEra toEra of
-        Left _adaOnly -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Left _adaOnly -> Left $ EraCastError v fromEra' toEra
         Right multiAssetSupp -> Right $ TxOutValue multiAssetSupp value
 
 
@@ -1525,21 +1525,21 @@ deriving instance Eq   (TxOutDatum ctx era)
 deriving instance Show (TxOutDatum ctx era)
 
 instance EraCast (TxOutDatum ctx)  where
-  eraCast toEra v = case v of
+  eraCast toEra fromEra' v = case v of
     TxOutDatumNone -> pure TxOutDatumNone
     TxOutDatumHash (_ :: ScriptDataSupportedInEra fromEra) hash ->
       case scriptDataSupportedInEra toEra of
-        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Nothing -> Left $ EraCastError v fromEra' toEra
         Just sDatumsSupported ->
           Right $ TxOutDatumHash sDatumsSupported hash
     TxOutDatumInTx' (_ :: ScriptDataSupportedInEra fromEra) scriptData hash ->
       case scriptDataSupportedInEra toEra of
-        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Nothing -> Left $ EraCastError v fromEra' toEra
         Just sDatumsSupported ->
           Right $ TxOutDatumInTx' sDatumsSupported scriptData hash
     TxOutDatumInline (_ :: ReferenceTxInsScriptsInlineDatumsSupportedInEra fromEra) scriptData ->
       case refInsScriptsAndInlineDatsSupportedInEra toEra of
-        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Nothing -> Left $ EraCastError v fromEra' toEra
         Just refInsAndInlineSupported ->
           Right $ TxOutDatumInline refInsAndInlineSupported scriptData
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix EraCast Certificate instance. There is no straightforward way to handle the different certificates that are allowed/disallowed across an era boundary due to the use of type families in the Certificate era data type. Therefore currently we don't allow casting to other eras.
  # no-api-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: breaking
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: bugfix
```

# Context

Addititional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
