### PR TITLE
Replace `CertificatesSupportedInEra` with `ShelleyBasedEra`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -592,19 +592,17 @@ genTxWithdrawals era =
         ]
 
 genTxCertificates :: CardanoEra era -> Gen (TxCertificates BuildTx era)
-genTxCertificates era =
-  case certificatesSupportedInEra era of
-    Nothing -> pure TxCertificatesNone
-    Just supported ->
-      case cardanoEraStyle era of
-        LegacyByronEra -> pure TxCertificatesNone
-        ShelleyBasedEra sbe -> do
-          certs <- Gen.list (Range.constant 0 3) $ genCertificate sbe
-          Gen.choice
-            [ pure TxCertificatesNone
-            , pure (TxCertificates supported certs $ BuildTxWith mempty)
-              -- TODO: Generate certificates
-            ]
+genTxCertificates =
+  inEonForEra
+    (pure TxCertificatesNone)
+    (\w -> do
+      certs <- Gen.list (Range.constant 0 3) $ genCertificate w
+      Gen.choice
+        [ pure TxCertificatesNone
+        , pure (TxCertificates w certs $ BuildTxWith mempty)
+          -- TODO: Generate certificates
+        ]
+    )
 
 -- TODO: Add remaining certificates
 -- TODO: This should be parameterised on ShelleyBasedEra

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -125,7 +125,6 @@ module Cardano.Api.TxBody (
     TxExtraKeyWitnessesSupportedInEra(..),
     ScriptDataSupportedInEra(..),
     WithdrawalsSupportedInEra(..),
-    CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
 
@@ -140,7 +139,6 @@ module Cardano.Api.TxBody (
     extraKeyWitnessesSupportedInEra,
     scriptDataSupportedInEra,
     withdrawalsSupportedInEra,
-    certificatesSupportedInEra,
     updateProposalSupportedInEra,
     txScriptValiditySupportedInShelleyBasedEra,
     txScriptValiditySupportedInCardanoEra,
@@ -1252,35 +1250,6 @@ withdrawalsSupportedInEra AlonzoEra  = Just WithdrawalsInAlonzoEra
 withdrawalsSupportedInEra BabbageEra = Just WithdrawalsInBabbageEra
 withdrawalsSupportedInEra ConwayEra  = Just WithdrawalsInConwayEra
 
-
--- | A representation of whether the era supports 'Certificate's embedded in
--- transactions.
---
--- The Shelley and subsequent eras support such certificates.
---
-data CertificatesSupportedInEra era where
-
-     CertificatesInShelleyEra :: CertificatesSupportedInEra ShelleyEra
-     CertificatesInAllegraEra :: CertificatesSupportedInEra AllegraEra
-     CertificatesInMaryEra    :: CertificatesSupportedInEra MaryEra
-     CertificatesInAlonzoEra  :: CertificatesSupportedInEra AlonzoEra
-     CertificatesInBabbageEra :: CertificatesSupportedInEra BabbageEra
-     CertificatesInConwayEra  :: CertificatesSupportedInEra ConwayEra
-
-deriving instance Eq   (CertificatesSupportedInEra era)
-deriving instance Show (CertificatesSupportedInEra era)
-
-certificatesSupportedInEra :: CardanoEra era
-                           -> Maybe (CertificatesSupportedInEra era)
-certificatesSupportedInEra ByronEra   = Nothing
-certificatesSupportedInEra ShelleyEra = Just CertificatesInShelleyEra
-certificatesSupportedInEra AllegraEra = Just CertificatesInAllegraEra
-certificatesSupportedInEra MaryEra    = Just CertificatesInMaryEra
-certificatesSupportedInEra AlonzoEra  = Just CertificatesInAlonzoEra
-certificatesSupportedInEra BabbageEra = Just CertificatesInBabbageEra
-certificatesSupportedInEra ConwayEra  = Just CertificatesInConwayEra
-
-
 -- | A representation of whether the era supports 'UpdateProposal's embedded in
 -- transactions.
 --
@@ -1687,13 +1656,14 @@ deriving instance Show (TxWithdrawals build era)
 
 data TxCertificates build era where
 
-     TxCertificatesNone :: TxCertificates build era
+  TxCertificatesNone
+    :: TxCertificates build era
 
-     TxCertificates     :: CertificatesSupportedInEra era
-                        -> [Certificate era]
-                        -> BuildTxWith build
-                             (Map StakeCredential (Witness WitCtxStake era))
-                        -> TxCertificates build era
+  TxCertificates
+    :: ShelleyBasedEra era
+    -> [Certificate era]
+    -> BuildTxWith build (Map StakeCredential (Witness WitCtxStake era))
+    -> TxCertificates build era
 
 deriving instance Eq   (TxCertificates build era)
 deriving instance Show (TxCertificates build era)
@@ -3210,59 +3180,11 @@ fromLedgerTxCertificates
   -> Ledger.TxBody (ShelleyLedgerEra era)
   -> TxCertificates ViewTx era
 fromLedgerTxCertificates sbe body =
-  case sbe of
-    ShelleyBasedEraShelley
-      | null certificates -> TxCertificatesNone
-      | otherwise ->
-          TxCertificates
-            CertificatesInShelleyEra
-            (map (fromShelleyCertificate sbe) $ toList certificates)
-            ViewTx
-      where
-        certificates = body ^. L.certsTxBodyL
-
-    ShelleyBasedEraAllegra
-      | null certificates -> TxCertificatesNone
-      | otherwise ->
-          TxCertificates
-            CertificatesInAllegraEra
-            (map (fromShelleyCertificate sbe) $ toList certificates)
-            ViewTx
-      where
-        certificates = body ^. L.certsTxBodyL
-
-    ShelleyBasedEraMary
-      | null certificates -> TxCertificatesNone
-      | otherwise ->
-          TxCertificates
-            CertificatesInMaryEra
-            (map (fromShelleyCertificate sbe) $ toList certificates)
-            ViewTx
-      where
-        certificates = body ^. L.certsTxBodyL
-
-    ShelleyBasedEraAlonzo
-      | null certificates -> TxCertificatesNone
-      | otherwise ->
-          TxCertificates
-            CertificatesInAlonzoEra
-            (map (fromShelleyCertificate sbe) $ toList certificates)
-            ViewTx
-      where
-        certificates = body ^. L.certsTxBodyL
-
-    ShelleyBasedEraBabbage
-      | null certificates -> TxCertificatesNone
-      | otherwise ->
-          TxCertificates
-            CertificatesInBabbageEra
-            (map (fromShelleyCertificate sbe) $ toList certificates)
-            ViewTx
-      where
-        certificates = body ^. L.certsTxBodyL
-
-    -- TODO: Implement once certificates are done in Conway.
-    ShelleyBasedEraConway -> TxCertificatesNone
+  shelleyBasedEraConstraints sbe $
+    let certificates = body ^. L.certsTxBodyL in
+    if null certificates
+      then TxCertificatesNone
+      else TxCertificates sbe (map (fromShelleyCertificate sbe) $ toList certificates) ViewTx
 
 fromLedgerTxUpdateProposal
   :: ShelleyBasedEra era

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -352,7 +352,6 @@ module Cardano.Api (
     TxExtraKeyWitnessesSupportedInEra(..),
     ScriptDataSupportedInEra(..),
     WithdrawalsSupportedInEra(..),
-    CertificatesSupportedInEra(..),
     UpdateProposalSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
 
@@ -366,7 +365,6 @@ module Cardano.Api (
     auxScriptsSupportedInEra,
     extraKeyWitnessesSupportedInEra,
     withdrawalsSupportedInEra,
-    certificatesSupportedInEra,
     updateProposalSupportedInEra,
     scriptDataSupportedInEra,
     totalAndReturnCollateralSupportedInEra,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `CertificatesSupportedInEra`.  Use `ShelleyBasedEra` instead.
    Delete `certificatesSupportedInEra`.  Use `inEonForEra` instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
