### PR TITLE
New functions `emptyVotingProcedures`, `singletonVotingProcedures` and `mergeVotingProcedures`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
@@ -256,3 +256,32 @@ instance IsShelleyBasedEra era => HasTextEnvelope (VotingProcedures era) where
 instance HasTypeProxy era => HasTypeProxy (VotingProcedures era) where
   data AsType (VotingProcedures era) = AsVotingProcedures
   proxyToAsType _ = AsVotingProcedures
+
+emptyVotingProcedures :: VotingProcedures era
+emptyVotingProcedures = VotingProcedures $ L.VotingProcedures Map.empty
+
+singletonVotingProcedures :: ()
+  => ShelleyBasedEra era
+  -> L.Voter (L.EraCrypto (ShelleyLedgerEra era))
+  -> L.GovActionId (L.EraCrypto (ShelleyLedgerEra era))
+  -> L.VotingProcedure (ShelleyLedgerEra era)
+  -> VotingProcedures era
+singletonVotingProcedures _ voter govActionId votingProcedure =
+  VotingProcedures
+    $ L.VotingProcedures
+    $ Map.singleton voter
+    $ Map.singleton govActionId votingProcedure
+
+-- | Right biased merge of Voting procedures.
+-- TODO Conway we need an alternative version of this function that can report conflicts as it is
+-- not safe to just throw away votes.
+unsafeMergeVotingProcedures :: ()
+  => VotingProcedures era
+  -> VotingProcedures era
+  -> VotingProcedures era
+unsafeMergeVotingProcedures vpsa vpsb =
+  VotingProcedures
+    $ L.VotingProcedures
+    $ Map.unionWith (Map.unionWith const)
+        (L.unVotingProcedures (unVotingProcedures vpsa))
+        (L.unVotingProcedures (unVotingProcedures vpsb))

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -288,6 +288,9 @@ module Cardano.Api.Shelley
     fromShelleyPoolParams,
     fromLedgerPParamsUpdate,
 
+    emptyVotingProcedures,
+    singletonVotingProcedures,
+    unsafeMergeVotingProcedures,
   ) where
 
 import           Cardano.Api


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    New functions `emptyVotingProcedures`, `singletonVotingProcedures` and `mergeVotingProcedures`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Useful functions for `VotingProcedures`.

For use cases, see: https://github.com/input-output-hk/cardano-cli/pull/203

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
