### PR TITLE
Replace WithdrawalsSupportedInEra with ShelleyBasedEra

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -583,15 +583,16 @@ genTxAuxScripts era =
                  (genScriptInEra era)
 
 genTxWithdrawals :: CardanoEra era -> Gen (TxWithdrawals BuildTx era)
-genTxWithdrawals era =
-  case withdrawalsSupportedInEra era of
-    Nothing -> pure TxWithdrawalsNone
-    Just supported ->
+genTxWithdrawals =
+  inEonForEra
+    (pure TxWithdrawalsNone)
+    (\w ->
       Gen.choice
         [ pure TxWithdrawalsNone
-        , pure (TxWithdrawals supported mempty)
+        , pure (TxWithdrawals w mempty)
           -- TODO: Generate withdrawals
         ]
+    )
 
 genTxCertificates :: CardanoEra era -> Gen (TxCertificates BuildTx era)
 genTxCertificates =

--- a/cardano-api/internal/Cardano/Api/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Tx.hs
@@ -50,6 +50,7 @@ module Cardano.Api.Tx (
 
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
+import           Cardano.Api.Eon.AlonzoEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras
 import           Cardano.Api.Eras.Constraints

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -393,7 +393,6 @@ module Cardano.Api (
     ValidityLowerBoundSupportedInEra(..),
     AuxScriptsSupportedInEra(..),
     TxExtraKeyWitnessesSupportedInEra(..),
-    WithdrawalsSupportedInEra(..),
     TxTotalAndReturnCollateralSupportedInEra(..),
 
     -- ** Feature availability functions
@@ -403,7 +402,6 @@ module Cardano.Api (
     validityLowerBoundSupportedInEra,
     auxScriptsSupportedInEra,
     extraKeyWitnessesSupportedInEra,
-    withdrawalsSupportedInEra,
     totalAndReturnCollateralSupportedInEra,
 
     -- ** Era-dependent protocol features


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `WithdrawalsSupportedInEra`.  Use `ShelleyBasedEra` instead.
    Delete `withdrawalsSupportedInEra`.  Use `inEonForEra` instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
