### PR TITLE
New era casing functions

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -616,20 +616,14 @@ genCertificate sbe =
     ]
 
 genStakeAddressRequirements :: ShelleyBasedEra era -> Gen (StakeAddressRequirements era)
-genStakeAddressRequirements sbe =
-  case sbe of
-    ShelleyBasedEraShelley ->
-      StakeAddrRegistrationPreConway ShelleyToBabbageEraShelley <$> genStakeCredential
-    ShelleyBasedEraAllegra ->
-      StakeAddrRegistrationPreConway ShelleyToBabbageEraAllegra <$> genStakeCredential
-    ShelleyBasedEraMary ->
-      StakeAddrRegistrationPreConway ShelleyToBabbageEraMary <$> genStakeCredential
-    ShelleyBasedEraAlonzo ->
-      StakeAddrRegistrationPreConway ShelleyToBabbageEraAlonzo <$> genStakeCredential
-    ShelleyBasedEraBabbage ->
-      StakeAddrRegistrationPreConway ShelleyToBabbageEraBabbage <$> genStakeCredential
-    ShelleyBasedEraConway ->
-      StakeAddrRegistrationConway ConwayEraOnwardsConway <$> genLovelace <*> genStakeCredential
+genStakeAddressRequirements =
+  caseShelleyToBabbageOrConwayEraOnwards
+    (\w ->
+      StakeAddrRegistrationPreConway w
+        <$> genStakeCredential)
+    (\w -> StakeAddrRegistrationConway w
+        <$> genLovelace
+        <*> genStakeCredential)
 
 genTxUpdateProposal :: CardanoEra era -> Gen (TxUpdateProposal era)
 genTxUpdateProposal era =

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -707,14 +707,10 @@ fromShelleyCertificate :: ()
   => ShelleyBasedEra era
   -> Ledger.TxCert (ShelleyLedgerEra era)
   -> Certificate era
-fromShelleyCertificate = \case
-  ShelleyBasedEraShelley  -> ShelleyRelatedCertificate ShelleyToBabbageEraShelley
-  ShelleyBasedEraAllegra  -> ShelleyRelatedCertificate ShelleyToBabbageEraAllegra
-  ShelleyBasedEraMary     -> ShelleyRelatedCertificate ShelleyToBabbageEraMary
-  ShelleyBasedEraAlonzo   -> ShelleyRelatedCertificate ShelleyToBabbageEraAlonzo
-  ShelleyBasedEraBabbage  -> ShelleyRelatedCertificate ShelleyToBabbageEraBabbage
-  ShelleyBasedEraConway   -> ConwayCertificate ConwayEraOnwardsConway
-
+fromShelleyCertificate =
+  caseShelleyToBabbageOrConwayEraOnwards
+    (\w -> shelleyToBabbageEraConstraints w $ ShelleyRelatedCertificate w)
+    (\w -> conwayEraOnwardsConstraints w $ ConwayCertificate w)
 
 toShelleyPoolParams :: StakePoolParameters -> Ledger.PoolParams StandardCrypto
 toShelleyPoolParams StakePoolParameters {

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -56,7 +56,14 @@ module Cardano.Api.Eras
   , withShelleyBasedEraConstraintsForLedger
 
     -- * Era case handling
-  , caseShelleyToBabbageAndConwayEraOnwards
+
+    -- ** Case on CardanoEra
+  , caseByronOrShelleyBasedEra
+
+    -- ** Case on ShelleyBasedEra
+  , caseShelleyToMaryOrAlonzoEraOnwards
+  , caseShelleyToAlonzoOrBabbageEraOnwards
+  , caseShelleyToBabbageOrConwayEraOnwards
   ) where
 
 import           Cardano.Api.Eras.Case

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -2,19 +2,69 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.Api.Eras.Case
-  ( caseShelleyToBabbageAndConwayEraOnwards
+  ( -- Case on CardanoEra
+    caseByronOrShelleyBasedEra
+
+    -- Case on ShelleyBasedEra
+  , caseShelleyToMaryOrAlonzoEraOnwards
+  , caseShelleyToAlonzoOrBabbageEraOnwards
+  , caseShelleyToBabbageOrConwayEraOnwards
   ) where
 
 import           Cardano.Api.Eras.Core
+import           Cardano.Api.Feature.AlonzoEraOnwards
+import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
+import           Cardano.Api.Feature.ShelleyToMaryEra
 
-caseShelleyToBabbageAndConwayEraOnwards :: ()
+caseByronOrShelleyBasedEra :: ()
+  => (CardanoEra ByronEra -> a)
+  -> (ShelleyBasedEra era -> a)
+  -> CardanoEra era
+  -> a
+caseByronOrShelleyBasedEra l r = \case
+  ByronEra   -> l ByronEra
+  ShelleyEra -> r ShelleyBasedEraShelley
+  AllegraEra -> r ShelleyBasedEraAllegra
+  MaryEra    -> r ShelleyBasedEraMary
+  AlonzoEra  -> r ShelleyBasedEraAlonzo
+  BabbageEra -> r ShelleyBasedEraBabbage
+  ConwayEra  -> r ShelleyBasedEraConway
+
+caseShelleyToMaryOrAlonzoEraOnwards :: ()
+  => (ShelleyToMaryEra era -> a)
+  -> (AlonzoEraOnwards era -> a)
+  -> ShelleyBasedEra era
+  -> a
+caseShelleyToMaryOrAlonzoEraOnwards l r = \case
+  ShelleyBasedEraShelley  -> l ShelleyToMaryEraShelley
+  ShelleyBasedEraAllegra  -> l ShelleyToMaryEraAllegra
+  ShelleyBasedEraMary     -> l ShelleyToMaryEraMary
+  ShelleyBasedEraAlonzo   -> r AlonzoEraOnwardsAlonzo
+  ShelleyBasedEraBabbage  -> r AlonzoEraOnwardsBabbage
+  ShelleyBasedEraConway   -> r AlonzoEraOnwardsConway
+
+caseShelleyToAlonzoOrBabbageEraOnwards :: ()
+  => (ShelleyToAlonzoEra era -> a)
+  -> (BabbageEraOnwards era -> a)
+  -> ShelleyBasedEra era
+  -> a
+caseShelleyToAlonzoOrBabbageEraOnwards l r = \case
+  ShelleyBasedEraShelley -> l ShelleyToAlonzoEraShelley
+  ShelleyBasedEraAllegra -> l ShelleyToAlonzoEraAllegra
+  ShelleyBasedEraMary    -> l ShelleyToAlonzoEraMary
+  ShelleyBasedEraAlonzo  -> l ShelleyToAlonzoEraAlonzo
+  ShelleyBasedEraBabbage -> r BabbageEraOnwardsBabbage
+  ShelleyBasedEraConway  -> r BabbageEraOnwardsConway
+
+caseShelleyToBabbageOrConwayEraOnwards :: ()
   => (ShelleyToBabbageEra era -> a)
   -> (ConwayEraOnwards era -> a)
   -> ShelleyBasedEra era
   -> a
-caseShelleyToBabbageAndConwayEraOnwards l r = \case
+caseShelleyToBabbageOrConwayEraOnwards l r = \case
   ShelleyBasedEraShelley -> l ShelleyToBabbageEraShelley
   ShelleyBasedEraAllegra -> l ShelleyToBabbageEraAllegra
   ShelleyBasedEraMary    -> l ShelleyToBabbageEraMary

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -1316,19 +1316,8 @@ calculateMinimumUTxO
   -> Ledger.PParams (ShelleyLedgerEra era)
   -> Lovelace
 calculateMinimumUTxO sbe txout pp =
-  case sbe of
-    ShelleyBasedEraShelley ->
-      calcMinUTxO pp (toShelleyTxOutAny sbe txout)
-    ShelleyBasedEraAllegra ->
-      calcMinUTxO pp (toShelleyTxOutAny sbe txout)
-    ShelleyBasedEraMary ->
-      calcMinUTxO pp (toShelleyTxOutAny sbe txout)
-    ShelleyBasedEraAlonzo ->
-      calcMinUTxO pp (toShelleyTxOutAny sbe txout)
-    ShelleyBasedEraBabbage ->
-      calcMinUTxO pp (toShelleyTxOutAny sbe txout)
-    ShelleyBasedEraConway ->
-      calcMinUTxO pp (toShelleyTxOutAny sbe txout)
+  shelleyBasedEraConstraints sbe
+    $ calcMinUTxO pp (toShelleyTxOutAny sbe txout)
  where
    calcMinUTxO :: L.EraTxOut ledgerera => L.PParams ledgerera -> L.TxOut ledgerera -> Lovelace
    calcMinUTxO pp' txOut =

--- a/cardano-api/internal/Cardano/Api/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Tx.hs
@@ -51,6 +51,8 @@ module Cardano.Api.Tx (
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
+import           Cardano.Api.Feature.AlonzoEraOnwards
+import           Cardano.Api.Feature.ShelleyToMaryEra
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Class
@@ -497,13 +499,10 @@ getTxWitnesses (ByronTx Byron.ATxAux { Byron.aTaWitness = witnesses }) =
   $ witnesses
 
 getTxWitnesses (ShelleyTx sbe tx') =
-    case sbe of
-      ShelleyBasedEraShelley -> getShelleyTxWitnesses tx'
-      ShelleyBasedEraAllegra -> getShelleyTxWitnesses tx'
-      ShelleyBasedEraMary    -> getShelleyTxWitnesses tx'
-      ShelleyBasedEraAlonzo  -> getAlonzoTxWitnesses  tx'
-      ShelleyBasedEraBabbage -> getAlonzoTxWitnesses  tx'
-      ShelleyBasedEraConway  -> getAlonzoTxWitnesses  tx'
+  caseShelleyToMaryOrAlonzoEraOnwards
+    (\w -> shelleyToMaryEraConstraints w $ getShelleyTxWitnesses tx')
+    (\w -> alonzoEraOnwardsConstraints w $ getAlonzoTxWitnesses  tx')
+    sbe
   where
     getShelleyTxWitnesses :: forall ledgerera.
                              L.EraTx ledgerera

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -111,7 +111,14 @@ module Cardano.Api (
     withShelleyBasedEraConstraintsForLedger,
 
     -- * Era case handling
-    caseShelleyToBabbageAndConwayEraOnwards,
+
+    -- ** Case on CardanoEra
+    caseByronOrShelleyBasedEra,
+
+    -- ** Case on ShelleyBasedEra
+    caseShelleyToMaryOrAlonzoEraOnwards,
+    caseShelleyToAlonzoOrBabbageEraOnwards,
+    caseShelleyToBabbageOrConwayEraOnwards,
 
     -- * Assertions on era
     requireShelleyBasedEra,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New functions:
    * `caseByronOrShelleyBasedEra`
    * `caseShelleyToMaryOrAlonzoEraOnwards`
    * `caseShelleyToAlonzoOrBabbageEraOnwards`
    Renamed `caseShelleyToBabbageAndConwayEraOnwards` to `caseShelleyToBabbageOrConwayEraOnwards`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Add new era casing functions.

Some example uses are included.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
