### PR TITLE
WIP Facility to represent mandatory fields some eras

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -63,6 +63,7 @@ library internal
                         Cardano.Api.Error
                         Cardano.Api.Feature
                         Cardano.Api.Feature.AlonzoEraOnwards
+                        Cardano.Api.Feature.BabbageEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -65,6 +65,7 @@ library internal
                         Cardano.Api.Feature.ConwayEraOnwards
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra
+                        Cardano.Api.Feature.ShelleyToMaryEra
                         Cardano.Api.Fees
                         Cardano.Api.Genesis
                         Cardano.Api.GenesisParameters

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -57,11 +57,14 @@ library internal
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast
                         Cardano.Api.Eras
+                        Cardano.Api.Eras.Complement
                         Cardano.Api.Eras.Constraints
                         Cardano.Api.Eras.Core
                         Cardano.Api.Eras.InAnyEra
+                        Cardano.Api.Eras.Mandatory
                         Cardano.Api.Error
                         Cardano.Api.Feature
+                        Cardano.Api.Feature.AlonzoEraOnly
                         Cardano.Api.Feature.AlonzoEraOnwards
                         Cardano.Api.Feature.BabbageEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -63,6 +63,7 @@ library internal
                         Cardano.Api.Error
                         Cardano.Api.Feature
                         Cardano.Api.Feature.ConwayEraOnwards
+                        Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra
                         Cardano.Api.Fees
                         Cardano.Api.Genesis

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -59,6 +59,7 @@ library internal
                         Cardano.Api.Eras
                         Cardano.Api.Eras.Constraints
                         Cardano.Api.Eras.Core
+                        Cardano.Api.Eras.InAnyEra
                         Cardano.Api.Error
                         Cardano.Api.Feature
                         Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -62,6 +62,7 @@ library internal
                         Cardano.Api.Eras.InAnyEra
                         Cardano.Api.Error
                         Cardano.Api.Feature
+                        Cardano.Api.Feature.AlonzoEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -65,6 +65,7 @@ library internal
                         Cardano.Api.Feature.AlonzoEraOnwards
                         Cardano.Api.Feature.BabbageEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards
+                        Cardano.Api.Feature.ShelleyToAllegraEra
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra
                         Cardano.Api.Feature.ShelleyToMaryEra

--- a/cardano-api/internal/Cardano/Api/Address.hs
+++ b/cardano-api/internal/Cardano/Api/Address.hs
@@ -78,7 +78,7 @@ module Cardano.Api.Address (
   ) where
 
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Byron

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -51,7 +51,8 @@ module Cardano.Api.Block (
     makeChainTip,
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -73,7 +73,8 @@ module Cardano.Api.Certificate (
 import           Cardano.Api.Address
 import           Cardano.Api.DRepMetadata
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Governance.Actions.VotingProcedure

--- a/cardano-api/internal/Cardano/Api/Convenience/Constraints.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Constraints.hs
@@ -8,7 +8,7 @@ module Cardano.Api.Convenience.Constraints (
   ) where
 
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 
 getIsCardanoEraConstraint :: CardanoEra era -> (IsCardanoEra era => a) -> a
 getIsCardanoEraConstraint ByronEra f = f

--- a/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
@@ -15,7 +15,7 @@ module Cardano.Api.Convenience.Construction (
 
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Fees
 import           Cardano.Api.Query
 import qualified Cardano.Api.ReexposeLedger as Ledger

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -16,7 +16,7 @@ module Cardano.Api.Convenience.Query (
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Convenience.Constraints
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.IO
 import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Monad

--- a/cardano-api/internal/Cardano/Api/DRepMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/DRepMetadata.hs
@@ -15,7 +15,7 @@ module Cardano.Api.DRepMetadata (
     Hash(..),
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -26,6 +26,7 @@ module Cardano.Api.Eras
   , maybeFeatureInEra
   , featureInShelleyBasedEra
   , inShelleyBasedEraFeature
+  , InAnyEra(..)
 
     -- * Deprecated aliases
   , Byron
@@ -61,3 +62,4 @@ module Cardano.Api.Eras
 
 import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.Eras.Core
+import           Cardano.Api.Eras.InAnyEra

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -9,6 +9,8 @@ module Cardano.Api.Eras
   , AlonzoEra
   , BabbageEra
   , ConwayEra
+
+    -- * CardanoEra
   , CardanoEra(..)
   , IsCardanoEra(..)
   , AnyCardanoEra(..)
@@ -16,6 +18,7 @@ module Cardano.Api.Eras
   , cardanoEraConstraints
   , InAnyCardanoEra(..)
   , CardanoLedgerEra
+  , ToCardanoEra(..)
 
     -- * FeatureInEra
   , FeatureInEra(..)

--- a/cardano-api/internal/Cardano/Api/Eras/Complement.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Complement.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Eras.Complement
+  ( HasComplement(..)
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToBabbageEra
+
+import           Data.Kind
+
+class HasComplement (whole :: Type -> Type) (part :: Type -> Type) where
+  type Complement whole part :: Type -> Type
+
+instance HasComplement ShelleyBasedEra ConwayEraOnwards where
+  type Complement ShelleyBasedEra ConwayEraOnwards = ShelleyToBabbageEra
+
+instance HasComplement ShelleyBasedEra ShelleyToBabbageEra where
+  type Complement ShelleyBasedEra ShelleyToBabbageEra = ConwayEraOnwards

--- a/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
@@ -52,20 +52,20 @@ cardanoEraConstraints = \case
   BabbageEra -> id
   ConwayEra  -> id
 
-type ShelleyBasedEraConstraints era ledgerera =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto ledgerera))
-  , C.Signable (L.VRF (L.EraCrypto ledgerera)) L.Seed
+type ShelleyBasedEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) ledgerera
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto ledgerera)
-  , L.Era ledgerera
-  , L.EraCrypto ledgerera ~ L.StandardCrypto
-  , L.EraPParams ledgerera
-  , L.EraTx ledgerera
-  , L.EraTxBody ledgerera
-  , L.HashAnnotated (L.TxBody ledgerera) L.EraIndependentTxBody L.StandardCrypto
-  , L.ShelleyEraTxBody ledgerera
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
@@ -76,9 +76,8 @@ type ShelleyBasedEraConstraints era ledgerera =
   )
 
 shelleyBasedEraConstraints :: ()
-  => ShelleyLedgerEra era ~ ledgerera
   => ShelleyBasedEra era
-  -> (ShelleyBasedEraConstraints era ledgerera => a)
+  -> (ShelleyBasedEraConstraints era => a)
   -> a
 shelleyBasedEraConstraints = \case
   ShelleyBasedEraShelley -> id
@@ -90,8 +89,7 @@ shelleyBasedEraConstraints = \case
 
 -- Deprecated: Use shelleyBasedEraConstraints instead.
 withShelleyBasedEraConstraintsForLedger :: ()
-  => ShelleyLedgerEra era ~ ledgerera
   => ShelleyBasedEra era
-  -> (ShelleyBasedEraConstraints era ledgerera => a)
+  -> (ShelleyBasedEraConstraints era => a)
   -> a
 withShelleyBasedEraConstraintsForLedger = shelleyBasedEraConstraints

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -20,12 +20,15 @@ module Cardano.Api.Eras.Core
   , AlonzoEra
   , BabbageEra
   , ConwayEra
+
+    -- * CardanoEra
   , CardanoEra(..)
   , IsCardanoEra(..)
   , AnyCardanoEra(..)
   , anyCardanoEra
   , InAnyCardanoEra(..)
   , CardanoLedgerEra
+  , ToCardanoEra(..)
 
     -- * FeatureInEra
   , FeatureInEra(..)
@@ -180,6 +183,14 @@ inShelleyBasedEraFeature era no yes =
   featureInShelleyBasedEra no yes era
 
 -- ----------------------------------------------------------------------------
+-- ToCardanoEra
+
+class ToCardanoEra (feature :: Type -> Type) where
+  toCardanoEra :: ()
+    => feature era
+    -> CardanoEra era
+
+-- ----------------------------------------------------------------------------
 -- Deprecated aliases
 --
 
@@ -267,6 +278,8 @@ instance TestEquality CardanoEra where
     testEquality ConwayEra  ConwayEra  = Just Refl
     testEquality _          _          = Nothing
 
+instance ToCardanoEra CardanoEra where
+  toCardanoEra = id
 
 -- | The class of Cardano eras. This allows uniform handling of all Cardano
 -- eras, but also non-uniform by making case distinctions on the 'CardanoEra'
@@ -378,7 +391,6 @@ data InAnyCardanoEra thing where
                      -> thing era
                      -> InAnyCardanoEra thing
 
-
 -- ----------------------------------------------------------------------------
 -- Shelley-based eras
 --
@@ -423,6 +435,15 @@ instance TestEquality ShelleyBasedEra where
     testEquality ShelleyBasedEraBabbage ShelleyBasedEraBabbage = Just Refl
     testEquality ShelleyBasedEraConway  ShelleyBasedEraConway  = Just Refl
     testEquality _                      _                      = Nothing
+
+instance ToCardanoEra ShelleyBasedEra where
+  toCardanoEra = \case
+    ShelleyBasedEraShelley -> ShelleyEra
+    ShelleyBasedEraAllegra -> AllegraEra
+    ShelleyBasedEraMary    -> MaryEra
+    ShelleyBasedEraAlonzo  -> AlonzoEra
+    ShelleyBasedEraBabbage -> BabbageEra
+    ShelleyBasedEraConway  -> ConwayEra
 
 -- | The class of eras that are based on Shelley. This allows uniform handling
 -- of Shelley-based eras, but also non-uniform by making case distinctions on

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -1,13 +1,9 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Cardano eras, sometimes we have to distinguish them.
 --

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -274,6 +274,9 @@ instance TestEquality CardanoEra where
     testEquality ConwayEra  ConwayEra  = Just Refl
     testEquality _          _          = Nothing
 
+instance FeatureInEra CardanoEra where
+  featureInEra _ yes = yes
+
 instance ToCardanoEra CardanoEra where
   toCardanoEra = id
 
@@ -431,6 +434,16 @@ instance TestEquality ShelleyBasedEra where
     testEquality ShelleyBasedEraBabbage ShelleyBasedEraBabbage = Just Refl
     testEquality ShelleyBasedEraConway  ShelleyBasedEraConway  = Just Refl
     testEquality _                      _                      = Nothing
+
+instance FeatureInEra ShelleyBasedEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyBasedEraShelley
+    AllegraEra  -> yes ShelleyBasedEraAllegra
+    MaryEra     -> yes ShelleyBasedEraMary
+    AlonzoEra   -> yes ShelleyBasedEraAlonzo
+    BabbageEra  -> yes ShelleyBasedEraBabbage
+    ConwayEra   -> yes ShelleyBasedEraConway
 
 instance ToCardanoEra ShelleyBasedEra where
   toCardanoEra = \case

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -30,6 +30,8 @@ module Cardano.Api.Eras.Core
   , FeatureInEra(..)
   , inEraFeature
   , maybeFeatureInEra
+  , justFeatureInEra
+  , justInEraFeature
   , featureInShelleyBasedEra
   , inShelleyBasedEraFeature
 
@@ -158,6 +160,20 @@ maybeFeatureInEra :: ()
   -> Maybe (feature era)  -- ^ The feature if supported in the era
 maybeFeatureInEra =
   featureInEra Nothing Just
+
+justFeatureInEra :: ()
+  => FeatureInEra feature
+  => (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  -> CardanoEra era       -- ^ Era to check
+  -> Maybe a              -- ^ The value to use
+justFeatureInEra f = featureInEra Nothing (Just . f)
+
+justInEraFeature :: ()
+  => FeatureInEra feature
+  => CardanoEra era       -- ^ Era to check
+  -> (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  -> Maybe a              -- ^ The value to use
+justInEraFeature era f = inEraFeature era Nothing (Just . f)
 
 -- | Determine the value to use for a feature in a given 'ShelleyBasedEra'.
 featureInShelleyBasedEra :: ()

--- a/cardano-api/internal/Cardano/Api/Eras/InAnyEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/InAnyEra.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+
+module Cardano.Api.Eras.InAnyEra
+  ( InAnyEra(..)
+  ) where
+
+import           Data.Kind
+
+-- | This pairs up some era-dependent type with a 'feature' value that tells
+-- us what feature involves, but hides the era type.
+data InAnyEra (feature :: Type -> Type) (t :: Type -> Type) where
+  InAnyEra :: feature era -> t era -> InAnyEra feature t

--- a/cardano-api/internal/Cardano/Api/Eras/Mandatory.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Mandatory.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.Api.Eras.Mandatory
+  ( Mandatory(..)
+  , mandatoryInEra
+  ) where
+
+import           Cardano.Api.Eras.Complement
+
+data Mandatory whole feature era a where
+  Mandatory :: feature era -> a -> Mandatory whole feature era a
+  Absent :: (Complement whole feature) era -> Mandatory whole feature era a
+
+mandatoryInEra :: (Complement whole feature era -> b) -> (feature era -> a -> b) -> Mandatory whole feature era a -> b
+mandatoryInEra no yes = \case
+  Mandatory feature a -> yes feature a
+  Absent c -> no c

--- a/cardano-api/internal/Cardano/Api/Feature.hs
+++ b/cardano-api/internal/Cardano/Api/Feature.hs
@@ -11,7 +11,7 @@ module Cardano.Api.Feature
   , asFeaturedInShelleyBasedEra
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 
 -- | A value only if the feature is supported in this era
 data Featured feature era a where

--- a/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnly.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.AlonzoEraOnly
+  ( AlonzoEraOnly(..)
+  , IsAlonzoEraOnly(..)
+  , AnyAlonzoEraOnly(..)
+  , alonzoEraOnlyConstraints
+  , alonzoEraOnlyToCardanoEra
+  , alonzoEraOnlyToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsAlonzoEraOnly era where
+  alonzoEraOnly :: AlonzoEraOnly era
+
+data AlonzoEraOnly era where
+  AlonzoEraOnlyAlonzo  :: AlonzoEraOnly AlonzoEra
+
+deriving instance Show (AlonzoEraOnly era)
+deriving instance Eq (AlonzoEraOnly era)
+
+instance IsAlonzoEraOnly AlonzoEra where
+  alonzoEraOnly = AlonzoEraOnlyAlonzo
+
+instance FeatureInEra AlonzoEraOnly where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> yes AlonzoEraOnlyAlonzo
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra AlonzoEraOnly where
+  toCardanoEra = \case
+    AlonzoEraOnlyAlonzo  -> AlonzoEra
+
+data AnyAlonzoEraOnly where
+  AnyAlonzoEraOnly :: AlonzoEraOnly era -> AnyAlonzoEraOnly
+
+deriving instance Show AnyAlonzoEraOnly
+
+type AlonzoEraOnlyConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.AlonzoEraPParams (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.ExactEra L.AlonzoEra (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsAlonzoEraOnly era
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+alonzoEraOnlyConstraints :: ()
+  => AlonzoEraOnly era
+  -> (AlonzoEraOnlyConstraints era => a)
+  -> a
+alonzoEraOnlyConstraints = \case
+  AlonzoEraOnlyAlonzo  -> id
+
+alonzoEraOnlyToCardanoEra :: AlonzoEraOnly era -> CardanoEra era
+alonzoEraOnlyToCardanoEra = shelleyBasedToCardanoEra . alonzoEraOnlyToShelleyBasedEra
+
+alonzoEraOnlyToShelleyBasedEra :: AlonzoEraOnly era -> ShelleyBasedEra era
+alonzoEraOnlyToShelleyBasedEra = \case
+  AlonzoEraOnlyAlonzo  -> ShelleyBasedEraAlonzo

--- a/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnwards.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.AlonzoEraOnwards
+  ( AlonzoEraOnwards(..)
+  , IsAlonzoEraOnwards(..)
+  , AnyAlonzoEraOnwards(..)
+  , alonzoEraOnwardsConstraints
+  , alonzoEraOnwardsToCardanoEra
+  , alonzoEraOnwardsToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsAlonzoEraOnwards era where
+  alonzoEraOnwards :: AlonzoEraOnwards era
+
+data AlonzoEraOnwards era where
+  AlonzoEraOnwardsAlonzo  :: AlonzoEraOnwards AlonzoEra
+  AlonzoEraOnwardsBabbage :: AlonzoEraOnwards BabbageEra
+  AlonzoEraOnwardsConway  :: AlonzoEraOnwards ConwayEra
+
+deriving instance Show (AlonzoEraOnwards era)
+deriving instance Eq (AlonzoEraOnwards era)
+
+instance IsAlonzoEraOnwards AlonzoEra where
+  alonzoEraOnwards = AlonzoEraOnwardsAlonzo
+
+instance IsAlonzoEraOnwards BabbageEra where
+  alonzoEraOnwards = AlonzoEraOnwardsBabbage
+
+instance IsAlonzoEraOnwards ConwayEra where
+  alonzoEraOnwards = AlonzoEraOnwardsConway
+
+instance FeatureInEra AlonzoEraOnwards where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> yes AlonzoEraOnwardsAlonzo
+    BabbageEra  -> yes AlonzoEraOnwardsBabbage
+    ConwayEra   -> yes AlonzoEraOnwardsConway
+
+instance ToCardanoEra AlonzoEraOnwards where
+  toCardanoEra = \case
+    AlonzoEraOnwardsAlonzo  -> AlonzoEra
+    AlonzoEraOnwardsBabbage -> BabbageEra
+    AlonzoEraOnwardsConway  -> ConwayEra
+
+data AnyAlonzoEraOnwards where
+  AnyAlonzoEraOnwards :: AlonzoEraOnwards era -> AnyAlonzoEraOnwards
+
+deriving instance Show AnyAlonzoEraOnwards
+
+type AlonzoEraOnwardsConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.AlonzoEraPParams (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsAlonzoEraOnwards era
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+alonzoEraOnwardsConstraints :: ()
+  => AlonzoEraOnwards era
+  -> (AlonzoEraOnwardsConstraints era => a)
+  -> a
+alonzoEraOnwardsConstraints = \case
+  AlonzoEraOnwardsAlonzo  -> id
+  AlonzoEraOnwardsBabbage -> id
+  AlonzoEraOnwardsConway  -> id
+
+alonzoEraOnwardsToCardanoEra :: AlonzoEraOnwards era -> CardanoEra era
+alonzoEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . alonzoEraOnwardsToShelleyBasedEra
+
+alonzoEraOnwardsToShelleyBasedEra :: AlonzoEraOnwards era -> ShelleyBasedEra era
+alonzoEraOnwardsToShelleyBasedEra = \case
+  AlonzoEraOnwardsAlonzo  -> ShelleyBasedEraAlonzo
+  AlonzoEraOnwardsBabbage -> ShelleyBasedEraBabbage
+  AlonzoEraOnwardsConway  -> ShelleyBasedEraConway

--- a/cardano-api/internal/Cardano/Api/Feature/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/BabbageEraOnwards.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.BabbageEraOnwards
+  ( BabbageEraOnwards(..)
+  , IsBabbageEraOnwards(..)
+  , AnyBabbageEraOnwards(..)
+  , babbageEraOnwardsConstraints
+  , babbageEraOnwardsToCardanoEra
+  , babbageEraOnwardsToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsBabbageEraOnwards era where
+  babbageEraOnwards :: BabbageEraOnwards era
+
+data BabbageEraOnwards era where
+  BabbageEraOnwardsBabbage :: BabbageEraOnwards BabbageEra
+  BabbageEraOnwardsConway  :: BabbageEraOnwards ConwayEra
+
+deriving instance Show (BabbageEraOnwards era)
+deriving instance Eq (BabbageEraOnwards era)
+
+instance IsBabbageEraOnwards BabbageEra where
+  babbageEraOnwards = BabbageEraOnwardsBabbage
+
+instance IsBabbageEraOnwards ConwayEra where
+  babbageEraOnwards = BabbageEraOnwardsConway
+
+instance FeatureInEra BabbageEraOnwards where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> yes BabbageEraOnwardsBabbage
+    ConwayEra   -> yes BabbageEraOnwardsConway
+
+instance ToCardanoEra BabbageEraOnwards where
+  toCardanoEra = \case
+    BabbageEraOnwardsBabbage -> BabbageEra
+    BabbageEraOnwardsConway  -> ConwayEra
+
+data AnyBabbageEraOnwards where
+  AnyBabbageEraOnwards :: BabbageEraOnwards era -> AnyBabbageEraOnwards
+
+deriving instance Show AnyBabbageEraOnwards
+
+type BabbageEraOnwardsConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.BabbageEraPParams (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsBabbageEraOnwards era
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+babbageEraOnwardsConstraints :: ()
+  => BabbageEraOnwards era
+  -> (BabbageEraOnwardsConstraints era => a)
+  -> a
+babbageEraOnwardsConstraints = \case
+  BabbageEraOnwardsBabbage -> id
+  BabbageEraOnwardsConway  -> id
+
+babbageEraOnwardsToCardanoEra :: BabbageEraOnwards era -> CardanoEra era
+babbageEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . babbageEraOnwardsToShelleyBasedEra
+
+babbageEraOnwardsToShelleyBasedEra :: BabbageEraOnwards era -> ShelleyBasedEra era
+babbageEraOnwardsToShelleyBasedEra = \case
+  BabbageEraOnwardsBabbage -> ShelleyBasedEraBabbage
+  BabbageEraOnwardsConway  -> ShelleyBasedEraConway

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -16,7 +16,7 @@ module Cardano.Api.Feature.ConwayEraOnwards
   , conwayEraOnwardsToShelleyBasedEra
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
 import           Cardano.Api.Query.Types
 
@@ -57,6 +57,10 @@ instance FeatureInEra ConwayEraOnwards where
     AlonzoEra   -> no
     BabbageEra  -> no
     ConwayEra   -> yes ConwayEraOnwardsConway
+
+instance ToCardanoEra ConwayEraOnwards where
+  toCardanoEra = \case
+    ConwayEraOnwardsConway -> ConwayEra
 
 data AnyConwayEraOnwards where
   AnyConwayEraOnwards :: ConwayEraOnwards era -> AnyConwayEraOnwards

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToAllegraEra.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.ShelleyToAllegraEra
+  ( ShelleyToAllegraEra(..)
+  , IsShelleyToAllegraEra(..)
+  , AnyShelleyToAllegraEra(..)
+  , shelleyToAllegraEraConstraints
+  , shelleyToAllegraEraToCardanoEra
+  , shelleyToAllegraEraToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsShelleyToAllegraEra era where
+  shelleyToAllegraEra :: ShelleyToAllegraEra era
+
+data ShelleyToAllegraEra era where
+  ShelleyToAllegraEraShelley :: ShelleyToAllegraEra ShelleyEra
+  ShelleyToAllegraEraAllegra :: ShelleyToAllegraEra AllegraEra
+
+deriving instance Show (ShelleyToAllegraEra era)
+deriving instance Eq (ShelleyToAllegraEra era)
+
+instance IsShelleyToAllegraEra ShelleyEra where
+  shelleyToAllegraEra = ShelleyToAllegraEraShelley
+
+instance IsShelleyToAllegraEra AllegraEra where
+  shelleyToAllegraEra = ShelleyToAllegraEraAllegra
+
+instance FeatureInEra ShelleyToAllegraEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToAllegraEraShelley
+    AllegraEra  -> yes ShelleyToAllegraEraAllegra
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyToAllegraEra where
+  toCardanoEra = \case
+    ShelleyToAllegraEraShelley  -> ShelleyEra
+    ShelleyToAllegraEraAllegra  -> AllegraEra
+
+type ShelleyToAllegraEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 4
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , IsShelleyToAllegraEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+data AnyShelleyToAllegraEra where
+  AnyShelleyToAllegraEra :: ShelleyToAllegraEra era -> AnyShelleyToAllegraEra
+
+deriving instance Show AnyShelleyToAllegraEra
+
+shelleyToAllegraEraConstraints :: ()
+  => ShelleyToAllegraEra era
+  -> (ShelleyToAllegraEraConstraints era => a)
+  -> a
+shelleyToAllegraEraConstraints = \case
+  ShelleyToAllegraEraShelley -> id
+  ShelleyToAllegraEraAllegra -> id
+
+shelleyToAllegraEraToCardanoEra :: ShelleyToAllegraEra era -> CardanoEra era
+shelleyToAllegraEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToAllegraEraToShelleyBasedEra
+
+shelleyToAllegraEraToShelleyBasedEra :: ShelleyToAllegraEra era -> ShelleyBasedEra era
+shelleyToAllegraEraToShelleyBasedEra = \case
+  ShelleyToAllegraEraShelley -> ShelleyBasedEraShelley
+  ShelleyToAllegraEraAllegra -> ShelleyBasedEraAllegra

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToAlonzoEra.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.ShelleyToAlonzoEra
+  ( ShelleyToAlonzoEra(..)
+  , IsShelleyToAlonzoEra(..)
+  , AnyShelleyToAlonzoEra(..)
+  , shelleyToAlonzoEraConstraints
+  , shelleyToAlonzoEraToCardanoEra
+  , shelleyToAlonzoEraToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsShelleyToAlonzoEra era where
+  shelleyToAlonzoEra :: ShelleyToAlonzoEra era
+
+data ShelleyToAlonzoEra era where
+  ShelleyToAlonzoEraShelley :: ShelleyToAlonzoEra ShelleyEra
+  ShelleyToAlonzoEraAllegra :: ShelleyToAlonzoEra AllegraEra
+  ShelleyToAlonzoEraMary :: ShelleyToAlonzoEra MaryEra
+  ShelleyToAlonzoEraAlonzo :: ShelleyToAlonzoEra AlonzoEra
+
+deriving instance Show (ShelleyToAlonzoEra era)
+deriving instance Eq (ShelleyToAlonzoEra era)
+
+instance IsShelleyToAlonzoEra ShelleyEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraShelley
+
+instance IsShelleyToAlonzoEra AllegraEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraAllegra
+
+instance IsShelleyToAlonzoEra MaryEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraMary
+
+instance IsShelleyToAlonzoEra AlonzoEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraAlonzo
+
+instance FeatureInEra ShelleyToAlonzoEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToAlonzoEraShelley
+    AllegraEra  -> yes ShelleyToAlonzoEraAllegra
+    MaryEra     -> yes ShelleyToAlonzoEraMary
+    AlonzoEra   -> yes ShelleyToAlonzoEraAlonzo
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyToAlonzoEra where
+  toCardanoEra = \case
+    ShelleyToAlonzoEraShelley  -> ShelleyEra
+    ShelleyToAlonzoEraAllegra  -> AllegraEra
+    ShelleyToAlonzoEraMary     -> MaryEra
+    ShelleyToAlonzoEraAlonzo   -> AlonzoEra
+
+type ShelleyToAlonzoEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 6
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , IsShelleyToAlonzoEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+data AnyShelleyToAlonzoEra where
+  AnyShelleyToAlonzoEra :: ShelleyToAlonzoEra era -> AnyShelleyToAlonzoEra
+
+deriving instance Show AnyShelleyToAlonzoEra
+
+shelleyToAlonzoEraConstraints :: ()
+  => ShelleyToAlonzoEra era
+  -> (ShelleyToAlonzoEraConstraints era => a)
+  -> a
+shelleyToAlonzoEraConstraints = \case
+  ShelleyToAlonzoEraShelley -> id
+  ShelleyToAlonzoEraAllegra -> id
+  ShelleyToAlonzoEraMary    -> id
+  ShelleyToAlonzoEraAlonzo  -> id
+
+shelleyToAlonzoEraToCardanoEra :: ShelleyToAlonzoEra era -> CardanoEra era
+shelleyToAlonzoEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToAlonzoEraToShelleyBasedEra
+
+shelleyToAlonzoEraToShelleyBasedEra :: ShelleyToAlonzoEra era -> ShelleyBasedEra era
+shelleyToAlonzoEraToShelleyBasedEra = \case
+  ShelleyToAlonzoEraShelley -> ShelleyBasedEraShelley
+  ShelleyToAlonzoEraAllegra -> ShelleyBasedEraAllegra
+  ShelleyToAlonzoEraMary    -> ShelleyBasedEraMary
+  ShelleyToAlonzoEraAlonzo  -> ShelleyBasedEraAlonzo

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -95,6 +96,7 @@ type ShelleyToBabbageEraConstraints era =
   , L.EraTx (ShelleyLedgerEra era)
   , L.EraTxBody (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 7
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
   , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -74,6 +74,14 @@ instance FeatureInEra ShelleyToBabbageEra where
     BabbageEra  -> yes ShelleyToBabbageEraBabbage
     ConwayEra   -> no
 
+instance ToCardanoEra ShelleyToBabbageEra where
+  toCardanoEra = \case
+    ShelleyToBabbageEraShelley  -> ShelleyEra
+    ShelleyToBabbageEraAllegra  -> AllegraEra
+    ShelleyToBabbageEraMary     -> MaryEra
+    ShelleyToBabbageEraAlonzo   -> AlonzoEra
+    ShelleyToBabbageEraBabbage  -> BabbageEra
+
 type ShelleyToBabbageEraConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -85,6 +86,7 @@ type ShelleyToMaryEraConstraints era =
   , L.EraTx (ShelleyLedgerEra era)
   , L.EraTxBody (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 5
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
   , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.ShelleyToMaryEra
+  ( ShelleyToMaryEra(..)
+  , IsShelleyToMaryEra(..)
+  , AnyShelleyToMaryEra(..)
+  , shelleyToMaryEraConstraints
+  , shelleyToMaryEraToCardanoEra
+  , shelleyToMaryEraToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsShelleyToMaryEra era where
+  shelleyToMaryEra :: ShelleyToMaryEra era
+
+data ShelleyToMaryEra era where
+  ShelleyToMaryEraShelley :: ShelleyToMaryEra ShelleyEra
+  ShelleyToMaryEraAllegra :: ShelleyToMaryEra AllegraEra
+  ShelleyToMaryEraMary    :: ShelleyToMaryEra MaryEra
+
+deriving instance Show (ShelleyToMaryEra era)
+deriving instance Eq (ShelleyToMaryEra era)
+
+instance IsShelleyToMaryEra ShelleyEra where
+  shelleyToMaryEra = ShelleyToMaryEraShelley
+
+instance IsShelleyToMaryEra AllegraEra where
+  shelleyToMaryEra = ShelleyToMaryEraAllegra
+
+instance IsShelleyToMaryEra MaryEra where
+  shelleyToMaryEra = ShelleyToMaryEraMary
+
+instance FeatureInEra ShelleyToMaryEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToMaryEraShelley
+    AllegraEra  -> yes ShelleyToMaryEraAllegra
+    MaryEra     -> yes ShelleyToMaryEraMary
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyToMaryEra where
+  toCardanoEra = \case
+    ShelleyToMaryEraShelley  -> ShelleyEra
+    ShelleyToMaryEraAllegra  -> AllegraEra
+    ShelleyToMaryEraMary     -> MaryEra
+
+type ShelleyToMaryEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , IsShelleyToMaryEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+data AnyShelleyToMaryEra where
+  AnyShelleyToMaryEra :: ShelleyToMaryEra era -> AnyShelleyToMaryEra
+
+deriving instance Show AnyShelleyToMaryEra
+
+shelleyToMaryEraConstraints :: ()
+  => ShelleyToMaryEra era
+  -> (ShelleyToMaryEraConstraints era => a)
+  -> a
+shelleyToMaryEraConstraints = \case
+  ShelleyToMaryEraShelley -> id
+  ShelleyToMaryEraAllegra -> id
+  ShelleyToMaryEraMary    -> id
+
+shelleyToMaryEraToCardanoEra :: ShelleyToMaryEra era -> CardanoEra era
+shelleyToMaryEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToMaryEraToShelleyBasedEra
+
+shelleyToMaryEraToShelleyBasedEra :: ShelleyToMaryEra era -> ShelleyBasedEra era
+shelleyToMaryEraToShelleyBasedEra = \case
+  ShelleyToMaryEraShelley -> ShelleyBasedEraShelley
+  ShelleyToMaryEraAllegra -> ShelleyBasedEraAllegra
+  ShelleyToMaryEraMary    -> ShelleyBasedEraMary

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -46,7 +46,8 @@ module Cardano.Api.Fees (
 
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters

--- a/cardano-api/internal/Cardano/Api/GenesisParameters.hs
+++ b/cardano-api/internal/Cardano/Api/GenesisParameters.hs
@@ -16,7 +16,7 @@ module Cardano.Api.GenesisParameters (
 
   ) where
 
-import           Cardano.Api.Eras (ShelleyBasedEra (ShelleyBasedEraShelley))
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Value

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -14,7 +14,8 @@
 module Cardano.Api.Governance.Actions.ProposalProcedure where
 
 import           Cardano.Api.Address
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
@@ -18,7 +18,7 @@ module Cardano.Api.Governance.Actions.VotingProcedure where
 
 import           Cardano.Api.Address
 import           Cardano.Api.Eras
-import           Cardano.Api.Feature.ConwayEraOnwards (ConwayEraOnwards)
+import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Governance.Actions.ProposalProcedure
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/Governance/Poll.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Poll.hs
@@ -36,7 +36,7 @@ module Cardano.Api.Governance.Poll(
     verifyPollAnswer,
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -25,7 +25,7 @@ module Cardano.Api.InMode (
     fromConsensusApplyTxErr,
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
 import           Cardano.Api.Tx
 import           Cardano.Api.TxBody

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -83,7 +83,8 @@ module Cardano.Api.LedgerState
 
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Genesis
 import           Cardano.Api.IO

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -19,6 +19,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 {- HLINT ignore "Redundant ==" -}
+{- HLINT ignore "Use mapM" -}
 
 -- | The various Cardano protocol parameters, including:
 --
@@ -992,6 +993,11 @@ instance FeatureInEra ProtocolUTxOCostPerByteFeature where
     BabbageEra  -> yes ProtocolUTxOCostPerByteInBabbageEra
     ConwayEra   -> yes ProtocolUTxOCostPerByteInConwayEra
 
+instance ToCardanoEra ProtocolUTxOCostPerByteFeature where
+  toCardanoEra = \case
+    ProtocolUTxOCostPerByteInBabbageEra -> BabbageEra
+    ProtocolUTxOCostPerByteInConwayEra  -> ConwayEra
+
 -- | A representation of whether the era supports the 'UTxO Cost Per Word'
 -- protocol parameter.
 --
@@ -1012,6 +1018,10 @@ instance FeatureInEra ProtocolUTxOCostPerWordFeature where
     AlonzoEra   -> yes ProtocolUpdateUTxOCostPerWordInAlonzoEra
     BabbageEra  -> no
     ConwayEra   -> no
+
+instance ToCardanoEra ProtocolUTxOCostPerWordFeature where
+  toCardanoEra = \case
+    ProtocolUpdateUTxOCostPerWordInAlonzoEra -> AlonzoEra
 
 -- ----------------------------------------------------------------------------
 -- Praos nonce
@@ -1968,4 +1978,3 @@ instance Error ProtocolParametersConversionError where
     PpceVersionInvalid majorProtVer -> "Major protocol version is invalid: " <> show majorProtVer
     PpceInvalidCostModel cm err -> "Invalid cost model: " <> display err <> " Cost model: " <> show cm
     PpceMissingParameter name -> "Missing parameter: " <> name
-

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -98,7 +98,7 @@ module Cardano.Api.ProtocolParameters (
   ) where
 
 import           Cardano.Api.Address
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -82,7 +82,8 @@ import           Cardano.Api.Address
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.GenesisParameters
 import           Cardano.Api.IPC.Version
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -36,7 +36,7 @@ module Cardano.Api.Query.Expr
 import           Cardano.Api.Address
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.GenesisParameters
 import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Monad

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -110,7 +110,7 @@ module Cardano.Api.Script (
   ) where
 
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/ScriptData.hs
+++ b/cardano-api/internal/Cardano/Api/ScriptData.hs
@@ -45,7 +45,7 @@ module Cardano.Api.ScriptData (
     Hash(..),
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
@@ -30,7 +30,7 @@ module Cardano.Api.SerialiseLedgerCddl
   )
   where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.IO

--- a/cardano-api/internal/Cardano/Api/SerialiseTextEnvelope.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseTextEnvelope.hs
@@ -34,7 +34,7 @@ module Cardano.Api.SerialiseTextEnvelope
   , AsType(..)
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.IO

--- a/cardano-api/internal/Cardano/Api/StakePoolMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/StakePoolMetadata.hs
@@ -15,7 +15,7 @@ module Cardano.Api.StakePoolMetadata (
     Hash(..),
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Tx.hs
@@ -50,7 +50,8 @@ module Cardano.Api.Tx (
 
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Class

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -188,7 +188,8 @@ import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Convenience.Constraints
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Governance.Actions.ProposalProcedure

--- a/cardano-api/internal/Cardano/Api/TxMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/TxMetadata.hs
@@ -47,7 +47,7 @@ module Cardano.Api.TxMetadata (
     AsType(..)
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.SerialiseCBOR (SerialiseAsCBOR (..))

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 
 #if !defined(mingw32_HOST_OS)
 #define UNIX
@@ -31,7 +30,7 @@ module Cardano.Api.Utils
   , bounded
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 
 import           Cardano.Ledger.Shelley ()
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -74,6 +74,13 @@ module Cardano.Api (
     alonzoEraOnwardsToCardanoEra,
     alonzoEraOnwardsToShelleyBasedEra,
 
+    AlonzoEraOnly(..),
+    IsAlonzoEraOnly(..),
+    AnyAlonzoEraOnly(..),
+    alonzoEraOnlyConstraints,
+    alonzoEraOnlyToCardanoEra,
+    alonzoEraOnlyToShelleyBasedEra,
+
     BabbageEraOnwards(..),
     IsBabbageEraOnwards(..),
     AnyBabbageEraOnwards(..),
@@ -1000,6 +1007,7 @@ import           Cardano.Api.Eras.Core
 import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
+import           Cardano.Api.Feature.AlonzoEraOnly
 import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -46,6 +46,13 @@ module Cardano.Api (
     shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
 
+    ShelleyToAllegraEra(..),
+    IsShelleyToAllegraEra(..),
+    AnyShelleyToAllegraEra(..),
+    shelleyToAllegraEraConstraints,
+    shelleyToAllegraEraToCardanoEra,
+    shelleyToAllegraEraToShelleyBasedEra,
+
     ShelleyToAlonzoEra(..),
     IsShelleyToAlonzoEra(..),
     AnyShelleyToAlonzoEra(..),
@@ -996,6 +1003,7 @@ import           Cardano.Api.Feature
 import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToAllegraEra
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Feature.ShelleyToMaryEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -67,6 +67,13 @@ module Cardano.Api (
     alonzoEraOnwardsToCardanoEra,
     alonzoEraOnwardsToShelleyBasedEra,
 
+    BabbageEraOnwards(..),
+    IsBabbageEraOnwards(..),
+    AnyBabbageEraOnwards(..),
+    babbageEraOnwardsConstraints,
+    babbageEraOnwardsToCardanoEra,
+    babbageEraOnwardsToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -987,6 +994,7 @@ import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.AlonzoEraOnwards
+import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -30,6 +30,8 @@ module Cardano.Api (
     -- * Feature support
     FeatureInEra(..),
     inEraFeature,
+    justFeatureInEra,
+    justInEraFeature,
     maybeFeatureInEra,
     featureInShelleyBasedEra,
     inShelleyBasedEraFeature,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -25,6 +25,7 @@ module Cardano.Api (
     anyCardanoEra,
     cardanoEraConstraints,
     InAnyCardanoEra(..),
+    ToCardanoEra(..),
 
     -- * Feature support
     FeatureInEra(..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -36,6 +36,7 @@ module Cardano.Api (
     Featured(..),
     asFeaturedInEra,
     asFeaturedInShelleyBasedEra,
+    InAnyEra(..),
 
     -- * Features
     ShelleyToBabbageEra(..),
@@ -961,6 +962,7 @@ import           Cardano.Api.DRepMetadata
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.Eras.Core
+import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -959,7 +959,8 @@ import           Cardano.Api.Convenience.Query
 import           Cardano.Api.DeserialiseAnyOf
 import           Cardano.Api.DRepMetadata
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -53,6 +53,13 @@ module Cardano.Api (
     shelleyToAlonzoEraToCardanoEra,
     shelleyToAlonzoEraToShelleyBasedEra,
 
+    ShelleyToMaryEra(..),
+    IsShelleyToMaryEra(..),
+    AnyShelleyToMaryEra(..),
+    shelleyToMaryEraConstraints,
+    shelleyToMaryEraToCardanoEra,
+    shelleyToMaryEraToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -975,6 +982,7 @@ import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
+import           Cardano.Api.Feature.ShelleyToMaryEra
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -60,6 +60,13 @@ module Cardano.Api (
     shelleyToMaryEraToCardanoEra,
     shelleyToMaryEraToShelleyBasedEra,
 
+    AlonzoEraOnwards(..),
+    IsAlonzoEraOnwards(..),
+    AnyAlonzoEraOnwards(..),
+    alonzoEraOnwardsConstraints,
+    alonzoEraOnwardsToCardanoEra,
+    alonzoEraOnwardsToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -979,6 +986,7 @@ import           Cardano.Api.Eras.Core
 import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
+import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -46,6 +46,13 @@ module Cardano.Api (
     shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
 
+    ShelleyToAlonzoEra(..),
+    IsShelleyToAlonzoEra(..),
+    AnyShelleyToAlonzoEra(..),
+    shelleyToAlonzoEraConstraints,
+    shelleyToAlonzoEraToCardanoEra,
+    shelleyToAlonzoEraToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -966,6 +973,7 @@ import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -294,7 +294,7 @@ import           Cardano.Api.Address
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.DRepMetadata
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Genesis
 import           Cardano.Api.Governance.Actions.ProposalProcedure
 import           Cardano.Api.Governance.Actions.VotingProcedure


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Facility to represent mandatory fields some eras
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This is WIP and includes many commits that are probably surplus to needs in case I need them.

This PR will investigate if there is a clean way to represent mandatory fields like Conway fields for transactions among other things.

Surplus commits can be removed before review.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
