### PR TITLE
Replace `UpdateproposalSupportedInEra` with `ShelleyToBabbageEra`

### DIFF
--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -2496,19 +2496,19 @@ fromLedgerTxBody
   -> TxBodyContent ViewTx era
 fromLedgerTxBody sbe scriptValidity body scriptdata mAux =
     TxBodyContent
-      { txIns                 = fromLedgerTxIns               sbe body
-      , txInsCollateral       = fromLedgerTxInsCollateral     sbe body
-      , txInsReference        = fromLedgerTxInsReference      sbe body
-      , txOuts                = fromLedgerTxOuts              sbe body scriptdata
-      , txTotalCollateral     = fromLedgerTxTotalCollateral   sbe body
-      , txReturnCollateral    = fromLedgerTxReturnCollateral  sbe body
-      , txFee                 = fromLedgerTxFee               sbe body
-      , txValidityRange       = fromLedgerTxValidityRange     sbe body
-      , txWithdrawals         = fromLedgerTxWithdrawals       sbe body
-      , txCertificates        = fromLedgerTxCertificates      sbe body
-      , txUpdateProposal      = fromLedgerTxUpdateProposal    sbe body
-      , txMintValue           = fromLedgerTxMintValue         sbe body
-      , txExtraKeyWits        = fromLedgerTxExtraKeyWitnesses sbe body
+      { txIns                 = fromLedgerTxIns                 sbe body
+      , txInsCollateral       = fromLedgerTxInsCollateral       sbe body
+      , txInsReference        = fromLedgerTxInsReference        sbe body
+      , txOuts                = fromLedgerTxOuts                sbe body scriptdata
+      , txTotalCollateral     = fromLedgerTxTotalCollateral     sbe body
+      , txReturnCollateral    = fromLedgerTxReturnCollateral    sbe body
+      , txFee                 = fromLedgerTxFee                 sbe body
+      , txValidityRange       = fromLedgerTxValidityRange       sbe body
+      , txWithdrawals         = fromLedgerTxWithdrawals         sbe body
+      , txCertificates        = fromLedgerTxCertificates        sbe body
+      , txUpdateProposal      = maybeFromLedgerTxUpdateProposal sbe body
+      , txMintValue           = fromLedgerTxMintValue           sbe body
+      , txExtraKeyWits        = fromLedgerTxExtraKeyWitnesses   sbe body
       , txProtocolParams      = ViewTx
       , txMetadata
       , txAuxScripts
@@ -3010,11 +3010,11 @@ fromLedgerTxCertificates sbe body =
       then TxCertificatesNone
       else TxCertificates sbe (map (fromShelleyCertificate sbe) $ toList certificates) ViewTx
 
-fromLedgerTxUpdateProposal :: ()
+maybeFromLedgerTxUpdateProposal :: ()
   => ShelleyBasedEra era
   -> Ledger.TxBody (ShelleyLedgerEra era)
   -> TxUpdateProposal era
-fromLedgerTxUpdateProposal sbe body =
+maybeFromLedgerTxUpdateProposal sbe body =
   caseShelleyToBabbageOrConwayEraOnwards
     (\w ->
       case body ^. L.updateTxBodyL of

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -390,7 +390,6 @@ module Cardano.Api (
     AuxScriptsSupportedInEra(..),
     TxExtraKeyWitnessesSupportedInEra(..),
     WithdrawalsSupportedInEra(..),
-    UpdateProposalSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
 
     -- ** Feature availability functions
@@ -402,7 +401,6 @@ module Cardano.Api (
     auxScriptsSupportedInEra,
     extraKeyWitnessesSupportedInEra,
     withdrawalsSupportedInEra,
-    updateProposalSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
 
     -- ** Era-dependent protocol features


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace `UpdateproposalSupportedInEra` with `ShelleyToBabbageEra`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
