### PR TITLE
`FeatureInEra` instances for `CardanoEra` and `ShelleyBasedEra`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -293,6 +293,8 @@ instance TestEquality CardanoEra where
     testEquality ConwayEra  ConwayEra  = Just Refl
     testEquality _          _          = Nothing
 
+instance FeatureInEra CardanoEra where
+  featureInEra _ yes = yes
 
 -- | The class of Cardano eras. This allows uniform handling of all Cardano
 -- eras, but also non-uniform by making case distinctions on the 'CardanoEra'
@@ -449,6 +451,16 @@ instance TestEquality ShelleyBasedEra where
     testEquality ShelleyBasedEraBabbage ShelleyBasedEraBabbage = Just Refl
     testEquality ShelleyBasedEraConway  ShelleyBasedEraConway  = Just Refl
     testEquality _                      _                      = Nothing
+
+instance FeatureInEra ShelleyBasedEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyBasedEraShelley
+    AllegraEra  -> yes ShelleyBasedEraAllegra
+    MaryEra     -> yes ShelleyBasedEraMary
+    AlonzoEra   -> yes ShelleyBasedEraAlonzo
+    BabbageEra  -> yes ShelleyBasedEraBabbage
+    ConwayEra   -> yes ShelleyBasedEraConway
 
 -- | The class of eras that are based on Shelley. This allows uniform handling
 -- of Shelley-based eras, but also non-uniform by making case distinctions on


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    `FeatureInEra` instances for `CardanoEra` and `ShelleyBasedEra`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This is for completeness, and I will use the `ShelleyBasedEra` instance shortly in `cardano-cli` to add era-based `stake-address` command group.  That command groups contains commands that should only appear in Shelley era onwards.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
