### PR TITLE
cardano-api-internal: ProposeNewCommittee: StakeKey -> CommitteeColdKey

### DIFF
--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -34,7 +34,7 @@ import           Cardano.Ledger.Core (EraCrypto)
 import qualified Cardano.Ledger.Core as Shelley
 import qualified Cardano.Ledger.Credential as L
 import           Cardano.Ledger.Crypto (StandardCrypto)
-import           Cardano.Ledger.Keys (HasKeyRole (coerceKeyRole), KeyRole (ColdCommitteeRole))
+import           Cardano.Ledger.Keys (KeyRole (ColdCommitteeRole))
 
 import           Data.ByteString (ByteString)
 import           Data.Map.Strict (Map)
@@ -54,8 +54,8 @@ data GovernanceAction
       (Ledger.Anchor StandardCrypto)
   | ProposeNewCommittee
       (StrictMaybe (Ledger.PrevGovActionId Ledger.CommitteePurpose StandardCrypto))
-      [Hash StakeKey] -- ^ Old constitutional committee
-      (Map (Hash StakeKey) EpochNo) -- ^ New committee members with epoch number when each of them expires
+      [Hash CommitteeColdKey] -- ^ Old constitutional committee
+      (Map (Hash CommitteeColdKey) EpochNo) -- ^ New committee members with epoch number when each of them expires
       Rational -- ^ Quorum of the committee that is necessary for a successful vote
   | InfoAct
   | TreasuryWithdrawal [(Network, StakeCredential, Lovelace)]
@@ -224,12 +224,12 @@ createAnchor url anchorData =
 -- TODO conversions that likely need to live elsewhere and may even deserve
 -- additional wrapper types
 
-toCommitteeMember :: Hash StakeKey -> L.Credential ColdCommitteeRole StandardCrypto
-toCommitteeMember (StakeKeyHash keyhash) = coerceKeyRole $ L.KeyHashObj keyhash
+toCommitteeMember :: Hash CommitteeColdKey -> L.Credential ColdCommitteeRole StandardCrypto
+toCommitteeMember (CommitteeColdKeyHash keyhash) = L.KeyHashObj keyhash
 
-fromCommitteeMember :: L.Credential ColdCommitteeRole StandardCrypto -> Hash StakeKey
-fromCommitteeMember = (. coerceKeyRole) $ \case
-  L.KeyHashObj keyhash -> StakeKeyHash keyhash
+fromCommitteeMember :: L.Credential ColdCommitteeRole StandardCrypto -> Hash CommitteeColdKey
+fromCommitteeMember = \case
+  L.KeyHashObj keyhash -> CommitteeColdKeyHash keyhash
   L.ScriptHashObj _scripthash -> error "TODO script committee members not yet supported"
 
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make ProposeNewCommittee use the appropriate type of key
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Required to implement [this comment](https://github.com/input-output-hk/cardano-cli/issues/300#issuecomment-1731004496) of https://github.com/input-output-hk/cardano-cli/issues/300.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] The changelog section in the PR is updated to describe the change
- [X] Self-reviewed the diff
