### PR TITLE
Add info about cache collisions in GHA builds in RELEASING.md troubleshooting section

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -127,6 +127,24 @@ Briefly speaking, it requires executing of the following steps:
 
 After package gets released, you can check the released version at: https://input-output-hk.github.io/cardano-haskell-packages/all-package-versions/ and update the version in the dependant packages, in their cabal files, for example: `cardano-api ^>= 8.3`
 
+## Troubleshooting
+
+### Build fails due to `installed package instance does not exist`
+If you notice that your build fails due to an error similar to the following one:
+```
+ Configuring library for cardano-ledger-conway-1.8.0.0..
+Error: cabal: The following package dependencies were requested
+--dependency='cardano-ledger-alonzo=cardano-ledger-alonzo-1.4.1.0-b1d2cdacf3fecf8f57f465701c6cc39a19521597ceee354f7a1ea4688dec9d9f'
+--dependency='cardano-ledger-babbage=cardano-ledger-babbage-1.4.4.0-3f75b69fa5a14215f31de708afe86d5d69fbecea8ff284dc3265e0701eada7b6'
+however the given installed package instance does not exist.
+```
+increase the cabal cache version number in [.github/workflows/haskell.yml](.github/workflows/haskell.yml):
+```yaml
+CABAL_CACHE_VERSION: "2023-08-22"
+```
+Usually setting this date to the current date is enough.
+If it is already set to the current date, you can add a suffix to it - the important part is to make it unique across all builds which occurred until now, for example `2023-08-22-1`.
+This issue happens due to frequent cache collisions in the [`cabal-cache`](https://github.com/haskell-works/cabal-cache).
 
 ## References
 1. https://github.com/input-output-hk/cardano-updates/tree/main/scripts
@@ -135,3 +153,4 @@ After package gets released, you can check the released version at: https://inpu
 1. https://input-output-hk.github.io/cardano-engineering-handbook/policy/haskell/packaging/versioning.html
 
 <!-- vim: set spell textwidth=0: -->
+


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    Add info about cache collisions in GHA builds in RELEASING.md troubleshooting section
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Rendered: https://github.com/input-output-hk/cardano-api/blob/mgalazyn/doc/add-info-about-cabal-cache-collisions/RELEASING.md

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
