### PR TITLE
Expose constraints from casing functions

### DIFF
--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -708,9 +708,7 @@ fromShelleyCertificate :: ()
   -> Ledger.TxCert (ShelleyLedgerEra era)
   -> Certificate era
 fromShelleyCertificate =
-  caseShelleyToBabbageOrConwayEraOnwards
-    (\w -> shelleyToBabbageEraConstraints w $ ShelleyRelatedCertificate w)
-    (\w -> conwayEraOnwardsConstraints w $ ConwayCertificate w)
+  caseShelleyToBabbageOrConwayEraOnwards ShelleyRelatedCertificate ConwayCertificate
 
 toShelleyPoolParams :: StakePoolParameters -> Ledger.PoolParams StandardCrypto
 toShelleyPoolParams StakePoolParameters {

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Cardano.Api.Eras.Case
   ( -- Case on CardanoEra
@@ -11,6 +13,7 @@ module Cardano.Api.Eras.Case
   , caseShelleyToBabbageOrConwayEraOnwards
   ) where
 
+import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.BabbageEraOnwards
@@ -21,7 +24,7 @@ import           Cardano.Api.Feature.ShelleyToMaryEra
 
 caseByronOrShelleyBasedEra :: ()
   => (CardanoEra ByronEra -> a)
-  -> (ShelleyBasedEra era -> a)
+  -> (ShelleyBasedEraConstraints era => ShelleyBasedEra era -> a)
   -> CardanoEra era
   -> a
 caseByronOrShelleyBasedEra l r = \case
@@ -34,8 +37,8 @@ caseByronOrShelleyBasedEra l r = \case
   ConwayEra  -> r ShelleyBasedEraConway
 
 caseShelleyToMaryOrAlonzoEraOnwards :: ()
-  => (ShelleyToMaryEra era -> a)
-  -> (AlonzoEraOnwards era -> a)
+  => (ShelleyToMaryEraConstraints era => ShelleyToMaryEra era -> a)
+  -> (AlonzoEraOnwardsConstraints era => AlonzoEraOnwards era -> a)
   -> ShelleyBasedEra era
   -> a
 caseShelleyToMaryOrAlonzoEraOnwards l r = \case
@@ -47,8 +50,8 @@ caseShelleyToMaryOrAlonzoEraOnwards l r = \case
   ShelleyBasedEraConway   -> r AlonzoEraOnwardsConway
 
 caseShelleyToAlonzoOrBabbageEraOnwards :: ()
-  => (ShelleyToAlonzoEra era -> a)
-  -> (BabbageEraOnwards era -> a)
+  => (ShelleyToAlonzoEraConstraints era => ShelleyToAlonzoEra era -> a)
+  -> (BabbageEraOnwardsConstraints  era => BabbageEraOnwards era  -> a)
   -> ShelleyBasedEra era
   -> a
 caseShelleyToAlonzoOrBabbageEraOnwards l r = \case
@@ -60,8 +63,8 @@ caseShelleyToAlonzoOrBabbageEraOnwards l r = \case
   ShelleyBasedEraConway  -> r BabbageEraOnwardsConway
 
 caseShelleyToBabbageOrConwayEraOnwards :: ()
-  => (ShelleyToBabbageEra era -> a)
-  -> (ConwayEraOnwards era -> a)
+  => (ShelleyToBabbageEraConstraints  era => ShelleyToBabbageEra era  -> a)
+  -> (ConwayEraOnwardsConstraints     era => ConwayEraOnwards era     -> a)
   -> ShelleyBasedEra era
   -> a
 caseShelleyToBabbageOrConwayEraOnwards l r = \case

--- a/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
@@ -12,6 +12,9 @@ module Cardano.Api.Eras.Constraints
   ( cardanoEraConstraints
   , withShelleyBasedEraConstraintsForLedger
   , shelleyBasedEraConstraints
+
+  , CardanoEraConstraints
+  , ShelleyBasedEraConstraints
   ) where
 
 import           Cardano.Api.Eras.Core
@@ -34,14 +37,14 @@ import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 import           Data.Aeson (ToJSON)
 import           Data.Typeable (Typeable)
 
-type CardanoEraConstraint era =
+type CardanoEraConstraints era =
   ( Typeable era
   , IsCardanoEra era
   )
 
 cardanoEraConstraints :: ()
   => CardanoEra era
-  -> (CardanoEraConstraint era => a)
+  -> (CardanoEraConstraints era => a)
   -> a
 cardanoEraConstraints = \case
   ByronEra   -> id
@@ -52,20 +55,20 @@ cardanoEraConstraints = \case
   BabbageEra -> id
   ConwayEra  -> id
 
-type ShelleyBasedEraConstraints era ledgerera =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto ledgerera))
-  , C.Signable (L.VRF (L.EraCrypto ledgerera)) L.Seed
+type ShelleyBasedEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) ledgerera
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto ledgerera)
-  , L.Era ledgerera
-  , L.EraCrypto ledgerera ~ L.StandardCrypto
-  , L.EraPParams ledgerera
-  , L.EraTx ledgerera
-  , L.EraTxBody ledgerera
-  , L.HashAnnotated (L.TxBody ledgerera) L.EraIndependentTxBody L.StandardCrypto
-  , L.ShelleyEraTxBody ledgerera
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
@@ -76,9 +79,8 @@ type ShelleyBasedEraConstraints era ledgerera =
   )
 
 shelleyBasedEraConstraints :: ()
-  => ShelleyLedgerEra era ~ ledgerera
   => ShelleyBasedEra era
-  -> (ShelleyBasedEraConstraints era ledgerera => a)
+  -> (ShelleyBasedEraConstraints era => a)
   -> a
 shelleyBasedEraConstraints = \case
   ShelleyBasedEraShelley -> id
@@ -90,8 +92,7 @@ shelleyBasedEraConstraints = \case
 
 -- Deprecated: Use shelleyBasedEraConstraints instead.
 withShelleyBasedEraConstraintsForLedger :: ()
-  => ShelleyLedgerEra era ~ ledgerera
   => ShelleyBasedEra era
-  -> (ShelleyBasedEraConstraints era ledgerera => a)
+  -> (ShelleyBasedEraConstraints era => a)
   -> a
 withShelleyBasedEraConstraintsForLedger = shelleyBasedEraConstraints

--- a/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnly.hs
@@ -14,6 +14,8 @@ module Cardano.Api.Feature.AlonzoEraOnly
   , alonzoEraOnlyConstraints
   , alonzoEraOnlyToCardanoEra
   , alonzoEraOnlyToShelleyBasedEra
+
+  , AlonzoEraOnlyConstraints
   ) where
 
 import           Cardano.Api.Eras.Core

--- a/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnwards.hs
@@ -14,6 +14,8 @@ module Cardano.Api.Feature.AlonzoEraOnwards
   , alonzoEraOnwardsConstraints
   , alonzoEraOnwardsToCardanoEra
   , alonzoEraOnwardsToShelleyBasedEra
+
+  , AlonzoEraOnwardsConstraints
   ) where
 
 import           Cardano.Api.Eras.Core

--- a/cardano-api/internal/Cardano/Api/Feature/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/BabbageEraOnwards.hs
@@ -14,6 +14,8 @@ module Cardano.Api.Feature.BabbageEraOnwards
   , babbageEraOnwardsConstraints
   , babbageEraOnwardsToCardanoEra
   , babbageEraOnwardsToShelleyBasedEra
+
+  , BabbageEraOnwardsConstraints
   ) where
 
 import           Cardano.Api.Eras.Core

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -14,6 +14,8 @@ module Cardano.Api.Feature.ConwayEraOnwards
   , conwayEraOnwardsConstraints
   , conwayEraOnwardsToCardanoEra
   , conwayEraOnwardsToShelleyBasedEra
+
+  , ConwayEraOnwardsConstraints
   ) where
 
 import           Cardano.Api.Eras.Core
@@ -67,24 +69,24 @@ data AnyConwayEraOnwards where
 
 deriving instance Show AnyConwayEraOnwards
 
-type ConwayEraOnwardsConstraints era ledgerera =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto ledgerera))
-  , C.Signable (L.VRF (L.EraCrypto ledgerera)) L.Seed
+type ConwayEraOnwardsConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) ledgerera
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.ConwayEraTxBody ledgerera
-  , L.ConwayEraTxCert ledgerera
-  , L.Crypto (L.EraCrypto ledgerera)
-  , L.Era ledgerera
-  , L.EraCrypto ledgerera ~ L.StandardCrypto
-  , L.EraGov ledgerera
-  , L.EraPParams ledgerera
-  , L.EraTx ledgerera
-  , L.EraTxBody ledgerera
-  , L.HashAnnotated (L.TxBody ledgerera) L.EraIndependentTxBody L.StandardCrypto
-  , L.ShelleyEraTxBody ledgerera
-  , L.TxCert ledgerera ~ L.ConwayTxCert ledgerera
+  , L.ConwayEraTxBody (ShelleyLedgerEra era)
+  , L.ConwayEraTxCert (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraGov (ShelleyLedgerEra era)
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ConwayTxCert (ShelleyLedgerEra era)
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
@@ -95,9 +97,8 @@ type ConwayEraOnwardsConstraints era ledgerera =
   )
 
 conwayEraOnwardsConstraints :: ()
-  => ShelleyLedgerEra era ~ ledgerera
   => ConwayEraOnwards era
-  -> (ConwayEraOnwardsConstraints era ledgerera => a)
+  -> (ConwayEraOnwardsConstraints era => a)
   -> a
 conwayEraOnwardsConstraints = \case
   ConwayEraOnwardsConway -> id

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToAllegraEra.hs
@@ -15,6 +15,8 @@ module Cardano.Api.Feature.ShelleyToAllegraEra
   , shelleyToAllegraEraConstraints
   , shelleyToAllegraEraToCardanoEra
   , shelleyToAllegraEraToShelleyBasedEra
+
+  , ShelleyToAllegraEraConstraints
   ) where
 
 import           Cardano.Api.Eras.Core

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToAlonzoEra.hs
@@ -15,6 +15,8 @@ module Cardano.Api.Feature.ShelleyToAlonzoEra
   , shelleyToAlonzoEraConstraints
   , shelleyToAlonzoEraToCardanoEra
   , shelleyToAlonzoEraToShelleyBasedEra
+
+  , ShelleyToAlonzoEraConstraints
   ) where
 
 import           Cardano.Api.Eras.Core

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -15,6 +15,8 @@ module Cardano.Api.Feature.ShelleyToBabbageEra
   , shelleyToBabbageEraConstraints
   , shelleyToBabbageEraToCardanoEra
   , shelleyToBabbageEraToShelleyBasedEra
+
+  , ShelleyToBabbageEraConstraints
   ) where
 
 import           Cardano.Api.Eras.Core

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
@@ -15,6 +15,8 @@ module Cardano.Api.Feature.ShelleyToMaryEra
   , shelleyToMaryEraConstraints
   , shelleyToMaryEraToCardanoEra
   , shelleyToMaryEraToShelleyBasedEra
+
+  , ShelleyToMaryEraConstraints
   ) where
 
 import           Cardano.Api.Eras.Core

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -85,8 +85,6 @@ import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
-import           Cardano.Api.Feature.BabbageEraOnwards
-import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Genesis
 import           Cardano.Api.IO
 import           Cardano.Api.IPC (ConsensusModeParams (..),
@@ -1521,7 +1519,7 @@ nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (Vr
       extraEntropy :: Nonce
       extraEntropy =
         caseShelleyToAlonzoOrBabbageEraOnwards
-          (\w -> shelleyToAlonzoEraConstraints w $ pp ^. Core.ppExtraEntropyL)
+          (const (pp ^. Core.ppExtraEntropyL))
           (const Ledger.NeutralNonce)
           sbe
 
@@ -1638,8 +1636,8 @@ currentEpochEligibleLeadershipSlots sbe sGen eInfo pp ptclState poolid (VrfSigni
         $ Set.fromList [firstSlotOfEpoch .. lastSlotofEpoch]
 
   caseShelleyToAlonzoOrBabbageEraOnwards
-    (\w -> shelleyToAlonzoEraConstraints w $ isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f)
-    (\w -> babbageEraOnwardsConstraints  w $ isLeadingSlotsPraos  (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f)
+    (const (isLeadingSlotsTPraos (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f))
+    (const (isLeadingSlotsPraos  (slotRangeOfInterest pp) poolid setSnapshotPoolDistr epochNonce vrkSkey f))
     sbe
 
  where

--- a/cardano-api/internal/Cardano/Api/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Tx.hs
@@ -51,8 +51,6 @@ module Cardano.Api.Tx (
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eras
-import           Cardano.Api.Feature.AlonzoEraOnwards
-import           Cardano.Api.Feature.ShelleyToMaryEra
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Class
@@ -500,8 +498,8 @@ getTxWitnesses (ByronTx Byron.ATxAux { Byron.aTaWitness = witnesses }) =
 
 getTxWitnesses (ShelleyTx sbe tx') =
   caseShelleyToMaryOrAlonzoEraOnwards
-    (\w -> shelleyToMaryEraConstraints w $ getShelleyTxWitnesses tx')
-    (\w -> alonzoEraOnwardsConstraints w $ getAlonzoTxWitnesses  tx')
+    (const (getShelleyTxWitnesses tx'))
+    (const (getAlonzoTxWitnesses  tx'))
     sbe
   where
     getShelleyTxWitnesses :: forall ledgerera.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Expose constraints from casing functions
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This means callers don't have to summon constraints separately.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
