### PR TITLE
Use `newtype` instead of `GADT` for `LedgerProtocolParameters`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -939,13 +939,12 @@ genProtocolParameters era = do
 genValidProtocolParameters :: ShelleyBasedEra era -> Gen (LedgerProtocolParameters era)
 genValidProtocolParameters era =
   case era of
-    ShelleyBasedEraShelley -> LedgerPParams era <$> Q.arbitrary
-    ShelleyBasedEraAllegra -> LedgerPParams era <$> Q.arbitrary
-    ShelleyBasedEraMary    -> LedgerPParams era <$> Q.arbitrary
-    ShelleyBasedEraAlonzo  -> LedgerPParams era <$> Q.arbitrary
-    ShelleyBasedEraBabbage -> LedgerPParams era <$> Q.arbitrary
-    ShelleyBasedEraConway  -> LedgerPParams era <$> Q.arbitrary
-
+    ShelleyBasedEraShelley -> LedgerProtocolParameters <$> Q.arbitrary
+    ShelleyBasedEraAllegra -> LedgerProtocolParameters <$> Q.arbitrary
+    ShelleyBasedEraMary    -> LedgerProtocolParameters <$> Q.arbitrary
+    ShelleyBasedEraAlonzo  -> LedgerProtocolParameters <$> Q.arbitrary
+    ShelleyBasedEraBabbage -> LedgerProtocolParameters <$> Q.arbitrary
+    ShelleyBasedEraConway  -> LedgerProtocolParameters <$> Q.arbitrary
 
 genProtocolParametersUpdate :: CardanoEra era -> Gen ProtocolParametersUpdate
 genProtocolParametersUpdate era = do

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -118,7 +118,7 @@ queryStateForBalancedTx era allTxIns certs = runExceptT $ do
           & onLeft (left . QceUnsupportedNtcVersion)
           & onLeft (left . QueryEraMismatch)
 
-  pure (utxo, createLedgerProtocolParameters sbe pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits)
+  pure (utxo, LedgerProtocolParameters pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits)
 
 -- | Query the node to determine which era it is in.
 determineEra

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -495,7 +495,7 @@ evaluateTransactionExecutionUnitsShelley :: forall era. ()
   -> L.Tx (ShelleyLedgerEra era)
   -> Either TransactionValidityError
             (Map ScriptWitnessIndex (Either ScriptExecutionError ExecutionUnits))
-evaluateTransactionExecutionUnitsShelley sbe systemstart epochInfo (LedgerPParams _ pp) utxo tx' =
+evaluateTransactionExecutionUnitsShelley sbe systemstart epochInfo (LedgerProtocolParameters pp) utxo tx' =
         case sbe of
           ShelleyBasedEraShelley -> evalPreAlonzo
           ShelleyBasedEraAllegra -> evalPreAlonzo
@@ -909,7 +909,7 @@ makeTransactionBodyAutoBalance
   -> AddressInEra era -- ^ Change address
   -> Maybe Word       -- ^ Override key witnesses
   -> Either TxBodyErrorAutoBalance (BalancedTxBody era)
-makeTransactionBodyAutoBalance systemstart history lpp@(LedgerPParams _ pp) poolids stakeDelegDeposits
+makeTransactionBodyAutoBalance systemstart history lpp@(LedgerProtocolParameters pp) poolids stakeDelegDeposits
                             utxo txbodycontent changeaddr mnkeys = do
     -- Our strategy is to:
     -- 1. evaluate all the scripts to get the exec units, update with ex units

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -1542,20 +1542,8 @@ nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (Vr
         (not . Ledger.isOverlaySlot firstSlotOfEpoch (pp' ^. Core.ppDG))
         $ Set.fromList [firstSlotOfEpoch .. lastSlotofEpoch]
 
-
-  case sbe of
-    ShelleyBasedEraShelley  ->
-      isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid markSnapshotPoolDistr nextEpochsNonce vrfSkey f
-    ShelleyBasedEraAllegra  ->
-      isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid markSnapshotPoolDistr nextEpochsNonce vrfSkey f
-    ShelleyBasedEraMary     ->
-      isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid markSnapshotPoolDistr nextEpochsNonce vrfSkey f
-    ShelleyBasedEraAlonzo   ->
-      isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid markSnapshotPoolDistr nextEpochsNonce vrfSkey f
-    ShelleyBasedEraBabbage  ->
-      isLeadingSlotsPraos  (slotRangeOfInterest pp) poolid markSnapshotPoolDistr nextEpochsNonce vrfSkey f
-    ShelleyBasedEraConway   ->
-      isLeadingSlotsPraos  (slotRangeOfInterest pp) poolid markSnapshotPoolDistr nextEpochsNonce vrfSkey f
+  shelleyBasedEraConstraints sbe
+    $ isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid markSnapshotPoolDistr nextEpochsNonce vrfSkey f
  where
   globals = shelleyBasedEraConstraints sbe
               $ constructGlobals sGen eInfo $ pp ^. Core.ppProtocolVersionL

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -2443,6 +2443,7 @@ createTransactionBody sbe txBodyContent =
             TxBodyNoScriptData -> pure SNothing
             TxBodyScriptData _ datums redeemers ->
               convPParamsToScriptIntegrityHash
+                sbe
                 apiProtocolParameters
                 redeemers
                 datums
@@ -2474,6 +2475,7 @@ createTransactionBody sbe txBodyContent =
             TxBodyScriptData _sDataSupported datums redeemers ->
               withShelleyBasedEraConstraintsForLedger sbe
                 $ convPParamsToScriptIntegrityHash
+                    sbe
                     apiProtocolParameters
                     redeemers
                     datums
@@ -2507,6 +2509,7 @@ createTransactionBody sbe txBodyContent =
             TxBodyScriptData _sDataSupported datums redeemers ->
               withShelleyBasedEraConstraintsForLedger sbe
                 $ convPParamsToScriptIntegrityHash
+                    sbe
                     apiProtocolParameters
                     redeemers
                     datums
@@ -3569,17 +3572,18 @@ convScriptData era txOuts scriptWitnesses =
                   ]
       in TxBodyScriptData scriptDataInEra datums redeemers
 
-convPParamsToScriptIntegrityHash
-  :: L.AlonzoEraPParams (ShelleyLedgerEra era)
+convPParamsToScriptIntegrityHash :: ()
+  => ShelleyBasedEra era
+  -> L.AlonzoEraPParams (ShelleyLedgerEra era)
   => BuildTxWith BuildTx (Maybe (LedgerProtocolParameters era))
   -> Alonzo.Redeemers (ShelleyLedgerEra era)
   -> Alonzo.TxDats (ShelleyLedgerEra era)
   -> Set Alonzo.Language
   -> Either TxBodyError (StrictMaybe (L.ScriptIntegrityHash (Ledger.EraCrypto (ShelleyLedgerEra era))))
-convPParamsToScriptIntegrityHash txProtocolParams redeemers datums languages = do
+convPParamsToScriptIntegrityHash sbe txProtocolParams redeemers datums languages = do
   lang <- case txProtocolParams of
                BuildTxWith Nothing -> return Nothing
-               BuildTxWith (Just (LedgerPParams sbe pp)) ->
+               BuildTxWith (Just (LedgerProtocolParameters pp)) ->
                  case sbe of
                    ShelleyBasedEraShelley ->
                      return Nothing
@@ -3788,7 +3792,7 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraAlonzo
 
     validateTxBodyContent sbe txbodycontent
     update <- convTxUpdateProposal sbe txUpdateProposal
-    scriptIntegrityHash <- convPParamsToScriptIntegrityHash txProtocolParams redeemers datums languages
+    scriptIntegrityHash <- convPParamsToScriptIntegrityHash sbe txProtocolParams redeemers datums languages
     return $
       ShelleyTxBody sbe
         (mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
@@ -3874,7 +3878,7 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraBabbage
 
     validateTxBodyContent sbe txbodycontent
     update <- convTxUpdateProposal sbe txUpdateProposal
-    scriptIntegrityHash <- convPParamsToScriptIntegrityHash txProtocolParams redeemers datums languages
+    scriptIntegrityHash <- convPParamsToScriptIntegrityHash sbe txProtocolParams redeemers datums languages
     return $
       ShelleyTxBody sbe
         (mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
@@ -3974,7 +3978,7 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraConway
                            } = do
 
     validateTxBodyContent sbe txbodycontent
-    scriptIntegrityHash <- convPParamsToScriptIntegrityHash txProtocolParams redeemers datums languages
+    scriptIntegrityHash <- convPParamsToScriptIntegrityHash sbe txProtocolParams redeemers datums languages
     return $
       ShelleyTxBody sbe
         (mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -120,7 +120,6 @@ module Cardano.Api.Shelley
     IntroducedInBabbagePParams(..),
     createEraBasedProtocolParamUpdate,
     convertToLedgerProtocolParameters,
-    createLedgerProtocolParameters,
 
     ProtocolParameters(..),
     checkProtocolParameters,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `newtype` instead of `GADT` for `LedgerProtocolParameters`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

A `newtype` is a thinner wrapper around the base type than a GADT.  This will make accessing the contents of the type easier.

There is no need to carry a witness value because the caller can supply it and there is no need to carry a constraint because the caller can use the witness to summon the constraint.  In this case `shelleyBasedEraConstraints w` will do.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
