### PR TITLE
RELEASING.md cosmetic changes

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,9 +36,12 @@ This part requires user to have the following tools installed on your local mach
 * https://jqlang.github.io/jq/
 * https://mikefarah.gitbook.io/yq/
 
+>[!NOTE]
+> Steps which are only required when performing this process for the first time are marked with :four_leaf_clover: .
+
 In order to generate changelog files in markdown format use the following steps:
 
-1. *When doing this guide for the first time:* Clone the `cardano-dev` repo at the same level as `cardano-api`:
+1. :four_leaf_clover: Clone the `cardano-dev` repo at the same level as `cardano-api`:
     ```bash
     git clone https://github.com/input-output-hk/cardano-dev
     ```
@@ -104,7 +107,7 @@ After the `cardano-api` version gets tagged, it needs to be pushed into `cardano
 Detailed description of the release process is described in [CHaP repository README](https://github.com/input-output-hk/cardano-haskell-packages#how-to-add-a-new-package-version).
 Briefly speaking, it requires executing of the following steps:
 
-1. Clone `cardano-haskell-packages`:
+1. :four_leaf_clover:  Clone `cardano-haskell-packages`:
     ```bash
     git clone git@github.com:input-output-hk/cardano-haskell-packages.git
     cd cardano-haskell-packages
@@ -130,3 +133,5 @@ After package gets released, you can check the released version at: https://inpu
 1. https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md
 1. https://input-output-hk.github.io/cardano-haskell-packages/index.html
 1. https://input-output-hk.github.io/cardano-engineering-handbook/policy/haskell/packaging/versioning.html
+
+<!-- vim: set spell textwidth=0: -->


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    RELEASING.md cosmetic changes
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
   - documentation  # change in code docs, haddocks...
```

# Context

Rendered: https://github.com/input-output-hk/cardano-api/blob/mgalazyn/doc/add-info-about-updating-flake-lock/RELEASING.md

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
