### PR TITLE
Replace ProtocolParameters usage with ledger's PParams

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -937,37 +937,14 @@ genProtocolParameters era = do
 -- | Generate valid protocol parameters which pass validations in Cardano.Api.ProtocolParameters
 genValidProtocolParameters :: CardanoEra era -> Gen ProtocolParameters
 genValidProtocolParameters era =
-  ProtocolParameters
-    <$> ((,) <$> genNat <*> genNat)
-    <*> Gen.maybe genRational
-    <*> genMaybePraosNonce
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> genLovelace
-    <*> genLovelace
-    <*> Gen.maybe genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genEpochNo
-    <*> genNat
-    <*> genRationalInt64
-    <*> genRational
-    <*> genRational
-    -- 'Just' is required by checks in Cardano.Api.ProtocolParameters
-    <*> featureInEra @ProtocolUTxOCostPerWordFeature (pure Nothing) (const (Just <$> genLovelace)) era
-    <*> return mempty
-    --TODO: Babbage figure out how to deal with
-    -- asymmetric cost model JSON instances
-    -- 'Just' is required by checks in Cardano.Api.ProtocolParameters
-    <*> fmap Just genExecutionUnitPrices
-    <*> fmap Just genExecutionUnits
-    <*> fmap Just genExecutionUnits
-    <*> fmap Just genNat
-    <*> fmap Just genNat
-    <*> fmap Just genNat
-    <*> featureInEra @ProtocolUTxOCostPerByteFeature (pure Nothing) (const (Just <$> genLovelace)) era
+  case era of
+    ShelleyBasedEraShelley -> LedgerPParams era <$> Q.arbitrary
+    ShelleyBasedEraAllegra -> LedgerPParams era <$> Q.arbitrary
+    ShelleyBasedEraMary    -> LedgerPParams era <$> Q.arbitrary
+    ShelleyBasedEraAlonzo  -> LedgerPParams era <$> Q.arbitrary
+    ShelleyBasedEraBabbage -> LedgerPParams era <$> Q.arbitrary
+    ShelleyBasedEraConway  -> LedgerPParams era <$> Q.arbitrary
+
 
 genProtocolParametersUpdate :: CardanoEra era -> Gen ProtocolParametersUpdate
 genProtocolParametersUpdate era = do

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -665,7 +665,9 @@ genTxBodyContent era = do
   txMetadata <- genTxMetadataInEra era
   txAuxScripts <- genTxAuxScripts era
   let txExtraKeyWits = TxExtraKeyWitnessesNone --TODO: Alonzo era: Generate witness key hashes
-  txProtocolParams <- BuildTxWith <$> Gen.maybe (genValidProtocolParameters era)
+  txProtocolParams <- BuildTxWith <$> case cardanoEraStyle era of
+                                        LegacyByronEra -> return Nothing
+                                        ShelleyBasedEra sbe -> Gen.maybe $ genValidProtocolParameters sbe
   txWithdrawals <- genTxWithdrawals era
   txCertificates <- genTxCertificates era
   txUpdateProposal <- genTxUpdateProposal era
@@ -935,7 +937,7 @@ genProtocolParameters era = do
   pure ProtocolParameters {..}
 
 -- | Generate valid protocol parameters which pass validations in Cardano.Api.ProtocolParameters
-genValidProtocolParameters :: CardanoEra era -> Gen ProtocolParameters
+genValidProtocolParameters :: ShelleyBasedEra era -> Gen (LedgerProtocolParameters era)
 genValidProtocolParameters era =
   case era of
     ShelleyBasedEraShelley -> LedgerPParams era <$> Q.arbitrary

--- a/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
@@ -17,8 +17,8 @@ import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
 import           Cardano.Api.Fees
+import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query
-import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.Tx
 import           Cardano.Api.TxBody
 import           Cardano.Api.Utils
@@ -41,20 +41,21 @@ constructBalancedTx
   -> AddressInEra era -- ^ Change address
   -> Maybe Word       -- ^ Override key witnesses
   -> UTxO era         -- ^ Just the transaction inputs, not the entire 'UTxO'.
-  -> Ledger.PParams (ShelleyLedgerEra era)
+  -> LedgerProtocolParameters era
   -> LedgerEpochInfo
   -> SystemStart
   -> Set PoolId       -- ^ The set of registered stake pools
   -> Map.Map StakeCredential Lovelace
   -> [ShelleyWitnessSigningKey]
   -> Either TxBodyErrorAutoBalance (Tx era)
-constructBalancedTx txbodcontent changeAddr mOverrideWits utxo pparams
+constructBalancedTx txbodcontent changeAddr mOverrideWits utxo lpp
                     ledgerEpochInfo systemStart stakePools
                     stakeDelegDeposits shelleyWitSigningKeys = do
+
   BalancedTxBody _ txbody _txBalanceOutput _fee
     <- makeTransactionBodyAutoBalance
          systemStart ledgerEpochInfo
-         pparams stakePools stakeDelegDeposits utxo txbodcontent
+         lpp stakePools stakeDelegDeposits utxo txbodcontent
          changeAddr mOverrideWits
 
   let keyWits = map (makeShelleyKeyWitness txbody) shelleyWitSigningKeys

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -8,6 +8,7 @@ module Cardano.Api.Convenience.Query (
     determineEra,
     -- * Simplest query related
     executeQueryCardanoMode,
+    executeQueryAnyMode,
 
     queryStateForBalancedTx,
     renderQueryConvenienceError,

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -22,9 +22,9 @@ import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Monad
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
-import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query
 import           Cardano.Api.Query.Expr
+import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.TxBody
 import           Cardano.Api.Utils
 import           Cardano.Api.Value
@@ -75,7 +75,7 @@ queryStateForBalancedTx :: ()
       ( Either
           QueryConvenienceError
           ( UTxO era
-          , ProtocolParameters
+          , Ledger.PParams (ShelleyLedgerEra era)
           , EraHistory CardanoMode
           , SystemStart
           , Set PoolId

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -23,9 +23,9 @@ import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Monad
 import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
+import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query
 import           Cardano.Api.Query.Expr
-import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.TxBody
 import           Cardano.Api.Utils
 import           Cardano.Api.Value
@@ -48,6 +48,7 @@ data QueryConvenienceError
   | ByronEraNotSupported
   | EraConsensusModeMismatch !AnyConsensusMode !AnyCardanoEra
   | QceUnsupportedNtcVersion !UnsupportedNtcVersionError
+  deriving Show
 
 renderQueryConvenienceError :: QueryConvenienceError -> Text
 renderQueryConvenienceError (AcqFailure e) =
@@ -76,7 +77,7 @@ queryStateForBalancedTx :: ()
       ( Either
           QueryConvenienceError
           ( UTxO era
-          , Ledger.PParams (ShelleyLedgerEra era)
+          , LedgerProtocolParameters era
           , EraHistory CardanoMode
           , SystemStart
           , Set PoolId
@@ -117,7 +118,7 @@ queryStateForBalancedTx era allTxIns certs = runExceptT $ do
           & onLeft (left . QceUnsupportedNtcVersion)
           & onLeft (left . QueryEraMismatch)
 
-  pure (utxo, pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits)
+  pure (utxo, createLedgerProtocolParameters sbe pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits)
 
 -- | Query the node to determine which era it is in.
 determineEra

--- a/cardano-api/internal/Cardano/Api/GenesisParameters.hs
+++ b/cardano-api/internal/Cardano/Api/GenesisParameters.hs
@@ -16,13 +16,11 @@ module Cardano.Api.GenesisParameters (
 
   ) where
 
-import           Cardano.Api.Eras (ShelleyBasedEra (ShelleyBasedEraShelley))
+import           Cardano.Api.Eras
 import           Cardano.Api.NetworkId
-import           Cardano.Api.ProtocolParameters
+import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.Value
 
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Cardano.Ledger.Crypto as Ledger
 import qualified Cardano.Ledger.Shelley.Genesis as Shelley
 import           Cardano.Slotting.Slot (EpochSize (..))
 
@@ -32,8 +30,8 @@ import           Data.Time (NominalDiffTime, UTCTime)
 -- ----------------------------------------------------------------------------
 -- Genesis parameters
 --
-
-data GenesisParameters =
+-- TODO: Conway era - remove GenesisParameters and use ledger types directly
+data GenesisParameters era =
      GenesisParameters {
 
        -- | The reference time the system started. The time of slot zero.
@@ -92,7 +90,7 @@ data GenesisParameters =
 
        -- | The initial values of the updateable 'ProtocolParameters'.
        --
-       protocolInitialUpdateableProtocolParameters :: ProtocolParameters
+       protocolInitialUpdateableProtocolParameters :: Ledger.PParams (ShelleyLedgerEra era)
      }
 
 
@@ -100,9 +98,9 @@ data GenesisParameters =
 -- Conversion functions
 --
 
-fromShelleyGenesis :: Shelley.ShelleyGenesis Ledger.StandardCrypto -> GenesisParameters
+fromShelleyGenesis :: Shelley.ShelleyGenesis Ledger.StandardCrypto -> GenesisParameters ShelleyEra
 fromShelleyGenesis
-    Shelley.ShelleyGenesis {
+    sg@Shelley.ShelleyGenesis {
       Shelley.sgSystemStart
     , Shelley.sgNetworkMagic
     , Shelley.sgNetworkId
@@ -114,7 +112,6 @@ fromShelleyGenesis
     , Shelley.sgSlotLength
     , Shelley.sgUpdateQuorum
     , Shelley.sgMaxLovelaceSupply
-    , Shelley.sgProtocolParams
     , Shelley.sgGenDelegs    = _  -- unused, might be of interest
     , Shelley.sgInitialFunds = _  -- unused, not retained by the node
     , Shelley.sgStaking      = _  -- unused, not retained by the node
@@ -133,7 +130,5 @@ fromShelleyGenesis
     , protocolParamUpdateQuorum           = fromIntegral sgUpdateQuorum
     , protocolParamMaxLovelaceSupply      = Lovelace
                                               (fromIntegral sgMaxLovelaceSupply)
-    , protocolInitialUpdateableProtocolParameters = fromLedgerPParams
-                                                      ShelleyBasedEraShelley
-                                                      sgProtocolParams
+    , protocolInitialUpdateableProtocolParameters = Shelley.sgProtocolParams sg
     }

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -1457,7 +1457,6 @@ instance Error LeadershipError where
     "Error while calculating the slot range: " <> Text.unpack e
   displayError LeaderErrCandidateNonceStillEvolving = "Candidate nonce is still evolving"
 
--- TODO: Conway era - replace BundledProtocolParameters era with Ledger.PParams (ShelleyLedgerEra era)
 nextEpochEligibleLeadershipSlots
   :: forall era. ()
   => FromCBOR (Consensus.ChainDepState (Api.ConsensusProtocol era))

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -96,10 +96,10 @@ import           Cardano.Api.LedgerEvent (LedgerEvent, toLedgerEvent)
 import           Cardano.Api.Modes (CardanoMode, EpochSlots (..))
 import qualified Cardano.Api.Modes as Api
 import           Cardano.Api.NetworkId (NetworkId (..), NetworkMagic (NetworkMagic))
-import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query (CurrentEpochState (..), PoolDistribution (unPoolDistr),
                    ProtocolState, SerialisedCurrentEpochState (..), SerialisedPoolDistribution,
                    decodeCurrentEpochState, decodePoolDistribution, decodeProtocolState)
+import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.SpecialByron as Byron
 import           Cardano.Api.Utils (textShow)
 
@@ -119,8 +119,6 @@ import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.BHeaderView as Ledger
 import           Cardano.Ledger.Binary (DecoderError, FromCBOR)
 import           Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
-import qualified Cardano.Ledger.Credential as Ledger
-import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Keys as SL
 import qualified Cardano.Ledger.PoolDistr as SL
 import qualified Cardano.Ledger.Shelley.API as ShelleyAPI
@@ -201,7 +199,7 @@ import           Data.Text.Lazy.Builder (toLazyText)
 import           Data.Word
 import qualified Data.Yaml as Yaml
 import           Formatting.Buildable (build)
-import           Lens.Micro ((^.))
+import           Lens.Micro
 import           Network.TypedProtocol.Pipelined (Nat (..))
 import           System.FilePath
 
@@ -740,10 +738,10 @@ pushLedgerState
   --   , Any existing items that are now past the security parameter
   --      and hence can no longer be rolled back.
   --   )
-pushLedgerState env hist ix st block
+pushLedgerState env hist sn st block
   = Seq.splitAt
       (fromIntegral $ envSecurityParam env + 1)
-      ((ix, st, At block) Seq.:<| hist)
+      ((sn, st, At block) Seq.:<| hist)
 
 rollBackLedgerStateHist :: History a -> SlotNo -> History a
 rollBackLedgerStateHist hist maxInc = Seq.dropWhileL ((> maxInc) . (\(x,_,_) -> x)) hist
@@ -1050,11 +1048,11 @@ mkProtocolInfoCardano (GenesisCardano dnc byronGenesis shelleyGenesis alonzoGene
             , Consensus.conwayMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
             }
       , Consensus.transitionParamsByronToShelley =
-          (ncByronToShelley dnc)
+          ncByronToShelley dnc
       , Consensus.transitionParamsShelleyToAllegra =
-          (ncShelleyToAllegra dnc)
+          ncShelleyToAllegra dnc
       , Consensus.transitionParamsAllegraToMary =
-          (ncAllegraToMary dnc)
+          ncAllegraToMary dnc
       , Consensus.transitionParamsMaryToAlonzo =
           Consensus.ProtocolTransitionParamsIntraShelley
             { Consensus.transitionIntraShelleyTranslationContext = alonzoGenesis
@@ -1474,11 +1472,11 @@ nextEpochEligibleLeadershipSlots
   -- ^ Potential slot leading stake pool
   -> SigningKey VrfKey
   -- ^ VRF signing key of the stake pool
-  -> BundledProtocolParameters era
+  -> Ledger.PParams (ShelleyLedgerEra era)
   -> EpochInfo (Either Text)
   -> (ChainTip, EpochNo)
   -> Either LeadershipError (Set SlotNo)
-nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (VrfSigningKey vrfSkey) bpp eInfo (cTip, currentEpoch) = do
+nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (VrfSigningKey vrfSkey) pp eInfo (cTip, currentEpoch) = do
   (_, currentEpochLastSlot) <- first LeaderErrSlotRangeCalculationFailure
                                  $ Slot.epochInfoRange eInfo currentEpoch
 
@@ -1519,7 +1517,15 @@ nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (Vr
 
   -- Get the previous epoch's last block header hash nonce
   let previousLabNonce = Consensus.previousLabNonce (Consensus.getPraosNonces (Proxy @(Api.ConsensusProtocol era)) chainDepState)
-      extraEntropy = toLedgerNonce $ protocolParamExtraPraosEntropy (unbundleProtocolParams bpp)
+      extraEntropy :: Nonce
+      extraEntropy = case sbe of
+                       ShelleyBasedEraShelley -> pp ^. Core.ppExtraEntropyL
+                       ShelleyBasedEraAllegra -> pp ^. Core.ppExtraEntropyL
+                       ShelleyBasedEraMary -> pp ^. Core.ppExtraEntropyL
+                       ShelleyBasedEraAlonzo -> pp ^. Core.ppExtraEntropyL
+                       ShelleyBasedEraBabbage -> Ledger.NeutralNonce
+                       ShelleyBasedEraConway -> Ledger.NeutralNonce
+
       nextEpochsNonce = candidateNonce ⭒ previousLabNonce ⭒ extraEntropy
 
   -- Then we get the "mark" snapshot. This snapshot will be used for the next
@@ -1533,11 +1539,10 @@ nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (Vr
       markSnapshotPoolDistr = ShelleyAPI.unPoolDistr . ShelleyAPI.calculatePoolDistr $ snapshot
 
   let slotRangeOfInterest :: Core.EraPParams ledgerera => Core.PParams ledgerera -> Set SlotNo
-      slotRangeOfInterest pp = Set.filter
-        (not . Ledger.isOverlaySlot firstSlotOfEpoch (pp ^. Core.ppDG))
+      slotRangeOfInterest pp' = Set.filter
+        (not . Ledger.isOverlaySlot firstSlotOfEpoch (pp' ^. Core.ppDG))
         $ Set.fromList [firstSlotOfEpoch .. lastSlotofEpoch]
 
-  let pp = unbundleLedgerShelleyBasedProtocolParams sbe bpp
 
   case sbe of
     ShelleyBasedEraShelley  ->
@@ -1553,7 +1558,8 @@ nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (Vr
     ShelleyBasedEraConway   ->
       isLeadingSlotsPraos  (slotRangeOfInterest pp) poolid markSnapshotPoolDistr nextEpochsNonce vrfSkey f
  where
-  globals = constructGlobals sGen eInfo (unbundleProtocolParams bpp)
+  globals = shelleyBasedEraConstraints sbe
+              $ constructGlobals sGen eInfo $ pp ^. Core.ppProtocolVersionL
 
   f :: Ledger.ActiveSlotCoeff
   f = activeSlotCoeff globals
@@ -1615,14 +1621,14 @@ currentEpochEligibleLeadershipSlots :: forall era. ()
   => ShelleyBasedEra era
   -> ShelleyGenesis Shelley.StandardCrypto
   -> EpochInfo (Either Text)
-  -> BundledProtocolParameters era
+  -> Ledger.PParams (ShelleyLedgerEra era)
   -> ProtocolState era
   -> PoolId
   -> SigningKey VrfKey
   -> SerialisedPoolDistribution era
   -> EpochNo -- ^ Current EpochInfo
   -> Either LeadershipError (Set SlotNo)
-currentEpochEligibleLeadershipSlots sbe sGen eInfo bpp ptclState poolid (VrfSigningKey vrkSkey) serPoolDistr currentEpoch = do
+currentEpochEligibleLeadershipSlots sbe sGen eInfo pp ptclState poolid (VrfSigningKey vrkSkey) serPoolDistr currentEpoch = do
 
   chainDepState :: ChainDepState (Api.ConsensusProtocol era) <-
     first LeaderErrDecodeProtocolStateFailure $ decodeProtocolState ptclState
@@ -1640,32 +1646,27 @@ currentEpochEligibleLeadershipSlots sbe sGen eInfo bpp ptclState poolid (VrfSign
       $ decodePoolDistribution sbe serPoolDistr
 
   let slotRangeOfInterest :: Core.EraPParams ledgerera => Core.PParams ledgerera -> Set SlotNo
-      slotRangeOfInterest pp = Set.filter
-        (not . Ledger.isOverlaySlot firstSlotOfEpoch (pp ^. Core.ppDG))
+      slotRangeOfInterest pp' = Set.filter
+        (not . Ledger.isOverlaySlot firstSlotOfEpoch (pp' ^. Core.ppDG))
         $ Set.fromList [firstSlotOfEpoch .. lastSlotofEpoch]
 
   case sbe of
     ShelleyBasedEraShelley ->
-      let pp = unbundleLedgerShelleyBasedProtocolParams ShelleyBasedEraShelley bpp
-      in isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
+      isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
     ShelleyBasedEraAllegra ->
-      let pp = unbundleLedgerShelleyBasedProtocolParams ShelleyBasedEraAllegra bpp
-      in isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
+      isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
     ShelleyBasedEraMary ->
-      let pp = unbundleLedgerShelleyBasedProtocolParams ShelleyBasedEraMary bpp
-      in isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
+      isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
     ShelleyBasedEraAlonzo ->
-      let pp = unbundleLedgerShelleyBasedProtocolParams ShelleyBasedEraAlonzo bpp
-      in isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
+      isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
     ShelleyBasedEraBabbage ->
-      let pp = unbundleLedgerShelleyBasedProtocolParams ShelleyBasedEraBabbage bpp
-      in isLeadingSlotsPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
+      isLeadingSlotsPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
     ShelleyBasedEraConway ->
-      let pp = unbundleLedgerShelleyBasedProtocolParams ShelleyBasedEraConway bpp
-      in isLeadingSlotsPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
+      isLeadingSlotsPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f
 
  where
-  globals = constructGlobals sGen eInfo (unbundleProtocolParams bpp)
+  globals = shelleyBasedEraConstraints sbe
+              $ constructGlobals sGen eInfo $ pp ^. Core.ppProtocolVersionL
 
   f :: Ledger.ActiveSlotCoeff
   f = activeSlotCoeff globals
@@ -1673,11 +1674,7 @@ currentEpochEligibleLeadershipSlots sbe sGen eInfo bpp ptclState poolid (VrfSign
 constructGlobals
   :: ShelleyGenesis Shelley.StandardCrypto
   -> EpochInfo (Either Text)
-  -> ProtocolParameters
+  -> Ledger.ProtVer
   -> Globals
-constructGlobals sGen eInfo pParams =
-  let majorPParamsVer = fst $ protocolParamProtocolVersion pParams
-  in Ledger.mkShelleyGlobals sGen eInfo $
-     case Ledger.mkVersion majorPParamsVer of
-       Nothing -> error $ "Invalid version: " ++ show majorPParamsVer
-       Just version -> version
+constructGlobals sGen eInfo (Ledger.ProtVer majorPParamsVer _) =
+  Ledger.mkShelleyGlobals sGen eInfo majorPParamsVer

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -151,7 +151,33 @@ import           Text.PrettyBy.Default (display)
 -- -----------------------------------------------------------------------------
 -- Era based ledger protocol parameters
 --
+data LedgerProtocolParameters era where
+  LedgerPParams
+    :: EraPParams (ShelleyLedgerEra era)
+    => ShelleyBasedEra era
+    -> (Ledger.PParams (ShelleyLedgerEra era))
+    -> LedgerProtocolParameters era
 
+
+deriving instance Show (LedgerProtocolParameters era )
+deriving instance Eq (LedgerProtocolParameters era)
+
+createLedgerProtocolParameters
+  :: ShelleyBasedEra era
+  -> Ledger.PParams (ShelleyLedgerEra era)
+  -> LedgerProtocolParameters era
+createLedgerProtocolParameters sbe pp =
+  shelleyBasedEraConstraints sbe $ LedgerPParams sbe pp
+
+
+-- TODO: Conway era - remove me when we begin relying on the JSON
+-- instances of Ledger.PParams
+convertToLedgerProtocolParameters
+  :: ShelleyBasedEra era
+  -> ProtocolParameters
+  -> Either ProtocolParametersConversionError (LedgerProtocolParameters era)
+convertToLedgerProtocolParameters sbe pp =
+  createLedgerProtocolParameters sbe <$> toLedgerPParams sbe pp
 
 createPParams
   :: EraPParams (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -32,10 +32,6 @@ module Cardano.Api.ProtocolParameters (
     ProtocolParameters(..),
     checkProtocolParameters,
     EpochNo,
-    BundledProtocolParameters(..),
-    bundleProtocolParams,
-    unbundleProtocolParams,
-    unbundleLedgerShelleyBasedProtocolParams,
 
     -- * The updatable protocol parameters
     LedgerProtocolParameters(..),
@@ -1568,44 +1564,6 @@ fromConwayPParamsUpdate :: BabbageEraPParams ledgerera
                         -> ProtocolParametersUpdate
 fromConwayPParamsUpdate = fromBabbagePParamsUpdate
 
--- | Bundle cardano-api representation and ledger representation of protocol parameters together so
--- they can be computed once and passed around rather than re-computed unecessarily.
---
--- The consructor arguments are intentionally lazy so that the values are not computed if not used
--- (which may be the case for some code paths).
-data BundledProtocolParameters era where
-  BundleAsByronProtocolParameters
-    :: ProtocolParameters
-    -> BundledProtocolParameters ByronEra
-  BundleAsShelleyBasedProtocolParameters
-    :: ShelleyBasedEra era
-    -> ProtocolParameters
-    -> Ledger.PParams (ShelleyLedgerEra era)
-    -> BundledProtocolParameters era
-
-bundleProtocolParams :: CardanoEra era
-                     -> ProtocolParameters
-                     -> Either ProtocolParametersConversionError (BundledProtocolParameters era)
-bundleProtocolParams cEra pp = case cardanoEraStyle cEra of
-  LegacyByronEra -> pure $ BundleAsByronProtocolParameters pp
-  ShelleyBasedEra sbe -> BundleAsShelleyBasedProtocolParameters sbe pp <$> toLedgerPParams sbe pp
-
-unbundleLedgerShelleyBasedProtocolParams
-  :: ShelleyBasedEra era
-  -> BundledProtocolParameters era
-  -> Ledger.PParams (ShelleyLedgerEra era)
-unbundleLedgerShelleyBasedProtocolParams = \case
-  ShelleyBasedEraShelley -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
-  ShelleyBasedEraAllegra -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
-  ShelleyBasedEraMary -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
-  ShelleyBasedEraAlonzo -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
-  ShelleyBasedEraBabbage -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
-  ShelleyBasedEraConway -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
-
-unbundleProtocolParams :: BundledProtocolParameters era -> ProtocolParameters
-unbundleProtocolParams = \case
-  BundleAsByronProtocolParameters pp -> pp
-  BundleAsShelleyBasedProtocolParameters _ pp _ -> pp
 
 -- ----------------------------------------------------------------------------
 -- Conversion functions: protocol parameters to ledger types

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -43,6 +43,8 @@ module Cardano.Api.ProtocolParameters (
     ShelleyToAlonzoPParams'(..),
     IntroducedInBabbagePParams(..),
     createEraBasedProtocolParamUpdate,
+    createLedgerProtocolParameters,
+    convertToLedgerProtocolParameters,
     createPParams,
 
     -- * Deprecated

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -38,6 +38,7 @@ module Cardano.Api.ProtocolParameters (
     unbundleLedgerShelleyBasedProtocolParams,
 
     -- * The updatable protocol parameters
+    LedgerProtocolParameters(..),
     EraBasedProtocolParametersUpdate(..),
     AlonzoOnwardsPParams(..),
     CommonProtocolParametersUpdate(..),

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -90,6 +90,7 @@ import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query.Types
+import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.TxBody
 import           Cardano.Api.Value
 
@@ -243,7 +244,7 @@ data QueryInShelleyBasedEra era result where
     :: QueryInShelleyBasedEra ShelleyEra (GenesisParameters ShelleyEra)
 
   QueryProtocolParameters
-    :: QueryInShelleyBasedEra era ProtocolParameters
+    :: QueryInShelleyBasedEra era (Ledger.PParams (ShelleyLedgerEra era))
 
   QueryProtocolParametersUpdate
     :: QueryInShelleyBasedEra era
@@ -867,9 +868,9 @@ fromConsensusQueryResultShelleyBased _ QueryGenesisParameters q' r' =
                                       (Consensus.getCompactGenesis r')
       _                          -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResultShelleyBased sbe QueryProtocolParameters q' r' =
+fromConsensusQueryResultShelleyBased _ QueryProtocolParameters q' r' =
     case q' of
-      Consensus.GetCurrentPParams -> fromLedgerPParams sbe r'
+      Consensus.GetCurrentPParams -> r'
       _                           -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResultShelleyBased sbe QueryProtocolParametersUpdate q' r' =

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -240,7 +240,7 @@ data QueryInShelleyBasedEra era result where
     :: QueryInShelleyBasedEra era EpochNo
 
   QueryGenesisParameters
-    :: QueryInShelleyBasedEra ShelleyEra GenesisParameters
+    :: QueryInShelleyBasedEra ShelleyEra (GenesisParameters ShelleyEra)
 
   QueryProtocolParameters
     :: QueryInShelleyBasedEra era ProtocolParameters

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -105,7 +105,7 @@ queryEraHistory =
 queryGenesisParameters :: ()
   => EraInMode ShelleyEra mode
   -> ShelleyBasedEra ShelleyEra
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch GenesisParameters))
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (GenesisParameters ShelleyEra)))
 queryGenesisParameters eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryGenesisParameters
 

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -45,6 +45,7 @@ import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query
+import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.Value
 
 import qualified Cardano.Ledger.Api as L
@@ -128,7 +129,7 @@ queryPoolState eraInMode sbe mPoolIds =
 queryPparams :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch ProtocolParameters))
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (L.PParams (ShelleyLedgerEra era))))
 queryPparams eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 {-# DEPRECATED queryPparams "Use queryProtocolParameters instead" #-}
@@ -136,7 +137,7 @@ queryPparams eraInMode sbe =
 queryProtocolParameters :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch ProtocolParameters))
+  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Ledger.PParams (ShelleyLedgerEra era))))
 queryProtocolParameters eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -63,6 +63,7 @@ module Cardano.Api.ReexposeLedger
 
   -- Alonzo
   , CoinPerWord (..)
+  , Prices(..)
 
   -- Base
   , boundRational
@@ -89,6 +90,7 @@ module Cardano.Api.ReexposeLedger
 
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
 import           Cardano.Ledger.Alonzo.Core (CoinPerWord (..))
+import           Cardano.Ledger.Alonzo.Scripts (Prices (..))
 import           Cardano.Ledger.Api.Tx.Cert (pattern AuthCommitteeHotKeyTxCert, pattern DelegTxCert,
                    pattern RegDRepTxCert, pattern RegDepositDelegTxCert, pattern RegDepositTxCert,
                    pattern RegPoolTxCert, pattern RegTxCert, pattern ResignCommitteeColdTxCert,

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -199,6 +199,7 @@ import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
+import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.Script
 import           Cardano.Api.ScriptData
 import           Cardano.Api.SerialiseCBOR
@@ -4353,12 +4354,9 @@ genesisUTxOPseudoTxIn nw (GenesisUTxOKeyHash kh) =
              (Shelley.KeyHashObj kh)
              Shelley.StakeRefNull
 
-calculateExecutionUnitsLovelace :: ExecutionUnitPrices -> ExecutionUnits -> Maybe Lovelace
-calculateExecutionUnitsLovelace euPrices eUnits =
-  case toAlonzoPrices euPrices of
-    Left _ -> Nothing
-    Right prices ->
-      return . fromShelleyLovelace $ Alonzo.txscriptfee prices (toAlonzoExUnits eUnits)
+calculateExecutionUnitsLovelace :: Ledger.Prices -> ExecutionUnits -> Maybe Lovelace
+calculateExecutionUnitsLovelace prices eUnits =
+  return . fromShelleyLovelace $ Alonzo.txscriptfee prices (toAlonzoExUnits eUnits)
 
 -- ----------------------------------------------------------------------------
 -- Inline data

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -834,9 +834,6 @@ module Cardano.Api (
     NetworkMagic(..),
 
     -- * Protocol parameters
-    BundledProtocolParameters(..),
-    bundleProtocolParams,
-    unbundleProtocolParams,
     ProtocolParametersConversionError(..),
 
     -- ** Conversions
@@ -858,6 +855,8 @@ module Cardano.Api (
     SocketPath,
 
     NodeToClientVersion(..),
+    -- ** Queries
+    executeQueryAnyMode,
 
     -- ** Monadic queries
     LocalStateQueryExpr,

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -119,6 +119,8 @@ module Cardano.Api.Shelley
     ShelleyToAlonzoPParams'(..),
     IntroducedInBabbagePParams(..),
     createEraBasedProtocolParamUpdate,
+    convertToLedgerProtocolParameters,
+    createLedgerProtocolParameters,
 
     ProtocolParameters(..),
     checkProtocolParameters,

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -110,6 +110,7 @@ module Cardano.Api.Shelley
     fromShelleyMetadatum,
 
     -- * Protocol parameters
+    LedgerProtocolParameters(..),
     EraBasedProtocolParametersUpdate(..),
     CommonProtocolParametersUpdate(..),
     AlonzoOnwardsPParams(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace ProtocolParameters usage with ledger's PParams 
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
