### PR TITLE
New `caseShelleyToBabbageAndConwayEraOnwards` function

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -57,6 +57,7 @@ library internal
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast
                         Cardano.Api.Eras
+                        Cardano.Api.Eras.Case
                         Cardano.Api.Eras.Constraints
                         Cardano.Api.Eras.Core
                         Cardano.Api.Error

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -58,7 +58,11 @@ module Cardano.Api.Eras
   , requireShelleyBasedEra
 
   , withShelleyBasedEraConstraintsForLedger
+
+    -- * Era case handling
+  , caseShelleyToBabbageAndConwayEraOnwards
   ) where
 
+import           Cardano.Api.Eras.Case
 import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.Eras.Core

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.Api.Eras.Case
+  ( caseShelleyToBabbageAndConwayEraOnwards
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToBabbageEra
+
+caseShelleyToBabbageAndConwayEraOnwards :: ()
+  => (ShelleyToBabbageEra era -> a)
+  -> (ConwayEraOnwards era -> a)
+  -> ShelleyBasedEra era
+  -> a
+caseShelleyToBabbageAndConwayEraOnwards l r = \case
+  ShelleyBasedEraShelley -> l ShelleyToBabbageEraShelley
+  ShelleyBasedEraAllegra -> l ShelleyToBabbageEraAllegra
+  ShelleyBasedEraMary    -> l ShelleyToBabbageEraMary
+  ShelleyBasedEraAlonzo  -> l ShelleyToBabbageEraAlonzo
+  ShelleyBasedEraBabbage -> l ShelleyToBabbageEraBabbage
+  ShelleyBasedEraConway  -> r ConwayEraOnwardsConway

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -16,7 +16,7 @@ module Cardano.Api.Feature.ConwayEraOnwards
   , conwayEraOnwardsToShelleyBasedEra
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
 import           Cardano.Api.Query.Types
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -67,6 +67,9 @@ module Cardano.Api (
     shelleyBasedEraConstraints,
     withShelleyBasedEraConstraintsForLedger,
 
+    -- * Era case handling
+    caseShelleyToBabbageAndConwayEraOnwards,
+
     -- * Assertions on era
     requireShelleyBasedEra,
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New `caseShelleyToBabbageAndConwayEraOnwards` function
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

When you are operating in the `ShelleyBasedEra` and are in a situation where you want a different code-path to handle `ShelleyToBabbageEra` and `ConwayEraOnwards`, then use this function.

Example use case: https://github.com/input-output-hk/cardano-cli/pull/256/files#r1319936305

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
