### PR TITLE
Release 8.15.0.0

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,0 @@
-import           Distribution.Simple
-main = defaultMain

--- a/cardano-api-gen/CHANGELOG.md
+++ b/cardano-api-gen/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for cardano-api-gen
 
+## 8.2.0.0
+
+- Deprecate `TxVotesSupportedInEra`
+  (feature; breaking)
+  [PR 154](https://github.com/input-output-hk/cardano-api/pull/154)
+
+- Expose functions for errors messages testing in golden files
+  (feature; compatible)
+  [PR 126](https://github.com/input-output-hk/cardano-api/pull/126)
+
 ## 8.1.1.1
 
 - Add a `HasTypeProxy` constraint to `getVerificationKey`

--- a/cardano-api-gen/cardano-api-gen.cabal
+++ b/cardano-api-gen/cardano-api-gen.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-api-gen
-version:                8.1.1.1
+version:                8.2.0.0
 synopsis:               Generators for the cardano api
 description:            Generators for the cardano api.
 category:               Cardano,

--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog for cardano-api
 
+## 8.15.0.0
+
+- Updating the ledger dependency to cardano-ledger-conway-1.7.0.0:
+    Many superficial renamings
+    TxVotes carries a map now
+    ResolvablePointers now has a different representation than does the ledger
+    ProposalNewCommitee requires the old committee's credentials
+    The ProposalNewConstitution case of toGovernanceAction was hashing the argument'ByteString, but it was already a hash.
+    See temporarilyOptOutOfPrevGovAction
+    makeGovernanceActionId was reusing the transaction id as the governance action id, but the types no longer allow that.
+    Semigroup oprhan was missing for ConwayPParams
+    QueryConstitutionHash phantom type is now more specific
+    Cardano.Ledger.Api no longer export EraCrypto
+    Introduced (internal) pattern synonyms for scripts to coverup a change in the corresponding ledger types.
+  (feature, breaking)
+  [PR 179](https://github.com/input-output-hk/cardano-api/pull/179)
+
+- New `VotingEntry` type
+  (compatible)
+  [PR 194](https://github.com/input-output-hk/cardano-api/pull/194)
+
+- Fix parameterisation of `GovernanceActionId`
+  (breaking)
+  [PR 192](https://github.com/input-output-hk/cardano-api/pull/192)
+
+- Implement createPParams and begin propagating Ledger.PParams in cardano-api
+  (feature)
+  [PR 190](https://github.com/input-output-hk/cardano-api/pull/190)
+
+- Delete deprecated functions and types
+  (improvement)
+  [PR 173](https://github.com/input-output-hk/cardano-api/pull/173)
+
 ## 8.14.0.0
 
 - Fix parameterisation of `GovernanceActionId`

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-api
-version:                8.14.0.0
+version:                8.15.0.0
 synopsis:               The cardano api
 description:            The cardano api.
 category:               Cardano,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release 8.15.0.0
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
   - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
