### PR TITLE
Features we currently could use

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -63,6 +63,7 @@ library internal
                         Cardano.Api.Error
                         Cardano.Api.Feature
                         Cardano.Api.Feature.AlonzoEraOnwards
+                        Cardano.Api.Feature.BabbageEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -65,6 +65,7 @@ library internal
                         Cardano.Api.Feature.ConwayEraOnwards
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra
+                        Cardano.Api.Feature.ShelleyToMaryEra
                         Cardano.Api.Fees
                         Cardano.Api.Genesis
                         Cardano.Api.GenesisParameters

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -63,6 +63,7 @@ library internal
                         Cardano.Api.Error
                         Cardano.Api.Feature
                         Cardano.Api.Feature.ConwayEraOnwards
+                        Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra
                         Cardano.Api.Fees
                         Cardano.Api.Genesis

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -62,6 +62,7 @@ library internal
                         Cardano.Api.Eras.Core
                         Cardano.Api.Error
                         Cardano.Api.Feature
+                        Cardano.Api.Feature.AlonzoEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -62,6 +62,7 @@ library internal
                         Cardano.Api.Eras.Core
                         Cardano.Api.Error
                         Cardano.Api.Feature
+                        Cardano.Api.Feature.AlonzoEraOnly
                         Cardano.Api.Feature.AlonzoEraOnwards
                         Cardano.Api.Feature.BabbageEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -65,6 +65,7 @@ library internal
                         Cardano.Api.Feature.AlonzoEraOnwards
                         Cardano.Api.Feature.BabbageEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards
+                        Cardano.Api.Feature.ShelleyToAllegraEra
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra
                         Cardano.Api.Feature.ShelleyToMaryEra

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -9,6 +9,8 @@ module Cardano.Api.Eras
   , AlonzoEra
   , BabbageEra
   , ConwayEra
+
+    -- * CardanoEra
   , CardanoEra(..)
   , IsCardanoEra(..)
   , AnyCardanoEra(..)
@@ -16,6 +18,7 @@ module Cardano.Api.Eras
   , cardanoEraConstraints
   , InAnyCardanoEra(..)
   , CardanoLedgerEra
+  , ToCardanoEra(..)
 
     -- * FeatureInEra
   , FeatureInEra(..)

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -20,12 +20,15 @@ module Cardano.Api.Eras.Core
   , AlonzoEra
   , BabbageEra
   , ConwayEra
+
+    -- * CardanoEra
   , CardanoEra(..)
   , IsCardanoEra(..)
   , AnyCardanoEra(..)
   , anyCardanoEra
   , InAnyCardanoEra(..)
   , CardanoLedgerEra
+  , ToCardanoEra(..)
 
     -- * FeatureInEra
   , FeatureInEra(..)
@@ -199,6 +202,14 @@ inShelleyBasedEraFeatureMaybe era yes =
   inShelleyBasedEraFeature era Nothing (Just . yes)
 
 -- ----------------------------------------------------------------------------
+-- ToCardanoEra
+
+class ToCardanoEra (feature :: Type -> Type) where
+  toCardanoEra :: ()
+    => feature era
+    -> CardanoEra era
+
+-- ----------------------------------------------------------------------------
 -- Value level representation for Cardano eras
 --
 
@@ -247,6 +258,9 @@ instance TestEquality CardanoEra where
 
 instance FeatureInEra CardanoEra where
   featureInEra _ yes = yes
+
+instance ToCardanoEra CardanoEra where
+  toCardanoEra = id
 
 -- | The class of Cardano eras. This allows uniform handling of all Cardano
 -- eras, but also non-uniform by making case distinctions on the 'CardanoEra'
@@ -358,7 +372,6 @@ data InAnyCardanoEra thing where
                      -> thing era
                      -> InAnyCardanoEra thing
 
-
 -- ----------------------------------------------------------------------------
 -- Shelley-based eras
 --
@@ -413,6 +426,15 @@ instance FeatureInEra ShelleyBasedEra where
     AlonzoEra   -> yes ShelleyBasedEraAlonzo
     BabbageEra  -> yes ShelleyBasedEraBabbage
     ConwayEra   -> yes ShelleyBasedEraConway
+
+instance ToCardanoEra ShelleyBasedEra where
+  toCardanoEra = \case
+    ShelleyBasedEraShelley -> ShelleyEra
+    ShelleyBasedEraAllegra -> AllegraEra
+    ShelleyBasedEraMary    -> MaryEra
+    ShelleyBasedEraAlonzo  -> AlonzoEra
+    ShelleyBasedEraBabbage -> BabbageEra
+    ShelleyBasedEraConway  -> ConwayEra
 
 -- | The class of eras that are based on Shelley. This allows uniform handling
 -- of Shelley-based eras, but also non-uniform by making case distinctions on

--- a/cardano-api/internal/Cardano/Api/Feature.hs
+++ b/cardano-api/internal/Cardano/Api/Feature.hs
@@ -12,7 +12,7 @@ module Cardano.Api.Feature
   , asFeaturedInShelleyBasedEra
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 
 -- | A value only if the feature is supported in this era
 data Featured feature era a where

--- a/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnly.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.AlonzoEraOnly
+  ( AlonzoEraOnly(..)
+  , IsAlonzoEraOnly(..)
+  , AnyAlonzoEraOnly(..)
+  , alonzoEraOnlyConstraints
+  , alonzoEraOnlyToCardanoEra
+  , alonzoEraOnlyToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsAlonzoEraOnly era where
+  alonzoEraOnly :: AlonzoEraOnly era
+
+data AlonzoEraOnly era where
+  AlonzoEraOnlyAlonzo  :: AlonzoEraOnly AlonzoEra
+
+deriving instance Show (AlonzoEraOnly era)
+deriving instance Eq (AlonzoEraOnly era)
+
+instance IsAlonzoEraOnly AlonzoEra where
+  alonzoEraOnly = AlonzoEraOnlyAlonzo
+
+instance FeatureInEra AlonzoEraOnly where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> yes AlonzoEraOnlyAlonzo
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra AlonzoEraOnly where
+  toCardanoEra = \case
+    AlonzoEraOnlyAlonzo  -> AlonzoEra
+
+data AnyAlonzoEraOnly where
+  AnyAlonzoEraOnly :: AlonzoEraOnly era -> AnyAlonzoEraOnly
+
+deriving instance Show AnyAlonzoEraOnly
+
+type AlonzoEraOnlyConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.AlonzoEraPParams (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.ExactEra L.AlonzoEra (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsAlonzoEraOnly era
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+alonzoEraOnlyConstraints :: ()
+  => AlonzoEraOnly era
+  -> (AlonzoEraOnlyConstraints era => a)
+  -> a
+alonzoEraOnlyConstraints = \case
+  AlonzoEraOnlyAlonzo  -> id
+
+alonzoEraOnlyToCardanoEra :: AlonzoEraOnly era -> CardanoEra era
+alonzoEraOnlyToCardanoEra = shelleyBasedToCardanoEra . alonzoEraOnlyToShelleyBasedEra
+
+alonzoEraOnlyToShelleyBasedEra :: AlonzoEraOnly era -> ShelleyBasedEra era
+alonzoEraOnlyToShelleyBasedEra = \case
+  AlonzoEraOnlyAlonzo  -> ShelleyBasedEraAlonzo

--- a/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnwards.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.AlonzoEraOnwards
+  ( AlonzoEraOnwards(..)
+  , IsAlonzoEraOnwards(..)
+  , AnyAlonzoEraOnwards(..)
+  , alonzoEraOnwardsConstraints
+  , alonzoEraOnwardsToCardanoEra
+  , alonzoEraOnwardsToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsAlonzoEraOnwards era where
+  alonzoEraOnwards :: AlonzoEraOnwards era
+
+data AlonzoEraOnwards era where
+  AlonzoEraOnwardsAlonzo  :: AlonzoEraOnwards AlonzoEra
+  AlonzoEraOnwardsBabbage :: AlonzoEraOnwards BabbageEra
+  AlonzoEraOnwardsConway  :: AlonzoEraOnwards ConwayEra
+
+deriving instance Show (AlonzoEraOnwards era)
+deriving instance Eq (AlonzoEraOnwards era)
+
+instance IsAlonzoEraOnwards AlonzoEra where
+  alonzoEraOnwards = AlonzoEraOnwardsAlonzo
+
+instance IsAlonzoEraOnwards BabbageEra where
+  alonzoEraOnwards = AlonzoEraOnwardsBabbage
+
+instance IsAlonzoEraOnwards ConwayEra where
+  alonzoEraOnwards = AlonzoEraOnwardsConway
+
+instance FeatureInEra AlonzoEraOnwards where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> yes AlonzoEraOnwardsAlonzo
+    BabbageEra  -> yes AlonzoEraOnwardsBabbage
+    ConwayEra   -> yes AlonzoEraOnwardsConway
+
+instance ToCardanoEra AlonzoEraOnwards where
+  toCardanoEra = \case
+    AlonzoEraOnwardsAlonzo  -> AlonzoEra
+    AlonzoEraOnwardsBabbage -> BabbageEra
+    AlonzoEraOnwardsConway  -> ConwayEra
+
+data AnyAlonzoEraOnwards where
+  AnyAlonzoEraOnwards :: AlonzoEraOnwards era -> AnyAlonzoEraOnwards
+
+deriving instance Show AnyAlonzoEraOnwards
+
+type AlonzoEraOnwardsConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.AlonzoEraPParams (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsAlonzoEraOnwards era
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+alonzoEraOnwardsConstraints :: ()
+  => AlonzoEraOnwards era
+  -> (AlonzoEraOnwardsConstraints era => a)
+  -> a
+alonzoEraOnwardsConstraints = \case
+  AlonzoEraOnwardsAlonzo  -> id
+  AlonzoEraOnwardsBabbage -> id
+  AlonzoEraOnwardsConway  -> id
+
+alonzoEraOnwardsToCardanoEra :: AlonzoEraOnwards era -> CardanoEra era
+alonzoEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . alonzoEraOnwardsToShelleyBasedEra
+
+alonzoEraOnwardsToShelleyBasedEra :: AlonzoEraOnwards era -> ShelleyBasedEra era
+alonzoEraOnwardsToShelleyBasedEra = \case
+  AlonzoEraOnwardsAlonzo  -> ShelleyBasedEraAlonzo
+  AlonzoEraOnwardsBabbage -> ShelleyBasedEraBabbage
+  AlonzoEraOnwardsConway  -> ShelleyBasedEraConway

--- a/cardano-api/internal/Cardano/Api/Feature/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/BabbageEraOnwards.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.BabbageEraOnwards
+  ( BabbageEraOnwards(..)
+  , IsBabbageEraOnwards(..)
+  , AnyBabbageEraOnwards(..)
+  , babbageEraOnwardsConstraints
+  , babbageEraOnwardsToCardanoEra
+  , babbageEraOnwardsToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsBabbageEraOnwards era where
+  babbageEraOnwards :: BabbageEraOnwards era
+
+data BabbageEraOnwards era where
+  BabbageEraOnwardsBabbage :: BabbageEraOnwards BabbageEra
+  BabbageEraOnwardsConway  :: BabbageEraOnwards ConwayEra
+
+deriving instance Show (BabbageEraOnwards era)
+deriving instance Eq (BabbageEraOnwards era)
+
+instance IsBabbageEraOnwards BabbageEra where
+  babbageEraOnwards = BabbageEraOnwardsBabbage
+
+instance IsBabbageEraOnwards ConwayEra where
+  babbageEraOnwards = BabbageEraOnwardsConway
+
+instance FeatureInEra BabbageEraOnwards where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> yes BabbageEraOnwardsBabbage
+    ConwayEra   -> yes BabbageEraOnwardsConway
+
+instance ToCardanoEra BabbageEraOnwards where
+  toCardanoEra = \case
+    BabbageEraOnwardsBabbage -> BabbageEra
+    BabbageEraOnwardsConway  -> ConwayEra
+
+data AnyBabbageEraOnwards where
+  AnyBabbageEraOnwards :: BabbageEraOnwards era -> AnyBabbageEraOnwards
+
+deriving instance Show AnyBabbageEraOnwards
+
+type BabbageEraOnwardsConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.BabbageEraPParams (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsBabbageEraOnwards era
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+babbageEraOnwardsConstraints :: ()
+  => BabbageEraOnwards era
+  -> (BabbageEraOnwardsConstraints era => a)
+  -> a
+babbageEraOnwardsConstraints = \case
+  BabbageEraOnwardsBabbage -> id
+  BabbageEraOnwardsConway  -> id
+
+babbageEraOnwardsToCardanoEra :: BabbageEraOnwards era -> CardanoEra era
+babbageEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . babbageEraOnwardsToShelleyBasedEra
+
+babbageEraOnwardsToShelleyBasedEra :: BabbageEraOnwards era -> ShelleyBasedEra era
+babbageEraOnwardsToShelleyBasedEra = \case
+  BabbageEraOnwardsBabbage -> ShelleyBasedEraBabbage
+  BabbageEraOnwardsConway  -> ShelleyBasedEraConway

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -58,6 +58,10 @@ instance FeatureInEra ConwayEraOnwards where
     BabbageEra  -> no
     ConwayEra   -> yes ConwayEraOnwardsConway
 
+instance ToCardanoEra ConwayEraOnwards where
+  toCardanoEra = \case
+    ConwayEraOnwardsConway -> ConwayEra
+
 data AnyConwayEraOnwards where
   AnyConwayEraOnwards :: ConwayEraOnwards era -> AnyConwayEraOnwards
 

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToAllegraEra.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.ShelleyToAllegraEra
+  ( ShelleyToAllegraEra(..)
+  , IsShelleyToAllegraEra(..)
+  , AnyShelleyToAllegraEra(..)
+  , shelleyToAllegraEraConstraints
+  , shelleyToAllegraEraToCardanoEra
+  , shelleyToAllegraEraToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsShelleyToAllegraEra era where
+  shelleyToAllegraEra :: ShelleyToAllegraEra era
+
+data ShelleyToAllegraEra era where
+  ShelleyToAllegraEraShelley :: ShelleyToAllegraEra ShelleyEra
+  ShelleyToAllegraEraAllegra :: ShelleyToAllegraEra AllegraEra
+
+deriving instance Show (ShelleyToAllegraEra era)
+deriving instance Eq (ShelleyToAllegraEra era)
+
+instance IsShelleyToAllegraEra ShelleyEra where
+  shelleyToAllegraEra = ShelleyToAllegraEraShelley
+
+instance IsShelleyToAllegraEra AllegraEra where
+  shelleyToAllegraEra = ShelleyToAllegraEraAllegra
+
+instance FeatureInEra ShelleyToAllegraEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToAllegraEraShelley
+    AllegraEra  -> yes ShelleyToAllegraEraAllegra
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyToAllegraEra where
+  toCardanoEra = \case
+    ShelleyToAllegraEraShelley  -> ShelleyEra
+    ShelleyToAllegraEraAllegra  -> AllegraEra
+
+type ShelleyToAllegraEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 4
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , IsShelleyToAllegraEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+data AnyShelleyToAllegraEra where
+  AnyShelleyToAllegraEra :: ShelleyToAllegraEra era -> AnyShelleyToAllegraEra
+
+deriving instance Show AnyShelleyToAllegraEra
+
+shelleyToAllegraEraConstraints :: ()
+  => ShelleyToAllegraEra era
+  -> (ShelleyToAllegraEraConstraints era => a)
+  -> a
+shelleyToAllegraEraConstraints = \case
+  ShelleyToAllegraEraShelley -> id
+  ShelleyToAllegraEraAllegra -> id
+
+shelleyToAllegraEraToCardanoEra :: ShelleyToAllegraEra era -> CardanoEra era
+shelleyToAllegraEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToAllegraEraToShelleyBasedEra
+
+shelleyToAllegraEraToShelleyBasedEra :: ShelleyToAllegraEra era -> ShelleyBasedEra era
+shelleyToAllegraEraToShelleyBasedEra = \case
+  ShelleyToAllegraEraShelley -> ShelleyBasedEraShelley
+  ShelleyToAllegraEraAllegra -> ShelleyBasedEraAllegra

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToAlonzoEra.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.ShelleyToAlonzoEra
+  ( ShelleyToAlonzoEra(..)
+  , IsShelleyToAlonzoEra(..)
+  , AnyShelleyToAlonzoEra(..)
+  , shelleyToAlonzoEraConstraints
+  , shelleyToAlonzoEraToCardanoEra
+  , shelleyToAlonzoEraToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsShelleyToAlonzoEra era where
+  shelleyToAlonzoEra :: ShelleyToAlonzoEra era
+
+data ShelleyToAlonzoEra era where
+  ShelleyToAlonzoEraShelley :: ShelleyToAlonzoEra ShelleyEra
+  ShelleyToAlonzoEraAllegra :: ShelleyToAlonzoEra AllegraEra
+  ShelleyToAlonzoEraMary :: ShelleyToAlonzoEra MaryEra
+  ShelleyToAlonzoEraAlonzo :: ShelleyToAlonzoEra AlonzoEra
+
+deriving instance Show (ShelleyToAlonzoEra era)
+deriving instance Eq (ShelleyToAlonzoEra era)
+
+instance IsShelleyToAlonzoEra ShelleyEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraShelley
+
+instance IsShelleyToAlonzoEra AllegraEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraAllegra
+
+instance IsShelleyToAlonzoEra MaryEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraMary
+
+instance IsShelleyToAlonzoEra AlonzoEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraAlonzo
+
+instance FeatureInEra ShelleyToAlonzoEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToAlonzoEraShelley
+    AllegraEra  -> yes ShelleyToAlonzoEraAllegra
+    MaryEra     -> yes ShelleyToAlonzoEraMary
+    AlonzoEra   -> yes ShelleyToAlonzoEraAlonzo
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyToAlonzoEra where
+  toCardanoEra = \case
+    ShelleyToAlonzoEraShelley  -> ShelleyEra
+    ShelleyToAlonzoEraAllegra  -> AllegraEra
+    ShelleyToAlonzoEraMary     -> MaryEra
+    ShelleyToAlonzoEraAlonzo   -> AlonzoEra
+
+type ShelleyToAlonzoEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 6
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , IsShelleyToAlonzoEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+data AnyShelleyToAlonzoEra where
+  AnyShelleyToAlonzoEra :: ShelleyToAlonzoEra era -> AnyShelleyToAlonzoEra
+
+deriving instance Show AnyShelleyToAlonzoEra
+
+shelleyToAlonzoEraConstraints :: ()
+  => ShelleyToAlonzoEra era
+  -> (ShelleyToAlonzoEraConstraints era => a)
+  -> a
+shelleyToAlonzoEraConstraints = \case
+  ShelleyToAlonzoEraShelley -> id
+  ShelleyToAlonzoEraAllegra -> id
+  ShelleyToAlonzoEraMary    -> id
+  ShelleyToAlonzoEraAlonzo  -> id
+
+shelleyToAlonzoEraToCardanoEra :: ShelleyToAlonzoEra era -> CardanoEra era
+shelleyToAlonzoEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToAlonzoEraToShelleyBasedEra
+
+shelleyToAlonzoEraToShelleyBasedEra :: ShelleyToAlonzoEra era -> ShelleyBasedEra era
+shelleyToAlonzoEraToShelleyBasedEra = \case
+  ShelleyToAlonzoEraShelley -> ShelleyBasedEraShelley
+  ShelleyToAlonzoEraAllegra -> ShelleyBasedEraAllegra
+  ShelleyToAlonzoEraMary    -> ShelleyBasedEraMary
+  ShelleyToAlonzoEraAlonzo  -> ShelleyBasedEraAlonzo

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -95,6 +96,7 @@ type ShelleyToBabbageEraConstraints era =
   , L.EraTx (ShelleyLedgerEra era)
   , L.EraTxBody (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 7
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
   , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -74,6 +74,14 @@ instance FeatureInEra ShelleyToBabbageEra where
     BabbageEra  -> yes ShelleyToBabbageEraBabbage
     ConwayEra   -> no
 
+instance ToCardanoEra ShelleyToBabbageEra where
+  toCardanoEra = \case
+    ShelleyToBabbageEraShelley  -> ShelleyEra
+    ShelleyToBabbageEraAllegra  -> AllegraEra
+    ShelleyToBabbageEraMary     -> MaryEra
+    ShelleyToBabbageEraAlonzo   -> AlonzoEra
+    ShelleyToBabbageEraBabbage  -> BabbageEra
+
 type ShelleyToBabbageEraConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -85,6 +86,7 @@ type ShelleyToMaryEraConstraints era =
   , L.EraTx (ShelleyLedgerEra era)
   , L.EraTxBody (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 5
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
   , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.ShelleyToMaryEra
+  ( ShelleyToMaryEra(..)
+  , IsShelleyToMaryEra(..)
+  , AnyShelleyToMaryEra(..)
+  , shelleyToMaryEraConstraints
+  , shelleyToMaryEraToCardanoEra
+  , shelleyToMaryEraToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsShelleyToMaryEra era where
+  shelleyToMaryEra :: ShelleyToMaryEra era
+
+data ShelleyToMaryEra era where
+  ShelleyToMaryEraShelley :: ShelleyToMaryEra ShelleyEra
+  ShelleyToMaryEraAllegra :: ShelleyToMaryEra AllegraEra
+  ShelleyToMaryEraMary    :: ShelleyToMaryEra MaryEra
+
+deriving instance Show (ShelleyToMaryEra era)
+deriving instance Eq (ShelleyToMaryEra era)
+
+instance IsShelleyToMaryEra ShelleyEra where
+  shelleyToMaryEra = ShelleyToMaryEraShelley
+
+instance IsShelleyToMaryEra AllegraEra where
+  shelleyToMaryEra = ShelleyToMaryEraAllegra
+
+instance IsShelleyToMaryEra MaryEra where
+  shelleyToMaryEra = ShelleyToMaryEraMary
+
+instance FeatureInEra ShelleyToMaryEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToMaryEraShelley
+    AllegraEra  -> yes ShelleyToMaryEraAllegra
+    MaryEra     -> yes ShelleyToMaryEraMary
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyToMaryEra where
+  toCardanoEra = \case
+    ShelleyToMaryEraShelley  -> ShelleyEra
+    ShelleyToMaryEraAllegra  -> AllegraEra
+    ShelleyToMaryEraMary     -> MaryEra
+
+type ShelleyToMaryEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , IsShelleyToMaryEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+data AnyShelleyToMaryEra where
+  AnyShelleyToMaryEra :: ShelleyToMaryEra era -> AnyShelleyToMaryEra
+
+deriving instance Show AnyShelleyToMaryEra
+
+shelleyToMaryEraConstraints :: ()
+  => ShelleyToMaryEra era
+  -> (ShelleyToMaryEraConstraints era => a)
+  -> a
+shelleyToMaryEraConstraints = \case
+  ShelleyToMaryEraShelley -> id
+  ShelleyToMaryEraAllegra -> id
+  ShelleyToMaryEraMary    -> id
+
+shelleyToMaryEraToCardanoEra :: ShelleyToMaryEra era -> CardanoEra era
+shelleyToMaryEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToMaryEraToShelleyBasedEra
+
+shelleyToMaryEraToShelleyBasedEra :: ShelleyToMaryEra era -> ShelleyBasedEra era
+shelleyToMaryEraToShelleyBasedEra = \case
+  ShelleyToMaryEraShelley -> ShelleyBasedEraShelley
+  ShelleyToMaryEraAllegra -> ShelleyBasedEraAllegra
+  ShelleyToMaryEraMary    -> ShelleyBasedEraMary

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -20,6 +20,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 {- HLINT ignore "Redundant ==" -}
+{- HLINT ignore "Use mapM" -}
 
 -- | The various Cardano protocol parameters, including:
 --
@@ -1012,6 +1013,11 @@ instance FeatureInEra ProtocolUTxOCostPerByteFeature where
     BabbageEra  -> yes ProtocolUTxOCostPerByteInBabbageEra
     ConwayEra   -> yes ProtocolUTxOCostPerByteInConwayEra
 
+instance ToCardanoEra ProtocolUTxOCostPerByteFeature where
+  toCardanoEra = \case
+    ProtocolUTxOCostPerByteInBabbageEra -> BabbageEra
+    ProtocolUTxOCostPerByteInConwayEra  -> ConwayEra
+
 -- | A representation of whether the era supports the 'UTxO Cost Per Word'
 -- protocol parameter.
 --
@@ -1032,6 +1038,10 @@ instance FeatureInEra ProtocolUTxOCostPerWordFeature where
     AlonzoEra   -> yes ProtocolUpdateUTxOCostPerWordInAlonzoEra
     BabbageEra  -> no
     ConwayEra   -> no
+
+instance ToCardanoEra ProtocolUTxOCostPerWordFeature where
+  toCardanoEra = \case
+    ProtocolUpdateUTxOCostPerWordInAlonzoEra -> AlonzoEra
 
 -- ----------------------------------------------------------------------------
 -- Praos nonce
@@ -1950,4 +1960,3 @@ instance Error ProtocolParametersConversionError where
     PpceVersionInvalid majorProtVer -> "Major protocol version is invalid: " <> show majorProtVer
     PpceInvalidCostModel cm err -> "Invalid cost model: " <> display err <> " Cost model: " <> show cm
     PpceMissingParameter name -> "Missing parameter: " <> name
-

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -78,6 +78,13 @@ module Cardano.Api (
     alonzoEraOnwardsToCardanoEra,
     alonzoEraOnwardsToShelleyBasedEra,
 
+    AlonzoEraOnly(..),
+    IsAlonzoEraOnly(..),
+    AnyAlonzoEraOnly(..),
+    alonzoEraOnlyConstraints,
+    alonzoEraOnlyToCardanoEra,
+    alonzoEraOnlyToShelleyBasedEra,
+
     BabbageEraOnwards(..),
     IsBabbageEraOnwards(..),
     AnyBabbageEraOnwards(..),
@@ -994,6 +1001,7 @@ import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
+import           Cardano.Api.Feature.AlonzoEraOnly
 import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -57,6 +57,13 @@ module Cardano.Api (
     shelleyToAlonzoEraToCardanoEra,
     shelleyToAlonzoEraToShelleyBasedEra,
 
+    ShelleyToMaryEra(..),
+    IsShelleyToMaryEra(..),
+    AnyShelleyToMaryEra(..),
+    shelleyToMaryEraConstraints,
+    shelleyToMaryEraToCardanoEra,
+    shelleyToMaryEraToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -969,6 +976,7 @@ import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
+import           Cardano.Api.Feature.ShelleyToMaryEra
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -25,6 +25,7 @@ module Cardano.Api (
     anyCardanoEra,
     cardanoEraConstraints,
     InAnyCardanoEra(..),
+    ToCardanoEra(..),
 
     -- * Feature support
     FeatureInEra(..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -50,6 +50,13 @@ module Cardano.Api (
     shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
 
+    ShelleyToAllegraEra(..),
+    IsShelleyToAllegraEra(..),
+    AnyShelleyToAllegraEra(..),
+    shelleyToAllegraEraConstraints,
+    shelleyToAllegraEraToCardanoEra,
+    shelleyToAllegraEraToShelleyBasedEra,
+
     ShelleyToAlonzoEra(..),
     IsShelleyToAlonzoEra(..),
     AnyShelleyToAlonzoEra(..),
@@ -990,6 +997,7 @@ import           Cardano.Api.Feature
 import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToAllegraEra
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Feature.ShelleyToMaryEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -64,6 +64,13 @@ module Cardano.Api (
     shelleyToMaryEraToCardanoEra,
     shelleyToMaryEraToShelleyBasedEra,
 
+    AlonzoEraOnwards(..),
+    IsAlonzoEraOnwards(..),
+    AnyAlonzoEraOnwards(..),
+    alonzoEraOnwardsConstraints,
+    alonzoEraOnwardsToCardanoEra,
+    alonzoEraOnwardsToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -973,6 +980,7 @@ import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
+import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -71,6 +71,13 @@ module Cardano.Api (
     alonzoEraOnwardsToCardanoEra,
     alonzoEraOnwardsToShelleyBasedEra,
 
+    BabbageEraOnwards(..),
+    IsBabbageEraOnwards(..),
+    AnyBabbageEraOnwards(..),
+    babbageEraOnwardsConstraints,
+    babbageEraOnwardsToCardanoEra,
+    babbageEraOnwardsToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -981,6 +988,7 @@ import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.AlonzoEraOnwards
+import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -50,6 +50,13 @@ module Cardano.Api (
     shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
 
+    ShelleyToAlonzoEra(..),
+    IsShelleyToAlonzoEra(..),
+    AnyShelleyToAlonzoEra(..),
+    shelleyToAlonzoEraConstraints,
+    shelleyToAlonzoEraToCardanoEra,
+    shelleyToAlonzoEraToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -960,6 +967,7 @@ import           Cardano.Api.Eras
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add the following features:
    * `AlonzoEraOnly`
    * `ShelleyToAllegraEra`
    * `BabbageEraOnwards`
    * `AlonzoEraOnwards`
    * `ShelleyToMaryEra`
    * `ShelleyToAlonzoEra`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

These represent the era-ranges that are currently relevant to protocol parameters in the ledger.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
