### PR TITLE
Fix typos in some deserialization error messages

### DIFF
--- a/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
@@ -1314,7 +1314,7 @@ instance SerialiseAsRawBytes (VerificationKey GenesisUTxOKey) where
       Crypto.rawSerialiseVerKeyDSIGN vk
 
     deserialiseFromRawBytes (AsVerificationKey AsGenesisUTxOKey) bs =
-      maybeToRight (SerialiseAsRawBytesError "Enable to deserialise VerificationKey GenesisUTxOKey") $
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise VerificationKey GenesisUTxOKey") $
         GenesisUTxOVerificationKey . Shelley.VKey <$> Crypto.rawDeserialiseVerKeyDSIGN bs
 
 instance SerialiseAsRawBytes (SigningKey GenesisUTxOKey) where

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -961,7 +961,7 @@ instance SerialiseAsRawBytes ScriptHash where
       Crypto.hashToBytes h
 
     deserialiseFromRawBytes AsScriptHash bs =
-      maybeToRight (SerialiseAsRawBytesError "Enable to deserialise ScriptHash") $
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise ScriptHash") $
         ScriptHash . Shelley.ScriptHash <$> Crypto.hashFromBytes bs
 
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix typos in some deserialization error messages
  type:
  - bugfix
```

# Context

"Enable" and "Unable" are phonetically very similar but have widely differing meanings.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] The changelog section in the PR is updated to describe the change
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
