### PR TITLE
Add consensus governance queries

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-07-13"
+      CABAL_CACHE_VERSION: "2023-08-22"
 
     concurrency:
       group: >

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -1,16 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
-{-# LANGUAGE TypeOperators #-}
-
-
 -- | Cardano eras, sometimes we have to distinguish them.
 --
 module Cardano.Api.Eras

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -74,6 +74,7 @@ type ConwayEraOnwardsConstraints era ledgerera =
   , L.Crypto (L.EraCrypto ledgerera)
   , L.Era ledgerera
   , L.EraCrypto ledgerera ~ L.StandardCrypto
+  , L.EraGov ledgerera
   , L.EraPParams ledgerera
   , L.EraTx ledgerera
   , L.EraTxBody ledgerera

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -48,6 +48,7 @@ module Cardano.Api.ReexposeLedger
   , ConwayDelegCert(..)
   , ConwayEraTxCert(..)
   , ConwayGovCert(..)
+  , GovState
   , GovActionId(..)
   , Vote (..)
   , Voter (..)
@@ -93,8 +94,8 @@ import           Cardano.Ledger.BaseTypes (DnsName, Network (..), StrictMaybe (.
                    boundRational, dnsToText, maybeToStrictMaybe, portToWord16, strictMaybeToMaybe,
                    textToDns, textToUrl, unboundRational, urlToText)
 import           Cardano.Ledger.Coin (Coin (..), addDeltaCoin, toDeltaCoin)
-import           Cardano.Ledger.Conway.Governance (GovActionId (..), Vote (..), Voter (..),
-                   VotingProcedure (..))
+import           Cardano.Ledger.Conway.Governance (GovActionId (..), GovState, Vote (..),
+                   Voter (..), VotingProcedure (..))
 import           Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..), ConwayEraTxCert (..),
                    ConwayGovCert (..), ConwayTxCert (..), Delegatee (..))
 import           Cardano.Ledger.Core (DRep (..), EraCrypto, PParams (..), PoolCert (..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -923,6 +923,11 @@ module Cardano.Api (
     querySystemStart,
     queryUtxo,
     determineEraExpr,
+    queryConstitution,
+    queryGovState,
+    queryDRepState,
+    queryDRepStakeDistribution,
+    queryCommitteeState,
 
     -- ** DReps
     DRepKey,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Expose following queries from consensus:
      - GetGovState
      - GetDRepState
      - GetDRepStakeDistr
      - GetCommitteeState
      - GetConstitution
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context
Implement consensus queries, similarly to: https://github.com/input-output-hk/cardano-ledger/pull/3648

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
