### PR TITLE
New `VotingEntry` type

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -67,6 +67,7 @@ library internal
                         Cardano.Api.Genesis
                         Cardano.Api.GenesisParameters
                         Cardano.Api.Governance.Actions.ProposalProcedure
+                        Cardano.Api.Governance.Actions.VotingEntry
                         Cardano.Api.Governance.Actions.VotingProcedure
                         Cardano.Api.Governance.Poll
                         Cardano.Api.Hash

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/VotingEntry.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/VotingEntry.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Governance.Actions.VotingEntry where
+
+import           Cardano.Api.Address
+import           Cardano.Api.Eras
+import           Cardano.Api.Governance.Actions.VotingProcedure
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.SerialiseCBOR (FromCBOR (fromCBOR), SerialiseAsCBOR (..),
+                   ToCBOR (toCBOR))
+import           Cardano.Api.SerialiseTextEnvelope
+
+import qualified Cardano.Binary as CBOR
+
+-- TODO Conway: Ledger needs to provide this triplet as a type.  Once that is done,
+-- this needs to be converted to a newtype wrapper around that type.  This will allow
+-- us to delegate the ToCBOR and FromCBOR instances to the ledger where it can be
+-- specified in the cddl spec.
+data VotingEntry era = VotingEntry
+  { votingEntryVoter            :: Voter era
+  , votingEntryGovActionId      :: GovernanceActionId era
+  , votingEntryVotingProcedure  :: VotingProcedure era
+  } deriving (Show, Eq)
+
+instance IsShelleyBasedEra era => ToCBOR (VotingEntry era) where
+  toCBOR = \case
+    VotingEntry a b c ->
+      CBOR.encodeListLen 3
+        <> toCBOR a
+        <> toCBOR b
+        <> toCBOR c
+
+  encodedSizeExpr size _ =
+    1
+    + size (Proxy @(Voter era))
+    + size (Proxy @(GovernanceActionId era))
+    + size (Proxy @(VotingProcedure era))
+
+instance IsShelleyBasedEra era => FromCBOR (VotingEntry era) where
+  fromCBOR = do
+    CBOR.decodeListLenOf 3
+    !votingEntryVoter <- fromCBOR
+    !votingEntryGovActionId <- fromCBOR
+    !votingEntryVotingProcedure <- fromCBOR
+    return VotingEntry
+      { votingEntryVoter
+      , votingEntryGovActionId
+      , votingEntryVotingProcedure
+      }
+
+instance IsShelleyBasedEra era => SerialiseAsCBOR (VotingEntry era) where
+  serialiseToCBOR = shelleyBasedEraConstraints (shelleyBasedEra @era) CBOR.serialize'
+  deserialiseFromCBOR _proxy = shelleyBasedEraConstraints (shelleyBasedEra @era) CBOR.decodeFull'
+
+instance IsShelleyBasedEra era => HasTextEnvelope (VotingEntry era) where
+  textEnvelopeType _ = "Governance voting entry"
+
+instance HasTypeProxy era => HasTypeProxy (VotingEntry era) where
+  data AsType (VotingEntry era) = AsVotingEntry
+  proxyToAsType _ = AsVotingEntry


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New `VotingEntry` type
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

In a future version of `cardano-ledger`, the voter and governance action id have been moved out of voting procedure so we require a type to carry the triplet for serialisation.  `VotingEntry` will be that new type.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
