### PR TITLE
Fix missing redeemers in certificate deregistration

### DIFF
--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -27,6 +27,7 @@ module Cardano.Api.ReexposeLedger
   , pattern ResignCommitteeColdTxCert
   , pattern RegTxCert
   , pattern UnRegTxCert
+  , pattern DelegStakeTxCert
   , pattern RegDepositDelegTxCert
   , pattern RegDRepTxCert
 
@@ -91,11 +92,11 @@ module Cardano.Api.ReexposeLedger
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
 import           Cardano.Ledger.Alonzo.Core (CoinPerWord (..))
 import           Cardano.Ledger.Alonzo.Scripts (Prices (..))
-import           Cardano.Ledger.Api.Tx.Cert (pattern AuthCommitteeHotKeyTxCert, pattern DelegTxCert,
-                   pattern RegDRepTxCert, pattern RegDepositDelegTxCert, pattern RegDepositTxCert,
-                   pattern RegPoolTxCert, pattern RegTxCert, pattern ResignCommitteeColdTxCert,
-                   pattern RetirePoolTxCert, pattern UnRegDRepTxCert, pattern UnRegDepositTxCert,
-                   pattern UnRegTxCert)
+import           Cardano.Ledger.Api.Tx.Cert (pattern AuthCommitteeHotKeyTxCert,
+                   pattern DelegStakeTxCert, pattern DelegTxCert, pattern RegDRepTxCert,
+                   pattern RegDepositDelegTxCert, pattern RegDepositTxCert, pattern RegPoolTxCert,
+                   pattern RegTxCert, pattern ResignCommitteeColdTxCert, pattern RetirePoolTxCert,
+                   pattern UnRegDRepTxCert, pattern UnRegDepositTxCert, pattern UnRegTxCert)
 import           Cardano.Ledger.Babbage.Core (CoinPerByte (..))
 import           Cardano.Ledger.BaseTypes (DnsName, Network (..), StrictMaybe (..), Url,
                    boundRational, dnsToText, maybeToStrictMaybe, portToWord16, strictMaybeToMaybe,

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -274,6 +274,7 @@ import qualified Text.Parsec as Parsec
 import           Text.Parsec ((<?>))
 import qualified Text.Parsec.String as Parsec
 
+
 -- | Indicates whether a script is expected to fail or pass validation.
 data ScriptValidity
   = ScriptInvalid -- ^ Script is expected to fail validation.
@@ -3508,6 +3509,7 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraBabbage
     txAuxData :: Maybe (L.TxAuxData StandardBabbage)
     txAuxData = toAuxiliaryData sbe txMetadata txAuxScripts
 
+
 makeShelleyTransactionBody sbe@ShelleyBasedEraConway
                             txbodycontent@TxBodyContent {
                              txIns,
@@ -3609,7 +3611,6 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraConway
     txAuxData = toAuxiliaryData sbe txMetadata txAuxScripts
 
 
-
 -- | A variant of 'toShelleyTxOutAny that is used only internally to this module
 -- that works with a 'TxOut' in any context (including CtxTx) by ignoring
 -- embedded datums (taking only their hash).
@@ -3674,6 +3675,8 @@ toBabbageTxOutDatum' (TxOutDatumInline _ sd) = scriptDataToInlineDatum sd
 --
 data AnyScriptWitness era where
      AnyScriptWitness :: ScriptWitness witctx era -> AnyScriptWitness era
+
+deriving instance Show (AnyScriptWitness era)
 
 -- | Identify the location of a 'ScriptWitness' within the context of a
 -- 'TxBody'. These are indexes of the objects within the transaction that
@@ -3791,10 +3794,9 @@ collectTxBodyScriptWitnesses sbe TxBodyContent {
           -- The certs are indexed in list order
         | (ix, cert) <- zip [0..] certs
         , ScriptWitness _ witness <- maybeToList $ do
-                                       stakecred <- shelleyBasedEraConstraints sbe $ selectStakeCredential sbe cert
+                                       stakecred <- shelleyBasedEraConstraints sbe $ selectStakeCredential cert
                                        Map.lookup stakecred witnesses
         ]
-
 
     scriptWitnessesMinting
       :: TxMintValue BuildTx era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix missing redeemers in certificate deregistration
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Part of:
- https://github.com/input-output-hk/cardano-cli/issues/299
- https://github.com/input-output-hk/cardano-cli/issues/297

Prerequisite of:
- https://github.com/input-output-hk/cardano-cli/pull/306

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
