### PR TITLE
Bump CHaP to cardano-ledger-conway-1.7.0.0

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-07-12"
+      CABAL_CACHE_VERSION: "2023-07-13"
 
     concurrency:
       group: >

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-06T23:58:58Z
-  , cardano-haskell-packages 2023-08-04T17:03:07Z
+  , cardano-haskell-packages 2023-08-21T16:55:07Z
 
 packages:
     cardano-api
@@ -41,3 +41,4 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -130,7 +130,7 @@ library internal
                       , bytestring
                       , cardano-binary
                       , cardano-crypto
-                      , cardano-crypto-class >= 2.1.1
+                      , cardano-crypto-class ^>= 2.1.2
                       , cardano-crypto-wrapper ^>= 1.5
                       , cardano-data >= 1.0
                       , cardano-ledger-alonzo >= 1.3.1.1
@@ -161,7 +161,7 @@ library internal
                       , network
                       , optparse-applicative-fork
                       , ouroboros-consensus >= 0.9
-                      , ouroboros-consensus-cardano >= 0.7
+                      , ouroboros-consensus-cardano >= 0.8
                       , ouroboros-consensus-diffusion >= 0.7
                       , ouroboros-consensus-protocol >= 0.5.0.4
                       , ouroboros-network
@@ -169,9 +169,9 @@ library internal
                       , ouroboros-network-framework
                       , ouroboros-network-protocols
                       , parsec
-                      , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>= 1.7
+                      , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>= 1.9
                       , prettyprinter
-                      , prettyprinter-configurable ^>= 1.7
+                      , prettyprinter-configurable ^>= 1.9
                       , random
                       , scientific
                       , serialise
@@ -210,7 +210,7 @@ library
                       , cardano-api:internal
                       , cardano-binary
                       , cardano-crypto
-                      , cardano-crypto-class >= 2.1.1
+                      , cardano-crypto-class ^>= 2.1.2
                       , cryptonite
                       , deepseq
                       , memory
@@ -239,7 +239,7 @@ library gen
                       , cardano-api
                       , cardano-api:internal
                       , cardano-binary >= 1.6 && < 1.8
-                      , cardano-crypto-class ^>= 2.1
+                      , cardano-crypto-class ^>= 2.1.2
                       , cardano-crypto-test ^>= 1.5
                       , cardano-ledger-alonzo >= 1.3.1.1
                       , cardano-ledger-alonzo-test
@@ -268,7 +268,7 @@ test-suite cardano-api-test
                       , cardano-api:gen
                       , cardano-api:internal
                       , cardano-crypto
-                      , cardano-crypto-class ^>= 2.1
+                      , cardano-crypto-class ^>= 2.1.2
                       , cardano-crypto-test ^>= 1.5
                       , cardano-crypto-tests ^>= 2.1
                       , cardano-ledger-api >= 1.3
@@ -317,7 +317,7 @@ test-suite cardano-api-golden
                       , cardano-api
                       , cardano-api:gen
                       , cardano-binary
-                      , cardano-crypto-class
+                      , cardano-crypto-class ^>= 2.1.2
                       , cardano-data >= 1.0
                       , cardano-ledger-alonzo
                       , cardano-ledger-api >= 1.3
@@ -331,8 +331,8 @@ test-suite cardano-api-golden
                       , hedgehog >= 1.1
                       , hedgehog-extras ^>= 0.4.7.0
                       , microlens
-                      , plutus-core ^>= 1.7
-                      , plutus-ledger-api ^>= 1.7
+                      , plutus-core ^>= 1.9
+                      , plutus-ledger-api ^>= 1.9
                       , tasty
                       , tasty-hedgehog
                       , time

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -127,6 +127,7 @@ import           Cardano.Api hiding (txIns)
 import qualified Cardano.Api as Api
 import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness),
                    WitnessNetworkIdOrByronAddress (..))
+import           Cardano.Api.Governance.Actions.VotingProcedure
 import           Cardano.Api.Script (scriptInEraToRefScript)
 import           Cardano.Api.Shelley
 
@@ -147,6 +148,7 @@ import qualified Data.ByteString.Short as SBS
 import           Data.Coerce
 import           Data.Int (Int64)
 import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import           Data.Ratio (Ratio, (%))
 import           Data.String
@@ -1125,7 +1127,18 @@ genTxVotes :: CardanoEra era -> Gen (TxVotes era)
 genTxVotes era = fromMaybe (pure TxVotesNone) $ do
   w <- featureInEra Nothing Just era
   let votes = Gen.list (Range.constant 0 10) $ genVote w
-  pure $ TxVotes w <$> votes
+  pure $ TxVotes w . Map.fromList <$> votes
   where
-    genVote :: ConwayEraOnwards era -> Gen (VotingProcedure era)
-    genVote w = conwayEraOnwardsConstraints w $ VotingProcedure <$> Q.arbitrary
+    genVote
+      :: ConwayEraOnwards era
+      -> Gen ( (Voter era, GovernanceActionId era)
+             , VotingProcedure era
+             )
+    genVote w =
+        conwayEraOnwardsConstraints w $
+        (,)
+          <$> ((,)
+                 <$> (fromVoterRole (conwayEraOnwardsToShelleyBasedEra w) <$> Q.arbitrary)
+                 <*> (GovernanceActionId <$> Q.arbitrary)
+              )
+          <*> (VotingProcedure <$> Q.arbitrary)

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -72,7 +72,6 @@ import qualified Cardano.Ledger.Crypto as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 import           Cardano.Ledger.Mary.Value (MaryValue)
 import qualified Cardano.Ledger.Shelley.API.Wallet as Ledger (evaluateTransactionFee)
-import           Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody)
 import           Cardano.Ledger.UTxO as Ledger (EraUTxO)
 import qualified Ouroboros.Consensus.HardFork.History as Consensus
 import qualified PlutusLedgerApi.V1 as Plutus
@@ -611,7 +610,16 @@ evaluateTransactionExecutionUnitsShelley sbe systemstart epochInfo pp utxo tx' =
         -- This should not occur while using cardano-cli because we zip together
         -- the Plutus script and the use site (txin, certificate etc). Therefore
         -- the redeemer pointer will always point to a Plutus script.
-        L.MissingScript rdmrPtr resolveable -> ScriptErrorMissingScript rdmrPtr (ResolvablePointers sbe resolveable)
+        L.MissingScript rdmrPtr resolveable ->
+          let cnv1 Alonzo.Plutus
+                { Alonzo.plutusLanguage = lang
+                , Alonzo.plutusScript = Alonzo.BinaryPlutus bytes
+                } = (bytes, lang)
+              cnv2 (purpose, mbScript, scriptHash) = (purpose, fmap cnv1 mbScript, scriptHash)
+          in
+            ScriptErrorMissingScript rdmrPtr
+          $ ResolvablePointers sbe
+          $ Map.map cnv2 resolveable
 
         L.NoCostModelInLedgerState l -> ScriptErrorMissingCostModel l
 
@@ -664,7 +672,6 @@ evaluateTransactionBalance pp poolids stakeDelegDeposits utxo
 
     evalMultiAsset :: forall ledgerera.
                       ShelleyLedgerEra era ~ ledgerera
-                   => ShelleyEraTxBody ledgerera
                    => LedgerEraConstraints ledgerera
                    => LedgerMultiAssetConstraints ledgerera
                    => MultiAssetSupportedInEra era
@@ -680,7 +687,6 @@ evaluateTransactionBalance pp poolids stakeDelegDeposits utxo
 
     evalAdaOnly :: forall ledgerera.
                    ShelleyLedgerEra era ~ ledgerera
-                => ShelleyEraTxBody ledgerera
                 => LedgerEraConstraints ledgerera
                 => LedgerAdaOnlyConstraints ledgerera
                 => OnlyAdaSupportedInEra era

--- a/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
@@ -683,7 +683,7 @@ instance HasTypeProxy CommitteeHotKey where
 instance Key CommitteeHotKey where
 
     newtype VerificationKey CommitteeHotKey =
-        CommitteeHotVerificationKey (Shelley.VKey Shelley.CommitteeHotKey StandardCrypto)
+        CommitteeHotVerificationKey (Shelley.VKey Shelley.HotCommitteeRole StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey CommitteeHotKey)
       deriving newtype (ToCBOR, FromCBOR)
@@ -734,7 +734,7 @@ instance SerialiseAsRawBytes (SigningKey CommitteeHotKey) where
 
 
 newtype instance Hash CommitteeHotKey =
-    CommitteeHotKeyHash (Shelley.KeyHash Shelley.CommitteeHotKey StandardCrypto)
+    CommitteeHotKeyHash (Shelley.KeyHash Shelley.HotCommitteeRole StandardCrypto)
   deriving stock (Eq, Ord)
   deriving (Show, IsString) via UsingRawBytesHex (Hash CommitteeHotKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash CommitteeHotKey)
@@ -791,7 +791,7 @@ instance HasTypeProxy CommitteeColdKey where
 instance Key CommitteeColdKey where
 
     newtype VerificationKey CommitteeColdKey =
-        CommitteeColdVerificationKey (Shelley.VKey Shelley.CommitteeColdKey StandardCrypto)
+        CommitteeColdVerificationKey (Shelley.VKey Shelley.ColdCommitteeRole StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey CommitteeColdKey)
       deriving newtype (ToCBOR, FromCBOR)
@@ -842,7 +842,7 @@ instance SerialiseAsRawBytes (SigningKey CommitteeColdKey) where
 
 
 newtype instance Hash CommitteeColdKey =
-    CommitteeColdKeyHash (Shelley.KeyHash Shelley.CommitteeColdKey StandardCrypto)
+    CommitteeColdKeyHash (Shelley.KeyHash Shelley.ColdCommitteeRole StandardCrypto)
   deriving stock (Eq, Ord)
   deriving (Show, IsString) via UsingRawBytesHex (Hash CommitteeColdKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash CommitteeColdKey)
@@ -1498,7 +1498,7 @@ instance HasTypeProxy DRepKey where
 instance Key DRepKey where
 
     newtype VerificationKey DRepKey =
-        DRepVerificationKey (Shelley.VKey Shelley.Voting StandardCrypto)
+        DRepVerificationKey (Shelley.VKey Shelley.DRepRole StandardCrypto)
       deriving stock (Eq)
       deriving (Show, IsString) via UsingRawBytesHex (VerificationKey DRepKey)
       deriving newtype (ToCBOR, FromCBOR)
@@ -1557,7 +1557,7 @@ instance SerialiseAsBech32 (SigningKey DRepKey) where
     bech32PrefixesPermitted _ = ["drep_sk"]
 
 newtype instance Hash DRepKey =
-    DRepKeyHash { unDRepKeyHash :: Shelley.KeyHash Shelley.Voting StandardCrypto }
+    DRepKeyHash { unDRepKeyHash :: Shelley.KeyHash Shelley.DRepRole StandardCrypto }
   deriving stock (Eq, Ord)
   deriving (Show, IsString) via UsingRawBytesHex (Hash DRepKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash DRepKey)

--- a/cardano-api/internal/Cardano/Api/Orphans.hs
+++ b/cardano-api/internal/Cardano/Api/Orphans.hs
@@ -20,6 +20,7 @@ import qualified Cardano.Ledger.Alonzo.PParams as Ledger
 import qualified Cardano.Ledger.Babbage.PParams as Ledger
 import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Conway.PParams as Ledger
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
 import qualified Cardano.Ledger.Crypto as Crypto
@@ -291,3 +292,37 @@ instance Semigroup (Ledger.BabbagePParams StrictMaybe era) where
          , Ledger.bppCollateralPercentage = fbppCollateralPercentage
          , Ledger.bppMaxCollateralInputs = fbppMaxCollateralInputs
          }
+
+instance Semigroup (Ledger.ConwayPParams StrictMaybe era) where
+  (<>) p1 p2 = Ledger.ConwayPParams
+    { Ledger.cppMinFeeA = Ledger.cppMinFeeA p1 `lastMappend` Ledger.cppMinFeeA p2
+    , Ledger.cppMinFeeB = Ledger.cppMinFeeB p1 `lastMappend` Ledger.cppMinFeeB p2
+    , Ledger.cppMaxBBSize = Ledger.cppMaxBBSize p1 `lastMappend` Ledger.cppMaxBBSize p2
+    , Ledger.cppMaxTxSize = Ledger.cppMaxTxSize p1 `lastMappend` Ledger.cppMaxTxSize p2
+    , Ledger.cppMaxBHSize = Ledger.cppMaxBHSize p1 `lastMappend` Ledger.cppMaxBHSize p2
+    , Ledger.cppKeyDeposit = Ledger.cppKeyDeposit p1 `lastMappend` Ledger.cppKeyDeposit p2
+    , Ledger.cppPoolDeposit = Ledger.cppPoolDeposit p1 `lastMappend` Ledger.cppPoolDeposit p2
+    , Ledger.cppEMax = Ledger.cppEMax p1 `lastMappend` Ledger.cppEMax p2
+    , Ledger.cppNOpt = Ledger.cppNOpt p1 `lastMappend` Ledger.cppNOpt p2
+    , Ledger.cppA0 = Ledger.cppA0 p1 `lastMappend` Ledger.cppA0 p2
+    , Ledger.cppRho = Ledger.cppRho p1 `lastMappend` Ledger.cppRho p2
+    , Ledger.cppTau = Ledger.cppTau p1 `lastMappend` Ledger.cppTau p2
+    , Ledger.cppProtocolVersion = Ledger.cppProtocolVersion p1 `lastMappend` Ledger.cppProtocolVersion p2
+    , Ledger.cppMinPoolCost = Ledger.cppMinPoolCost p1 `lastMappend` Ledger.cppMinPoolCost p2
+    , Ledger.cppCoinsPerUTxOByte = Ledger.cppCoinsPerUTxOByte p1 `lastMappend` Ledger.cppCoinsPerUTxOByte p2
+    , Ledger.cppCostModels = Ledger.cppCostModels p1 `lastMappend` Ledger.cppCostModels p2
+    , Ledger.cppPrices = Ledger.cppPrices p1 `lastMappend` Ledger.cppPrices p2
+    , Ledger.cppMaxTxExUnits = Ledger.cppMaxTxExUnits p1 `lastMappend` Ledger.cppMaxTxExUnits p2
+    , Ledger.cppMaxBlockExUnits = Ledger.cppMaxBlockExUnits p1 `lastMappend` Ledger.cppMaxBlockExUnits p2
+    , Ledger.cppMaxValSize = Ledger.cppMaxValSize p1 `lastMappend` Ledger.cppMaxValSize p2
+    , Ledger.cppCollateralPercentage = Ledger.cppCollateralPercentage p1 `lastMappend` Ledger.cppCollateralPercentage p2
+    , Ledger.cppMaxCollateralInputs = Ledger.cppMaxCollateralInputs p1 `lastMappend` Ledger.cppMaxCollateralInputs p2
+    , Ledger.cppPoolVotingThresholds = Ledger.cppPoolVotingThresholds p1 `lastMappend` Ledger.cppPoolVotingThresholds p2
+    , Ledger.cppDRepVotingThresholds = Ledger.cppDRepVotingThresholds p1 `lastMappend` Ledger.cppDRepVotingThresholds p2
+    , Ledger.cppMinCommitteeSize = Ledger.cppMinCommitteeSize p1 `lastMappend` Ledger.cppMinCommitteeSize p2
+    , Ledger.cppCommitteeTermLimit = Ledger.cppCommitteeTermLimit p1 `lastMappend` Ledger.cppCommitteeTermLimit p2
+    , Ledger.cppGovActionExpiration = Ledger.cppGovActionExpiration p1 `lastMappend` Ledger.cppGovActionExpiration p2
+    , Ledger.cppGovActionDeposit = Ledger.cppGovActionDeposit p1 `lastMappend` Ledger.cppGovActionDeposit p2
+    , Ledger.cppDRepDeposit = Ledger.cppDRepDeposit p1 `lastMappend` Ledger.cppDRepDeposit p2
+    , Ledger.cppDRepActivity = Ledger.cppDRepActivity p1 `lastMappend` Ledger.cppDRepActivity p2
+    }

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -94,12 +94,11 @@ import           Cardano.Api.TxBody
 import           Cardano.Api.Value
 
 import qualified Cardano.Chain.Update.Validation.Interface as Byron.Update
+import qualified Cardano.Ledger.Api as L
 import           Cardano.Ledger.Binary
 import qualified Cardano.Ledger.Binary.Plain as Plain
-import           Cardano.Ledger.Core (EraCrypto)
 import qualified Cardano.Ledger.Credential as Shelley
 import           Cardano.Ledger.Crypto (Crypto)
-import           Cardano.Ledger.SafeHash (SafeHash)
 import qualified Cardano.Ledger.Shelley.API as Shelley
 import qualified Cardano.Ledger.Shelley.Core as Core
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
@@ -131,7 +130,6 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import           Data.Aeson.Types (Parser)
 import           Data.Bifunctor (bimap, first)
-import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Either.Combinators (rightToMaybe)
 import qualified Data.HashMap.Strict as HMS
@@ -297,8 +295,8 @@ data QueryInShelleyBasedEra era result where
     :: Set StakeCredential
     -> QueryInShelleyBasedEra era (Map StakeCredential Lovelace)
 
-  QueryConstitutionHash
-    :: QueryInShelleyBasedEra era (Maybe (SafeHash (EraCrypto (ShelleyLedgerEra era)) ByteString))
+  QueryConstitution
+    :: QueryInShelleyBasedEra era (Maybe (L.Constitution (ShelleyLedgerEra era)))
 
 
 instance NodeToClientVersionOf (QueryInShelleyBasedEra era result) where
@@ -318,7 +316,7 @@ instance NodeToClientVersionOf (QueryInShelleyBasedEra era result) where
   nodeToClientVersionOf (QueryPoolDistribution _) = NodeToClientV_14
   nodeToClientVersionOf (QueryStakeSnapshot _) = NodeToClientV_14
   nodeToClientVersionOf (QueryStakeDelegDeposits _) = NodeToClientV_15
-  nodeToClientVersionOf QueryConstitutionHash = NodeToClientV_15
+  nodeToClientVersionOf QueryConstitution = NodeToClientV_15
 
 deriving instance Show (QueryInShelleyBasedEra era result)
 
@@ -583,8 +581,8 @@ toConsensusQueryShelleyBased
 toConsensusQueryShelleyBased erainmode QueryEpoch =
     Some (consensusQueryInEraInMode erainmode Consensus.GetEpochNo)
 
-toConsensusQueryShelleyBased erainmode QueryConstitutionHash =
-    Some (consensusQueryInEraInMode erainmode Consensus.GetConstitutionHash)
+toConsensusQueryShelleyBased erainmode QueryConstitution =
+    Some (consensusQueryInEraInMode erainmode Consensus.GetConstitution)
 
 toConsensusQueryShelleyBased erainmode QueryGenesisParameters =
     Some (consensusQueryInEraInMode erainmode Consensus.GetGenesisConfig)
@@ -824,9 +822,9 @@ fromConsensusQueryResultShelleyBased _ QueryEpoch q' epoch =
       Consensus.GetEpochNo -> epoch
       _                    -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased _ QueryConstitutionHash q' mCHash =
+fromConsensusQueryResultShelleyBased _ QueryConstitution q' mConstitution =
     case q' of
-      Consensus.GetConstitutionHash -> mCHash
+      Consensus.GetConstitution -> mConstitution
       _                    -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResultShelleyBased _ QueryGenesisParameters q' r' =

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -42,12 +42,12 @@ import           Cardano.Api.Query
 import           Cardano.Api.Value
 
 import qualified Cardano.Ledger.Api as L
+import           Cardano.Ledger.Core (EraCrypto)
 import           Cardano.Ledger.SafeHash
 import           Cardano.Slotting.Slot
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as Consensus
 
 import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
-import           Data.ByteString
 import           Data.Map (Map)
 import           Data.Set (Set)
 
@@ -133,9 +133,10 @@ queryProtocolParameters eraInMode sbe =
 queryConstitutionHash :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (SafeHash (L.EraCrypto (ShelleyLedgerEra era)) ByteString))))
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (SafeHash (EraCrypto (ShelleyLedgerEra era)) L.AnchorData))))
 queryConstitutionHash eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryConstitutionHash
+  (fmap . fmap . fmap . fmap) (L.anchorDataHash .  L.constitutionAnchor)
+    $ queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryConstitution
 
 queryProtocolParametersUpdate :: ()
   => EraInMode era mode

--- a/cardano-api/internal/Cardano/Api/Query/Types.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Types.hs
@@ -38,7 +38,7 @@ data DebugLedgerState era where
 instance
     ( Typeable era
     , Core.EraTxOut (ShelleyLedgerEra era)
-    , Core.EraGovernance (ShelleyLedgerEra era)
+    , Core.EraGov (ShelleyLedgerEra era)
     , DecCBOR (Shelley.StashedAVVMAddresses (ShelleyLedgerEra era))
     ) => FromCBOR (DebugLedgerState era) where
   fromCBOR = DebugLedgerState <$>

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -19,6 +19,8 @@ module Cardano.Api.ReexposeLedger
 
   -- Core
   , Coin (..)
+  , EraCrypto
+  , Network(..)
   , PoolCert(..)
   , addDeltaCoin
   , toDeltaCoin
@@ -28,9 +30,9 @@ module Cardano.Api.ReexposeLedger
   -- Conway
   , DRep(..)
   , ConwayTxCert(..)
-  , ConwayCommitteeCert(..)
   , ConwayDelegCert(..)
   , ConwayEraTxCert(..)
+  , ConwayGovCert(..)
 
   -- Base
   , boundRational
@@ -55,13 +57,13 @@ module Cardano.Api.ReexposeLedger
 
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
 import           Cardano.Ledger.Api
-import           Cardano.Ledger.BaseTypes (DnsName, StrictMaybe (..), Url, boundRational, dnsToText,
-                   maybeToStrictMaybe, portToWord16, strictMaybeToMaybe, textToDns, textToUrl,
-                   unboundRational, urlToText)
+import           Cardano.Ledger.BaseTypes (DnsName, Network (..), StrictMaybe (..), Url,
+                   boundRational, dnsToText, maybeToStrictMaybe, portToWord16, strictMaybeToMaybe,
+                   textToDns, textToUrl, unboundRational, urlToText)
 import           Cardano.Ledger.Coin (Coin (..), addDeltaCoin, toDeltaCoin)
-import           Cardano.Ledger.Conway.TxCert (ConwayCommitteeCert (..), ConwayDelegCert (..),
-                   ConwayEraTxCert (..), ConwayTxCert (..))
-import           Cardano.Ledger.Core (DRep (..), PoolCert (..), fromEraCBOR, toEraCBOR)
+import           Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..), ConwayEraTxCert (..),
+                   ConwayGovCert (..), ConwayTxCert (..))
+import           Cardano.Ledger.Core (DRep (..), EraCrypto, PoolCert (..), fromEraCBOR, toEraCBOR)
 import           Cardano.Ledger.Credential (Credential (..))
 import           Cardano.Ledger.Keys (HasKeyRole (..), KeyHash (..), KeyRole (..))
 import           Cardano.Ledger.PoolParams (PoolMetadata (..), PoolParams (..), StakePoolRelay (..))

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -287,6 +287,7 @@ module Cardano.Api (
     TxMintValue(..),
     TxVotes(..),
     TxGovernanceActions(..),
+    VotingEntry(..),
 
     -- ** Building vs viewing transactions
     BuildTxWith(..),
@@ -961,6 +962,7 @@ import           Cardano.Api.Fees
 import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters
 import           Cardano.Api.Governance.Actions.ProposalProcedure
+import           Cardano.Api.Governance.Actions.VotingEntry
 import           Cardano.Api.Governance.Actions.VotingProcedure
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -192,6 +192,12 @@ module Cardano.Api.Shelley
       ),
     EpochNo(..),
 
+    -- * Governance Actions
+    createAnchor,
+    createPreviousGovernanceActionId,
+    createGovernanceActionId,
+    unsafeBytesToSafeHash,
+
     -- * DRep
     DRepMetadata(DRepMetadata),
     DRepMetadataReference(DRepMetadataReference),
@@ -261,7 +267,6 @@ module Cardano.Api.Shelley
     Voter(..),
     createProposalProcedure,
     createVotingProcedure,
-    makeGoveranceActionId,
     renderGovernancePollError,
     toVotingCredential,
     fromProposalProcedure,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1688739041,
-        "narHash": "sha256-1ji5gb5c7e/dMvwMIGjNfkDF1AOCMVdiFrSN+xUQpzw=",
+        "lastModified": 1692639433,
+        "narHash": "sha256-EBtyW1h7prisB4JfI4lUwvxWA9EBrYTnNaDzzInaPKg=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "ba9bfea00fa468dc4c18de2ab0b7d3c7cb4a35ef",
+        "rev": "b16f5ccf6ead743987b54af4593db032d862e168",
         "type": "github"
       },
       "original": {
@@ -359,11 +359,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1685607784,
-        "narHash": "sha256-ZewBEw5+/3DfuBYym+3XWQZbZRFvtng1Y0tlahfhohc=",
+        "lastModified": 1691469905,
+        "narHash": "sha256-TV0p1dFGYAMl1dLJEfe/tNFjxvV2H7VgHU1I43q+b84=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "e4b4589168c6abc698c49faba130dda65d908051",
+        "rev": "2f3760f135616ebc477d3ed74eba9b63c22f83a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Updating the ledger dependency to cardano-ledger-conway-1.7.0.0:
      Many superficial renamings
      TxVotes carries a map now
      ResolvablePointers now has a different representation than does the ledger
      ProposalNewCommitee requires the old committee's credentials
      The ProposalNewConstitution case of toGovernanceAction was hashing the argument'ByteString, but it was already a hash.
      See temporarilyOptOutOfPrevGovAction
      makeGovernanceActionId was reusing the transaction id as the governance action id, but the types no longer allow that.
      Semigroup oprhan was missing for ConwayPParams
      QueryConstitutionHash phantom type is now more specific
      Cardano.Ledger.Api no longer export EraCrypto
      Introduced (internal) pattern synonyms for scripts to coverup a change in the corresponding ledger types.

# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Updating the ledger dependency to the work-in-progress `cardano-ledger-conway-1.7.0.0` (via a `source-repository-package` for now) required the following.

- Many superficial renamings
- `TxVotes` carries a map now
- `ResolvablePointers` now has a different representation than does the ledger
- `ProposalNewCommitee` requires the old committee's credentials
- The `ProposalNewConstitution` case of `toGovernanceAction` was hashing the argument`'ByteString`, but it was already a hash.
- See `temporarilyOptOutOfPrevGovAction`
- Many more `TODO`s throughout the code due to new partiality/missing arguments/etc
- `makeGovernanceActionId` was reusing the transaction id as the governance action id, but the types no longer allow that.
- `Semigroup` oprhan was missing for `ConwayPParams`
- `QueryConstitutionHash` phantom type is now more specific
- `Cardano.Ledger.Api` no longer export `EraCrypto`
- Introduced (internal) pattern synonyms for scripts to coverup a change in the corresponding ledger types.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
