### PR TITLE
Fix `EraCast Certificate`

### DIFF
--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -15,6 +15,7 @@ module Cardano.Api.ReexposeLedger
   , StakePoolRelay(..)
   , PoolMetadata(..)
   , EraTxCert(..)
+  , StrictMaybe(..)
 
   -- Core
   , Coin (..)
@@ -54,7 +55,7 @@ module Cardano.Api.ReexposeLedger
 
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
 import           Cardano.Ledger.Api
-import           Cardano.Ledger.BaseTypes (DnsName, Url, boundRational, dnsToText,
+import           Cardano.Ledger.BaseTypes (DnsName, StrictMaybe (..), Url, boundRational, dnsToText,
                    maybeToStrictMaybe, portToWord16, strictMaybeToMaybe, textToDns, textToUrl,
                    unboundRational, urlToText)
 import           Cardano.Ledger.Coin (Coin (..), addDeltaCoin, toDeltaCoin)


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    Fix `EraCast Certificate`
  compatibility: no-api-changes
  type: bugfix
```

# Context

`EraCast Certificate` needs to be able to cast certificates between eras.

In future, the ledger will support this, however it is not available at the moment.

This PR implements the logic in `cardano-api`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
