### PR TITLE
Fix parameterisation of `GovernanceActionId`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
@@ -55,15 +55,15 @@ data TxVotes era where
 deriving instance Show (TxVotes era)
 deriving instance Eq (TxVotes era)
 
-newtype GovernanceActionId ledgerera = GovernanceActionId
-  { unGovernanceActionId :: Ledger.GovernanceActionId (EraCrypto ledgerera)
+newtype GovernanceActionId era = GovernanceActionId
+  { unGovernanceActionId :: Ledger.GovernanceActionId (EraCrypto (ShelleyLedgerEra era))
   }
   deriving (Show, Eq)
 
 makeGoveranceActionId
   :: ShelleyBasedEra era
   -> TxIn
-  -> GovernanceActionId (ShelleyLedgerEra era)
+  -> GovernanceActionId era
 makeGoveranceActionId sbe txin =
   let Ledger.TxIn txid (Ledger.TxIx txix) = toShelleyTxIn txin
   in shelleyBasedEraConstraints sbe
@@ -146,7 +146,7 @@ createVotingProcedure
   :: ShelleyBasedEra era
   -> Vote
   -> Voter era
-  -> GovernanceActionId (ShelleyLedgerEra era)
+  -> GovernanceActionId era
   -> VotingProcedure era
 createVotingProcedure sbe vChoice vt (GovernanceActionId govActId) =
   shelleyBasedEraConstraints sbe $ shelleyBasedEraConstraints sbe


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix parameterisation of `GovernanceActionId`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The `GovernanceActionId` `newtype` was parameterised on `ledgerera` which is wrong.  It is inconsistent with other newtypes and later on in the new ledger integration branch, it interferes with the introduction of `ToCBOR` and `FromCBOR` instances that are needed to store this data in the vote file.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
