### PR TITLE
Tighten era bounds of conway specific API to `ConwayEraOnwards`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -94,38 +94,45 @@ toSafeHash = makeHashWithExplicitProxys (Proxy @StandardCrypto) (Proxy @ByteStri
 toGovernanceAction
   :: EraCrypto ledgerera ~ StandardCrypto
   => ShelleyLedgerEra era ~ ledgerera
-  => ShelleyBasedEra era
+  => ConwayEraOnwards era
   -> GovernanceAction
   -> Gov.GovernanceAction ledgerera
-toGovernanceAction _ MotionOfNoConfidence = Gov.NoConfidence
-toGovernanceAction _ (ProposeNewConstitution bs) =
-  Gov.NewConstitution $ toSafeHash bs
-toGovernanceAction _ (ProposeNewCommittee stakeKeys quor) =
-  Gov.NewCommittee (Set.fromList $ map (\(StakeKeyHash sk) -> coerceKeyRole sk) stakeKeys) quor
-toGovernanceAction _ InfoAct = Gov.InfoAction
-toGovernanceAction _ (TreasuryWithdrawal withdrawals) =
-  let m = Map.fromList [(toShelleyStakeCredential sc, toShelleyLovelace l) | (sc,l) <- withdrawals]
-  in Gov.TreasuryWithdrawals m
-toGovernanceAction _ (InitiateHardfork pVer) = Gov.HardForkInitiation pVer
-toGovernanceAction sbe (UpdatePParams ppup) =
-  case toLedgerPParamsUpdate sbe ppup of
-    Left e -> error $ "toGovernanceAction: " <> show e
-    -- TODO: Conway era - remove use of error. Ideally we will use the ledger's PParams type
-    -- in place of ProtocolParametersUpdate
-    Right ppup' -> Gov.ParameterChange ppup'
+toGovernanceAction w = \case
+  MotionOfNoConfidence ->
+    Gov.NoConfidence
+  ProposeNewConstitution bs ->
+    Gov.NewConstitution $ toSafeHash bs
+  ProposeNewCommittee stakeKeys quor ->
+    Gov.NewCommittee (Set.fromList $ map (\(StakeKeyHash sk) -> coerceKeyRole sk) stakeKeys) quor
+  InfoAct ->
+    Gov.InfoAction
+  TreasuryWithdrawal withdrawals ->
+    let m = Map.fromList [(toShelleyStakeCredential sc, toShelleyLovelace l) | (sc,l) <- withdrawals]
+    in Gov.TreasuryWithdrawals m
+  InitiateHardfork pVer ->
+    Gov.HardForkInitiation pVer
+  UpdatePParams ppup->
+    case toLedgerPParamsUpdate (conwayEraOnwardsToShelleyBasedEra w) ppup of
+      Left e -> error $ "toGovernanceAction: " <> show e
+      -- TODO: Conway era - remove use of error. Ideally we will use the ledger's PParams type
+      -- in place of ProtocolParametersUpdate
+      Right ppup' -> Gov.ParameterChange ppup'
 
 fromGovernanceAction
   :: EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
-  => ShelleyBasedEra era
+  => ConwayEraOnwards era
   -> Gov.GovernanceAction (ShelleyLedgerEra era)
   -> GovernanceAction
-fromGovernanceAction sbe = \case
+fromGovernanceAction w = \case
   Gov.NoConfidence ->
     MotionOfNoConfidence
   Gov.NewConstitution h ->
-    ProposeNewConstitution $ shelleyBasedEraConstraints sbe $ originalBytes h
+    ProposeNewConstitution
+      $ conwayEraOnwardsConstraints w
+      $ originalBytes h
   Gov.ParameterChange pparams ->
-    UpdatePParams $ fromLedgerPParamsUpdate sbe pparams
+    UpdatePParams
+      $ fromLedgerPParamsUpdate (conwayEraOnwardsToShelleyBasedEra w) pparams
   Gov.HardForkInitiation pVer ->
     InitiateHardfork pVer
   Gov.TreasuryWithdrawals withdrawlMap ->
@@ -168,26 +175,26 @@ instance HasTypeProxy era => HasTypeProxy (Proposal era) where
 
 
 createProposalProcedure
-  :: ShelleyBasedEra era
+  :: ConwayEraOnwards era
   -> Lovelace -- ^ Deposit
   -> Hash StakeKey -- ^ Return address
   -> GovernanceAction
   -> Proposal era
-createProposalProcedure sbe dep (StakeKeyHash retAddrh) govAct =
-  shelleyBasedEraConstraints sbe $ shelleyBasedEraConstraints sbe $
+createProposalProcedure w dep (StakeKeyHash retAddrh) govAct =
+  conwayEraOnwardsConstraints w $
     Proposal Gov.ProposalProcedure
       { Gov.pProcDeposit = toShelleyLovelace dep
       , Gov.pProcReturnAddr = retAddrh
-      , Gov.pProcGovernanceAction = toGovernanceAction sbe govAct
+      , Gov.pProcGovernanceAction = toGovernanceAction w govAct
       , Gov.pProcAnchor = SNothing -- TODO: Conway
       }
 
 fromProposalProcedure
-  :: ShelleyBasedEra era
+  :: ConwayEraOnwards era
   -> Proposal era
   -> (Lovelace, Hash StakeKey, GovernanceAction)
-fromProposalProcedure sbe (Proposal pp) =
+fromProposalProcedure w (Proposal pp) =
   ( fromShelleyLovelace $ Gov.pProcDeposit pp
-  , StakeKeyHash (shelleyBasedEraConstraints sbe (Gov.pProcReturnAddr pp))
-  , shelleyBasedEraConstraints sbe $ fromGovernanceAction sbe (Gov.pProcGovernanceAction pp)
+  , StakeKeyHash (conwayEraOnwardsConstraints w (Gov.pProcReturnAddr pp))
+  , conwayEraOnwardsConstraints w $ fromGovernanceAction w (Gov.pProcGovernanceAction pp)
   )


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    <insert-changelog-description-here>
# uncomment types applicable to the change:
  type:
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
