### PR TITLE
New function `alonzoEraOnwardsToMaryEraOnwards` and `shelleyToAllegraEraToByronToAllegraEra`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -21,6 +21,7 @@ module Cardano.Api.Eras.Case
 
     -- Conversions
   , shelleyToAllegraEraToByronToAllegraEra
+  , alonzoEraOnwardsToMaryEraOnwards
   ) where
 
 import           Cardano.Api.Eon.AlonzoEraOnwards
@@ -154,3 +155,11 @@ shelleyToAllegraEraToByronToAllegraEra :: ShelleyToAllegraEra era -> ByronToAlle
 shelleyToAllegraEraToByronToAllegraEra = \case
   ShelleyToAllegraEraShelley -> ByronToAllegraEraShelley
   ShelleyToAllegraEraAllegra -> ByronToAllegraEraAllegra
+
+alonzoEraOnwardsToMaryEraOnwards :: ()
+  => AlonzoEraOnwards era
+  -> MaryEraOnwards era
+alonzoEraOnwardsToMaryEraOnwards = \case
+  AlonzoEraOnwardsAlonzo  -> MaryEraOnwardsAlonzo
+  AlonzoEraOnwardsBabbage -> MaryEraOnwardsBabbage
+  AlonzoEraOnwardsConway  -> MaryEraOnwardsConway

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -139,6 +139,10 @@ module Cardano.Api (
     caseShelleyToAlonzoOrBabbageEraOnwards,
     caseShelleyToBabbageOrConwayEraOnwards,
 
+    -- ** Eon relaxation
+    shelleyToAllegraEraToByronToAllegraEra,
+    alonzoEraOnwardsToMaryEraOnwards,
+
     -- * Assertions on era
     requireShelleyBasedEra,
 
@@ -1034,6 +1038,7 @@ import           Cardano.Api.Eon.ShelleyToBabbageEra
 import           Cardano.Api.Eon.ShelleyToMaryEra
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Case
 import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.Error
 import           Cardano.Api.Feature


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New functions `alonzoEraOnwardsToMaryEraOnwards` and `shelleyToAllegraEraToByronToAllegraEra`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
