### PR TITLE
Rename `ExecutionUnitPrices` to `LegacyExecutionUnitPrices`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -52,7 +52,7 @@ module Test.Gen.Cardano.Api.Typed
   , genAssetName
   , genAssetId
   , genEpochNo
-  , genExecutionUnitPrices
+  , genLegacyExecutionUnitPrices
   , genExecutionUnits
   , genHashScriptData
   , genKESPeriod
@@ -922,7 +922,7 @@ genProtocolParameters era = do
   protocolParamCostModels <- pure mempty
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
-  protocolParamPrices <- Gen.maybe genExecutionUnitPrices
+  protocolParamPrices <- Gen.maybe genLegacyExecutionUnitPrices
   protocolParamMaxTxExUnits <- Gen.maybe genExecutionUnits
   protocolParamMaxBlockExUnits <- Gen.maybe genExecutionUnits
   protocolParamMaxValueSize <- Gen.maybe genNat
@@ -959,7 +959,7 @@ genValidProtocolParameters era =
     --TODO: Babbage figure out how to deal with
     -- asymmetric cost model JSON instances
     -- 'Just' is required by checks in Cardano.Api.ProtocolParameters
-    <*> fmap Just genExecutionUnitPrices
+    <*> fmap Just genLegacyExecutionUnitPrices
     <*> fmap Just genExecutionUnits
     <*> fmap Just genExecutionUnits
     <*> fmap Just genNat
@@ -990,7 +990,7 @@ genProtocolParametersUpdate era = do
   let protocolUpdateCostModels = mempty -- genCostModels
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
-  protocolUpdatePrices              <- Gen.maybe genExecutionUnitPrices
+  protocolUpdatePrices              <- Gen.maybe genLegacyExecutionUnitPrices
   protocolUpdateMaxTxExUnits        <- Gen.maybe genExecutionUnits
   protocolUpdateMaxBlockExUnits     <- Gen.maybe genExecutionUnits
   protocolUpdateMaxValueSize        <- Gen.maybe genNat
@@ -1036,8 +1036,8 @@ genExecutionUnits :: Gen ExecutionUnits
 genExecutionUnits = ExecutionUnits <$> Gen.integral (Range.constant 0 1000)
                                    <*> Gen.integral (Range.constant 0 1000)
 
-genExecutionUnitPrices :: Gen ExecutionUnitPrices
-genExecutionUnitPrices = ExecutionUnitPrices <$> genRational <*> genRational
+genLegacyExecutionUnitPrices :: Gen LegacyExecutionUnitPrices
+genLegacyExecutionUnitPrices = LegacyExecutionUnitPrices <$> genRational <*> genRational
 
 genTxOutDatumHashTxContext :: CardanoEra era -> Gen (TxOutDatum CtxTx era)
 genTxOutDatumHashTxContext era = case era of

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -59,7 +59,7 @@ module Cardano.Api.ProtocolParameters (
 
     -- * Execution units, prices and cost models,
     ExecutionUnits(..),
-    ExecutionUnitPrices(..),
+    LegacyExecutionUnitPrices(..),
     CostModel(..),
     fromAlonzoCostModels,
 
@@ -545,7 +545,7 @@ data ProtocolParameters =
        -- | Price of execution units for script languages that use them.
        --
        -- /Introduced in Alonzo/
-       protocolParamPrices :: Maybe ExecutionUnitPrices,
+       protocolParamPrices :: Maybe LegacyExecutionUnitPrices,
 
        -- | Max total script execution resources units allowed per tx
        --
@@ -784,7 +784,7 @@ data ProtocolParametersUpdate =
        -- | Price of execution units for script languages that use them.
        --
        -- /Introduced in Alonzo/
-       protocolUpdatePrices :: Maybe ExecutionUnitPrices,
+       protocolUpdatePrices :: Maybe LegacyExecutionUnitPrices,
 
        -- | Max total script execution resources units allowed per tx
        --
@@ -1043,42 +1043,42 @@ fromLedgerNonce (Ledger.Nonce h)    = Just (PraosNonce (Crypto.castHash h))
 -- These are used to determine the fee for the use of a script within a
 -- transaction, based on the 'ExecutionUnits' needed by the use of the script.
 --
-data ExecutionUnitPrices =
-     ExecutionUnitPrices {
+data LegacyExecutionUnitPrices =
+     LegacyExecutionUnitPrices {
        priceExecutionSteps  :: Rational,
        priceExecutionMemory :: Rational
      }
   deriving (Eq, Show)
 
-instance ToCBOR ExecutionUnitPrices where
-  toCBOR ExecutionUnitPrices{priceExecutionSteps, priceExecutionMemory} =
+instance ToCBOR LegacyExecutionUnitPrices where
+  toCBOR LegacyExecutionUnitPrices{priceExecutionSteps, priceExecutionMemory} =
       CBOR.encodeListLen 2
    <> toCBOR priceExecutionSteps
    <> toCBOR priceExecutionMemory
 
-instance FromCBOR ExecutionUnitPrices where
+instance FromCBOR LegacyExecutionUnitPrices where
   fromCBOR = do
-    CBOR.enforceSize "ExecutionUnitPrices" 2
-    ExecutionUnitPrices
+    CBOR.enforceSize "LegacyExecutionUnitPrices" 2
+    LegacyExecutionUnitPrices
       <$> fromCBOR
       <*> fromCBOR
 
-instance ToJSON ExecutionUnitPrices where
-  toJSON ExecutionUnitPrices{priceExecutionSteps, priceExecutionMemory} =
+instance ToJSON LegacyExecutionUnitPrices where
+  toJSON LegacyExecutionUnitPrices{priceExecutionSteps, priceExecutionMemory} =
     object [ "priceSteps"  .= toRationalJSON priceExecutionSteps
            , "priceMemory" .= toRationalJSON priceExecutionMemory
            ]
 
-instance FromJSON ExecutionUnitPrices where
+instance FromJSON LegacyExecutionUnitPrices where
   parseJSON =
-    withObject "ExecutionUnitPrices" $ \o ->
-      ExecutionUnitPrices
+    withObject "LegacyExecutionUnitPrices" $ \o ->
+      LegacyExecutionUnitPrices
         <$> o .: "priceSteps"
         <*> o .: "priceMemory"
 
 
-toAlonzoPrices :: ExecutionUnitPrices -> Either ProtocolParametersConversionError Alonzo.Prices
-toAlonzoPrices ExecutionUnitPrices {
+toAlonzoPrices :: LegacyExecutionUnitPrices -> Either ProtocolParametersConversionError Alonzo.Prices
+toAlonzoPrices LegacyExecutionUnitPrices {
                  priceExecutionSteps,
                  priceExecutionMemory
                } = do
@@ -1089,9 +1089,9 @@ toAlonzoPrices ExecutionUnitPrices {
     Alonzo.prMem
   }
 
-fromAlonzoPrices :: Alonzo.Prices -> ExecutionUnitPrices
+fromAlonzoPrices :: Alonzo.Prices -> LegacyExecutionUnitPrices
 fromAlonzoPrices Alonzo.Prices{Alonzo.prSteps, Alonzo.prMem} =
-  ExecutionUnitPrices {
+  LegacyExecutionUnitPrices {
     priceExecutionSteps  = Ledger.unboundRational prSteps,
     priceExecutionMemory = Ledger.unboundRational prMem
   }

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -4326,7 +4326,7 @@ genesisUTxOPseudoTxIn nw (GenesisUTxOKeyHash kh) =
              (Shelley.KeyHashObj kh)
              Shelley.StakeRefNull
 
-calculateExecutionUnitsLovelace :: ExecutionUnitPrices -> ExecutionUnits -> Maybe Lovelace
+calculateExecutionUnitsLovelace :: LegacyExecutionUnitPrices -> ExecutionUnits -> Maybe Lovelace
 calculateExecutionUnitsLovelace euPrices eUnits =
   case toAlonzoPrices euPrices of
     Left _ -> Nothing

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -522,7 +522,7 @@ module Cardano.Api (
 
     -- ** Script execution units
     ExecutionUnits(..),
-    ExecutionUnitPrices(..),
+    LegacyExecutionUnitPrices(..),
     CostModel(..),
     toAlonzoCostModel,
     fromAlonzoCostModel,

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -112,7 +112,6 @@ module Cardano.Api.Shelley
     -- * Protocol parameters
     EraBasedProtocolParametersUpdate(..),
     AlonzoOnwardsPParams(..),
-    CommonProtocolParameters(..),
     DeprecatedAfterMaryPParams(..),
     ShelleyToAlonzoPParams(..),
     ShelleyToAlonzoPParams'(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Rename `ExecutionUnitPrices` to `LegacyExecutionUnitPrices`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The `ExecutionUnitPrices` type was not a thin newtype wrapper around the ledger type and furthermore conversion to the ledger type can fail so one could not easily round trip.

The PR renames that type to `LegacyExecutionUnitPrices` and introduce a new `ExecutionUnitPrices` type that is a thing newtype wrapper.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
