### PR TITLE
Release 8.20.1.0

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog for cardano-api
 
+## 8.20.1.0
+
+- Fix typos in some deserialization error messages
+  (bugfix)
+  [PR 243](https://github.com/input-output-hk/cardano-api/pull/243)
+
+- Fix DRep Stake and DRep Stake queries for empty lists
+  (bugfix)
+  [PR 245](https://github.com/input-output-hk/cardano-api/pull/245)
+
+- Fix querying for dreps in `transaction build` in eras before conway
+  (bugfix)
+  [PR 240](https://github.com/input-output-hk/cardano-api/pull/240)
+
+- Fix Query error in QueryStakeDelegDeposits when executing transaction build
+  (bugfix)
+  [PR 239](https://github.com/input-output-hk/cardano-api/pull/239)
+
 ## 8.20.0.0
 
 - Expose constraints from casing functions

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-api
-version:                8.20.0.0
+version:                8.20.1.0
 synopsis:               The cardano api
 description:            The cardano api.
 category:               Cardano,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release 8.20.1.0
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
   - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
