### PR TITLE
Fix querying for dreps in `transaction build` in eras before conway

### DIFF
--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -60,6 +60,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as Consensus
 import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import           Data.Map (Map)
 import           Data.Set (Set)
+import qualified Data.Set as S
 
 queryChainBlockNo :: ()
   => LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (WithOrigin BlockNo))
@@ -168,8 +169,9 @@ queryStakeDelegDeposits :: ()
   -> ShelleyBasedEra era
   -> Set StakeCredential
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential Lovelace)))
-queryStakeDelegDeposits eraInMode sbe stakeCreds =
-  queryExpr $ QueryInEra eraInMode . QueryInShelleyBasedEra sbe $ QueryStakeDelegDeposits stakeCreds
+queryStakeDelegDeposits eraInMode sbe stakeCreds
+  | S.null stakeCreds = pure . pure $ pure mempty
+  | otherwise         = queryExpr $ QueryInEra eraInMode . QueryInShelleyBasedEra sbe $ QueryStakeDelegDeposits stakeCreds
 
 queryStakeDistribution :: ()
   => EraInMode era mode
@@ -183,8 +185,9 @@ queryStakePoolParameters :: ()
   -> ShelleyBasedEra era
   -> Set PoolId
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map PoolId StakePoolParameters)))
-queryStakePoolParameters eraInMode sbe poolIds =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakePoolParameters poolIds
+queryStakePoolParameters eraInMode sbe poolIds
+  | S.null poolIds  = pure . pure $ pure mempty
+  | otherwise       = queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakePoolParameters poolIds
 
 queryStakePools :: ()
   => EraInMode era mode
@@ -243,16 +246,18 @@ queryDRepState :: ()
   -> ShelleyBasedEra era
   -> Set (L.Credential L.DRepRole L.StandardCrypto)
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.Credential L.DRepRole L.StandardCrypto) (L.DRepState L.StandardCrypto))))
-queryDRepState eraInMode sbe drepCreds =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryDRepState drepCreds
+queryDRepState eraInMode sbe drepCreds
+  | S.null drepCreds  = pure . pure $ pure mempty
+  | otherwise         = queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryDRepState drepCreds
 
 queryDRepStakeDistribution :: ()
   => EraInMode era mode
   -> ShelleyBasedEra era
   -> Set (L.DRep L.StandardCrypto)
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.DRep L.StandardCrypto) Lovelace)))
-queryDRepStakeDistribution eraInMode sbe dreps =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryDRepStakeDistr dreps
+queryDRepStakeDistribution eraInMode sbe dreps
+  | S.null dreps = pure . pure $ pure mempty
+  | otherwise    = queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryDRepStakeDistr dreps
 
 queryCommitteeState :: ()
   => EraInMode era mode


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix querying for dreps in `transaction build` in eras before conway
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

In eras before conway, querying for dreps may result in an exception due to protocol versions mismatch. This PR safeguards against that, skipping the drep query in eras before conway.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
