### PR TITLE
Update cardano-api to a newer cardano-ledger

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-06T23:58:58Z
-  , cardano-haskell-packages 2023-08-21T16:55:07Z
+  , cardano-haskell-packages 2023-09-07T15:55:30Z
 
 packages:
     cardano-api

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -175,7 +175,9 @@ library internal
                       , scientific
                       , serialise
                       , small-steps ^>= 1.0
+                      , sop-core
                       , stm
+                      , strict-sop-core
                       , text >= 2.0
                       , time
                       , transformers

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -97,6 +97,7 @@ library internal
                         Cardano.Api.Query.Expr
                         Cardano.Api.Query.Types
                         Cardano.Api.ReexposeLedger
+                        Cardano.Api.Rewards
                         Cardano.Api.Script
                         Cardano.Api.ScriptData
                         Cardano.Api.SerialiseBech32

--- a/cardano-api/internal/Cardano/Api/Address.hs
+++ b/cardano-api/internal/Cardano/Api/Address.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -69,6 +69,7 @@ module Cardano.Api.Certificate (
 
     -- * Internal functions
     filterUnRegCreds,
+    filterUnRegDRepCreds,
     selectStakeCredential,
   ) where
 
@@ -715,6 +716,14 @@ filterUnRegCreds sbe cert =
     ConwayCertificate _ (Ledger.ConwayTxCertDeleg (Ledger.ConwayUnRegCert cred _)) ->
       Just $ shelleyBasedEraConstraints sbe $ fromShelleyStakeCredential cred
     _  -> Nothing
+
+filterUnRegDRepCreds
+  :: ShelleyBasedEra era -> Certificate era -> Maybe (Ledger.Credential Ledger.DRepRole Ledger.StandardCrypto)
+filterUnRegDRepCreds sbe cert =
+  case (sbe, cert) of
+    (_, ShelleyRelatedCertificate {}) -> Nothing
+    (ShelleyBasedEraConway, ConwayCertificate _ (Ledger.UnRegDRepTxCert cred _)) -> Just cred
+    (_, ConwayCertificate {}) -> Nothing
 
 -- ----------------------------------------------------------------------------
 -- Internal conversion functions

--- a/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 -- | Convenience transaction construction functions
 --
 module Cardano.Api.Convenience.Construction (
@@ -24,6 +26,10 @@ import           Cardano.Api.TxBody
 import           Cardano.Api.Utils
 import           Cardano.Api.Value
 
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.Credential as L
+import qualified Cardano.Ledger.Keys as L
+
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
@@ -46,16 +52,17 @@ constructBalancedTx
   -> SystemStart
   -> Set PoolId       -- ^ The set of registered stake pools
   -> Map.Map StakeCredential Lovelace
+  -> Map.Map (L.Credential L.DRepRole L.StandardCrypto) Lovelace
   -> [ShelleyWitnessSigningKey]
   -> Either TxBodyErrorAutoBalance (Tx era)
 constructBalancedTx txbodcontent changeAddr mOverrideWits utxo lpp
                     ledgerEpochInfo systemStart stakePools
-                    stakeDelegDeposits shelleyWitSigningKeys = do
+                    stakeDelegDeposits drepDelegDeposits shelleyWitSigningKeys = do
 
   BalancedTxBody _ txbody _txBalanceOutput _fee
     <- makeTransactionBodyAutoBalance
          systemStart ledgerEpochInfo
-         lpp stakePools stakeDelegDeposits utxo txbodcontent
+         lpp stakePools stakeDelegDeposits drepDelegDeposits utxo txbodcontent
          changeAddr mOverrideWits
 
   let keyWits = map (makeShelleyKeyWitness txbody) shelleyWitSigningKeys

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -645,14 +645,15 @@ evaluateTransactionBalance :: forall era.
                            => Ledger.PParams (ShelleyLedgerEra era)
                            -> Set PoolId
                            -> Map StakeCredential Lovelace
+                           -> Map (Ledger.Credential Ledger.DRepRole Ledger.StandardCrypto) Lovelace
                            -> UTxO era
                            -> TxBody era
                            -> TxOutValue era
-evaluateTransactionBalance _ _ _ _ (ByronTxBody _) =
+evaluateTransactionBalance _ _ _ _ _ (ByronTxBody _) =
     case shelleyBasedEra :: ShelleyBasedEra era of {}
     --TODO: we could actually support Byron here, it'd be different but simpler
 
-evaluateTransactionBalance pp poolids stakeDelegDeposits utxo
+evaluateTransactionBalance pp poolids stakeDelegDeposits drepDelegDeposits utxo
                            (ShelleyTxBody sbe txbody _ _ _ _) =
     withLedgerConstraints
       sbe
@@ -668,6 +669,12 @@ evaluateTransactionBalance pp poolids stakeDelegDeposits utxo
       toShelleyLovelace <$>
       Map.lookup (fromShelleyStakeCredential stakeCred) stakeDelegDeposits
 
+    lookupDRepDeposit ::
+      Ledger.Credential 'Ledger.DRepRole L.StandardCrypto -> Maybe Ledger.Coin
+    lookupDRepDeposit drepCred =
+      toShelleyLovelace <$>
+      Map.lookup drepCred drepDelegDeposits
+
     evalMultiAsset :: forall ledgerera.
                       ShelleyLedgerEra era ~ ledgerera
                    => LedgerEraConstraints ledgerera
@@ -679,6 +686,7 @@ evaluateTransactionBalance pp poolids stakeDelegDeposits utxo
          L.evalBalanceTxBody
            pp
            lookupDelegDeposit
+           lookupDRepDeposit
            isRegPool
            (toLedgerUTxO sbe utxo)
            txbody
@@ -694,6 +702,7 @@ evaluateTransactionBalance pp poolids stakeDelegDeposits utxo
        $ L.evalBalanceTxBody
            pp
            lookupDelegDeposit
+           lookupDRepDeposit
            isRegPool
            (toLedgerUTxO sbe utxo)
            txbody
@@ -904,13 +913,16 @@ makeTransactionBodyAutoBalance
   -> Map StakeCredential Lovelace
                       -- ^ Map of all deposits for stake credentials that are being
                       --   unregistered in this transaction
+  -> Map (Ledger.Credential Ledger.DRepRole Ledger.StandardCrypto) Lovelace
+                      -- ^ Map of all deposits for drep credentials that are being
+                      --   unregistered in this transaction
   -> UTxO era         -- ^ Just the transaction inputs, not the entire 'UTxO'.
   -> TxBodyContent BuildTx era
   -> AddressInEra era -- ^ Change address
   -> Maybe Word       -- ^ Override key witnesses
   -> Either TxBodyErrorAutoBalance (BalancedTxBody era)
 makeTransactionBodyAutoBalance systemstart history lpp@(LedgerProtocolParameters pp) poolids stakeDelegDeposits
-                            utxo txbodycontent changeaddr mnkeys = do
+                            drepDelegDeposits utxo txbodycontent changeaddr mnkeys = do
     -- Our strategy is to:
     -- 1. evaluate all the scripts to get the exec units, update with ex units
     -- 2. figure out the overall min fees
@@ -1006,7 +1018,7 @@ makeTransactionBodyAutoBalance systemstart history lpp@(LedgerProtocolParameters
                  txReturnCollateral = retColl,
                  txTotalCollateral = reqCol
                }
-    let balance = evaluateTransactionBalance pp poolids stakeDelegDeposits utxo txbody2
+    let balance = evaluateTransactionBalance pp poolids stakeDelegDeposits drepDelegDeposits utxo txbody2
 
     forM_ (txOuts txbodycontent1) $ \txout -> checkMinUTxOValue txout pp
 

--- a/cardano-api/internal/Cardano/Api/LedgerEvent.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerEvent.hs
@@ -55,7 +55,9 @@ import           Control.State.Transition (Event)
 import           Data.List.NonEmpty (NonEmpty)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Proxy (Proxy (Proxy))
 import           Data.Set (Set)
+import           Data.SOP (All, K (K))
 import           Data.SOP.Strict
 
 data LedgerEvent

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -190,7 +190,8 @@ import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.SOP.Strict (K (..), NP (..), fn, (:.:) (Comp))
+import           Data.SOP (K (K), (:.:) (Comp))
+import           Data.SOP.Strict (NP (..), fn)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -62,7 +62,8 @@ import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus
 
 import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value)
 import           Data.Aeson.Types (Parser, prependFailure, typeMismatch)
-import           Data.SOP.Strict (K (K), NS (S, Z))
+import           Data.SOP (K (K))
+import           Data.SOP.Strict (NS (S, Z))
 import           Data.Text (Text)
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -99,7 +99,6 @@ import qualified Cardano.Ledger.Api as L
 import           Cardano.Ledger.Binary
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import qualified Cardano.Ledger.CertState as L
-import qualified Cardano.Ledger.Credential as L
 import qualified Cardano.Ledger.Credential as Shelley
 import           Cardano.Ledger.Crypto (Crypto)
 import qualified Cardano.Ledger.Shelley.API as Shelley
@@ -141,7 +140,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.SOP.Strict (SListI)
+import           Data.SOP.Constraint (SListI)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
@@ -305,8 +304,8 @@ data QueryInShelleyBasedEra era result where
     :: QueryInShelleyBasedEra era (L.GovState (ShelleyLedgerEra era))
 
   QueryDRepState
-    :: Set (L.Credential Shelley.DRepRole StandardCrypto)
-    -> QueryInShelleyBasedEra era (Map (L.Credential Shelley.DRepRole StandardCrypto) (L.DRepState StandardCrypto))
+    :: Set (Shelley.Credential Shelley.DRepRole StandardCrypto)
+    -> QueryInShelleyBasedEra era (Map (Shelley.Credential Shelley.DRepRole StandardCrypto) (L.DRepState StandardCrypto))
 
   QueryDRepStakeDistr
     :: Set (Core.DRep StandardCrypto)

--- a/cardano-api/internal/Cardano/Api/Rewards.hs
+++ b/cardano-api/internal/Cardano/Api/Rewards.hs
@@ -1,0 +1,71 @@
+module Cardano.Api.Rewards
+  ( DelegationsAndRewards(..)
+  , mergeDelegsAndRewards
+  ) where
+
+import           Cardano.Api.Address
+import           Cardano.Api.Certificate
+import           Cardano.Api.Value
+
+import           Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import           Data.List (nub)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Vector as Vector
+
+-- | A mapping of Shelley reward accounts to both the stake pool that they
+-- delegate to and their reward account balance.
+-- TODO: Move to cardano-api
+newtype DelegationsAndRewards
+  = DelegationsAndRewards (Map StakeAddress Lovelace, Map StakeAddress PoolId)
+    deriving (Eq, Show)
+
+
+instance ToJSON DelegationsAndRewards where
+  toJSON delegsAndRwds =
+      Aeson.Array . Vector.fromList
+        . map delegAndRwdToJson $ mergeDelegsAndRewards delegsAndRwds
+    where
+      delegAndRwdToJson :: (StakeAddress, Maybe Lovelace, Maybe PoolId) -> Aeson.Value
+      delegAndRwdToJson (addr, mRewards, mPoolId) =
+        Aeson.object
+          [ "address" .= addr
+          , "delegation" .= mPoolId
+          , "rewardAccountBalance" .= mRewards
+          ]
+
+instance FromJSON DelegationsAndRewards where
+  parseJSON = withArray "DelegationsAndRewards" $ \arr -> do
+    let vals = Vector.toList arr
+    decoded <- mapM decodeObject vals
+    pure $ zipper decoded
+    where
+      zipper :: [(StakeAddress, Maybe Lovelace, Maybe PoolId)]
+              -> DelegationsAndRewards
+      zipper l = do
+        let maps = [ ( maybe mempty (Map.singleton sa) delegAmt
+                     , maybe mempty (Map.singleton sa) mPool
+                     )
+                   | (sa, delegAmt, mPool) <- l
+                   ]
+        DelegationsAndRewards
+          $ foldl
+              (\(amtA, delegA) (amtB, delegB) -> (amtA <> amtB, delegA <> delegB))
+              (mempty, mempty)
+              maps
+
+      decodeObject :: Aeson.Value
+                   -> Aeson.Parser (StakeAddress, Maybe Lovelace, Maybe PoolId)
+      decodeObject  = withObject "DelegationsAndRewards" $ \o -> do
+        address <- o .: "address"
+        delegation <- o .:? "delegation"
+        rewardAccountBalance <- o .:? "rewardAccountBalance"
+        pure (address, rewardAccountBalance, delegation)
+
+
+mergeDelegsAndRewards :: DelegationsAndRewards -> [(StakeAddress, Maybe Lovelace, Maybe PoolId)]
+mergeDelegsAndRewards (DelegationsAndRewards (rewardsMap, delegMap)) =
+ [ (stakeAddr, Map.lookup stakeAddr rewardsMap, Map.lookup stakeAddr delegMap)
+ | stakeAddr <- nub $ Map.keys rewardsMap ++ Map.keys delegMap
+ ]

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -434,6 +434,10 @@ module Cardano.Api (
     StakePoolRelay,
     StakePoolMetadataReference,
 
+    -- * Rewards
+    DelegationsAndRewards(..),
+    mergeDelegsAndRewards,
+
     -- * Stake pool off-chain metadata
     StakePoolMetadata,
     validateAndHashStakePoolMetadata,
@@ -991,6 +995,7 @@ import           Cardano.Api.Protocol
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query hiding (LedgerState (..))
 import           Cardano.Api.Query.Expr
+import           Cardano.Api.Rewards
 import           Cardano.Api.Script
 import           Cardano.Api.ScriptData
 import           Cardano.Api.SerialiseBech32

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1692973747,
-        "narHash": "sha256-mTlxhYzPUYJ/LggHQzsPomhqslCfTbjq8vqAhMaQN/o=",
+        "lastModified": 1694155919,
+        "narHash": "sha256-sdbrl4GlUszafQPZqr+ud1mBeT2yAFtj2zaXO693qUc=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "1f0aed302bafbf897d3deefd9fc5de8229d04e1a",
+        "rev": "92255dd59e1e851b1dd36042d52611b818d19549",
         "type": "github"
       },
       "original": {
@@ -185,22 +185,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1679360468,
-        "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
-        "owner": "hamishmack",
-        "repo": "flake-utils",
-        "rev": "e1ea268ff47ad475443dbabcd54744b4e5b9d4f5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hamishmack",
-        "ref": "hkm/nested-hydraJobs",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "ghc-8.6.5-iohk": {
       "flake": false,
       "locked": {
@@ -221,11 +205,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1688603318,
-        "narHash": "sha256-rXEPjf6pecyl0mIpK6xk3Vp/lKxWiCUfw6PMU+7utjY=",
+        "lastModified": 1693786968,
+        "narHash": "sha256-QNQ2dM3iqNV1o+0kWiO5GbMZWNA+of8wCknNKnBBQPI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a5604f20c9446451d4f1fd3ad4c160240069833a",
+        "rev": "4e9caa4ef2cc7a17a8a31ff7a44bcbbc1a314842",
         "type": "github"
       },
       "original": {
@@ -242,11 +226,11 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
+        "hls-2.2": "hls-2.2",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -265,11 +249,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1688518296,
-        "narHash": "sha256-8c6I2aRGg1mHVHHWj49sbcdbkxoXbL5d6fWcHsvwCw4=",
+        "lastModified": 1693878116,
+        "narHash": "sha256-8s+pouNz8BSvb3r+yaiDLkKzx+GzSmLsYP8Wbh/eM/8=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "0f0cbc1c42adc9dfa017ce5836abd87d652efdfb",
+        "rev": "1b4bccb032d5a32fee0f5b7872660c017a0748d2",
         "type": "github"
       },
       "original": {
@@ -298,16 +282,33 @@
     "hls-2.0": {
       "flake": false,
       "locked": {
-        "lastModified": 1684398654,
-        "narHash": "sha256-RW44up2BIyBBYN6tZur5f9kDDR3kr0Rd+TgPbLTfwB4=",
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "20c6d1e731cd9c0beef7338e2fc7a8126ba9b6fb",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.0.0.0",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -375,11 +376,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1670983692,
-        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
+        "lastModified": 1688517130,
+        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
         "ref": "hkm/remote-iserv",
-        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
-        "revCount": 10,
+        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
+        "revCount": 13,
         "type": "git",
         "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       },
@@ -492,11 +493,11 @@
     },
     "nixpkgs-2205": {
       "locked": {
-        "lastModified": 1682600000,
-        "narHash": "sha256-ha4BehR1dh8EnXSoE1m/wyyYVvHI9txjW4w5/oxsW5Y=",
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50fc86b75d2744e1ab3837ef74b53f103a9b55a0",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
         "type": "github"
       },
       "original": {
@@ -508,11 +509,11 @@
     },
     "nixpkgs-2211": {
       "locked": {
-        "lastModified": 1685314633,
-        "narHash": "sha256-8LXBPqTQXl5ofkjpJ18JcbmLJ/lWDoMxtUwiDYv0wro=",
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8a17ce7abc03c50cd072e9e6c9b389c5f61836b",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
         "type": "github"
       },
       "original": {
@@ -524,11 +525,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1685338297,
-        "narHash": "sha256-+Aq4O0Jn1W1q927ZHc3Zn6RO7bwQGmb6O8xYoGy0KrM=",
+        "lastModified": 1690680713,
+        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6287b47dbfabbb8bfbb9b1b53d198ad58a774de4",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
         "type": "github"
       },
       "original": {
@@ -556,11 +557,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1685347552,
-        "narHash": "sha256-9woSppRyUFo26yUffORTzttJ+apOt8MmCv6RxpPNTU4=",
+        "lastModified": 1690720142,
+        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2f1ec390714d303cf84ba086e34e45b450dd8c4",
+        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
         "type": "github"
       },
       "original": {
@@ -654,11 +655,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1688515874,
-        "narHash": "sha256-KG+rk/RcqJyRKGKBUjrTyRDjvpyrlQgW9tqBhwZzn8A=",
+        "lastModified": 1693786159,
+        "narHash": "sha256-IzpBwbwD90CIdhOKfdzS98+o3AtoADNsSz5QBr281Gg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "faa8d0b836ca86e0e5f78c2cb77c0acc2dc1d585",
+        "rev": "69d620fde80c1dfbe78b081db1b5725e9c0ce9e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    - Added `Cardano.Api.Certificate.filterUnRegDRepCreds`.
    - `queryStateForBalancedTx`  returns `DRep` credetnial.
    - `QueryDRepState` returns map indexed by `DRepCredential`.
    - `contructBalancedTx` and `evaluateTransactionBalance` takes `DRep` credential as an argument.
    - Updated IPC to `ouroboros-network-0.9.0.0` API

# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
    - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Make `cardano-api` compatible with a newer ledger input-output-hk/cardano-ledger@9e2f8151e3b9a0dde9faeb29a7dd2456e854427c.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
