### PR TITLE
Replace `ValidityUpperBoundSupportedInEra` and `ValidityNoUpperBoundSupportedInEra`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -66,6 +66,7 @@ library internal
                         Cardano.Api.Eon.ConwayEraOnwards
                         Cardano.Api.Eon.MaryEraOnwards
                         Cardano.Api.Eon.ShelleyBasedEra
+                        Cardano.Api.Eon.ShelleyEraOnly
                         Cardano.Api.Eon.ShelleyToAllegraEra
                         Cardano.Api.Eon.ShelleyToAlonzoEra
                         Cardano.Api.Eon.ShelleyToBabbageEra

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -58,6 +58,7 @@ library internal
                         Cardano.Api.Eon.AlonzoEraOnly
                         Cardano.Api.Eon.AlonzoEraOnwards
                         Cardano.Api.Eon.BabbageEraOnwards
+                        Cardano.Api.Eon.ByronAndAllegraEraOnwards
                         Cardano.Api.Eon.ByronEraOnly
                         Cardano.Api.Eon.ByronToAllegraEra
                         Cardano.Api.Eon.ByronToAlonzoEra

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -543,16 +543,12 @@ genTxValidityLowerBound =
 -- TODO: Accept a range for generating ttl.
 genTxValidityUpperBound :: CardanoEra era -> Gen (TxValidityUpperBound era)
 genTxValidityUpperBound era =
-  case (validityUpperBoundSupportedInEra era,
-       validityNoUpperBoundSupportedInEra era) of
-    (Just supported, _) ->
-      TxValidityUpperBound supported <$> genTtl
-
-    (Nothing, Just supported) ->
-      pure (TxValidityNoUpperBound supported)
-
-    (Nothing, Nothing) ->
-      error "genTxValidityUpperBound: unexpected era support combination"
+  forEraInEon era
+    ( forEraInEon era
+        (error "genTxValidityUpperBound: unexpected era support combination")
+        (pure . TxValidityNoUpperBound)
+    )
+    (\w -> TxValidityUpperBound w <$> genTtl)
 
 genTxValidityRange
   :: CardanoEra era

--- a/cardano-api/internal/Cardano/Api/Eon/ByronAndAllegraEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronAndAllegraEraOnwards.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Eon.ByronAndAllegraEraOnwards
+  ( ByronAndAllegraEraOnwards(..)
+  , byronAndAllegraEraOnwardsConstraints
+  , byronAndAllegraEraOnwardsToCardanoEra
+
+  , ByronAndAllegraEraOnwardsConstraints
+  ) where
+
+import           Cardano.Api.Eras.Core
+
+import           Data.Typeable (Typeable)
+
+data ByronAndAllegraEraOnwards era where
+  ByronAndAllegraEraOnwardsByron   :: ByronAndAllegraEraOnwards ByronEra
+  ByronAndAllegraEraOnwardsAllegra :: ByronAndAllegraEraOnwards AllegraEra
+  ByronAndAllegraEraOnwardsMary    :: ByronAndAllegraEraOnwards MaryEra
+  ByronAndAllegraEraOnwardsAlonzo  :: ByronAndAllegraEraOnwards AlonzoEra
+  ByronAndAllegraEraOnwardsBabbage :: ByronAndAllegraEraOnwards BabbageEra
+  ByronAndAllegraEraOnwardsConway  :: ByronAndAllegraEraOnwards ConwayEra
+
+deriving instance Show (ByronAndAllegraEraOnwards era)
+deriving instance Eq (ByronAndAllegraEraOnwards era)
+
+instance Eon ByronAndAllegraEraOnwards where
+  inEonForEra no yes = \case
+    ByronEra    -> yes ByronAndAllegraEraOnwardsByron
+    ShelleyEra  -> no
+    AllegraEra  -> yes ByronAndAllegraEraOnwardsAllegra
+    MaryEra     -> yes ByronAndAllegraEraOnwardsMary
+    AlonzoEra   -> yes ByronAndAllegraEraOnwardsAlonzo
+    BabbageEra  -> yes ByronAndAllegraEraOnwardsBabbage
+    ConwayEra   -> yes ByronAndAllegraEraOnwardsConway
+
+instance ToCardanoEra ByronAndAllegraEraOnwards where
+  toCardanoEra = \case
+    ByronAndAllegraEraOnwardsByron   -> ByronEra
+    ByronAndAllegraEraOnwardsAllegra -> AllegraEra
+    ByronAndAllegraEraOnwardsMary    -> MaryEra
+    ByronAndAllegraEraOnwardsAlonzo  -> AlonzoEra
+    ByronAndAllegraEraOnwardsBabbage -> BabbageEra
+    ByronAndAllegraEraOnwardsConway  -> ConwayEra
+
+type ByronAndAllegraEraOnwardsConstraints era =
+  ( IsCardanoEra era
+  , Typeable era
+  )
+
+byronAndAllegraEraOnwardsConstraints :: ()
+  => ByronAndAllegraEraOnwards era
+  -> (ByronAndAllegraEraOnwardsConstraints era => a)
+  -> a
+byronAndAllegraEraOnwardsConstraints = \case
+  ByronAndAllegraEraOnwardsByron    -> id
+  ByronAndAllegraEraOnwardsAllegra  -> id
+  ByronAndAllegraEraOnwardsMary     -> id
+  ByronAndAllegraEraOnwardsAlonzo   -> id
+  ByronAndAllegraEraOnwardsBabbage  -> id
+  ByronAndAllegraEraOnwardsConway   -> id
+
+byronAndAllegraEraOnwardsToCardanoEra :: ByronAndAllegraEraOnwards era -> CardanoEra era
+byronAndAllegraEraOnwardsToCardanoEra = \case
+  ByronAndAllegraEraOnwardsByron    -> ByronEra
+  ByronAndAllegraEraOnwardsAllegra  -> AllegraEra
+  ByronAndAllegraEraOnwardsMary     -> MaryEra
+  ByronAndAllegraEraOnwardsAlonzo   -> AlonzoEra
+  ByronAndAllegraEraOnwardsBabbage  -> BabbageEra
+  ByronAndAllegraEraOnwardsConway   -> ConwayEra

--- a/cardano-api/internal/Cardano/Api/Eon/ByronToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronToAllegraEra.hs
@@ -9,7 +9,6 @@
 
 module Cardano.Api.Eon.ByronToAllegraEra
   ( ByronToAllegraEra(..)
-  , IsByronToAllegraEra(..)
   , byronToAllegraEraConstraints
   , byronToAllegraEraToCardanoEra
 
@@ -20,9 +19,6 @@ import           Cardano.Api.Eras.Core
 
 import           Data.Typeable (Typeable)
 
-class IsByronToAllegraEra era where
-  byronToAllegraEra :: ByronToAllegraEra era
-
 data ByronToAllegraEra era where
   ByronToAllegraEraByron    :: ByronToAllegraEra ByronEra
   ByronToAllegraEraShelley  :: ByronToAllegraEra ShelleyEra
@@ -30,25 +26,6 @@ data ByronToAllegraEra era where
 
 deriving instance Show (ByronToAllegraEra era)
 deriving instance Eq (ByronToAllegraEra era)
-
-instance IsByronToAllegraEra ByronEra where
-  byronToAllegraEra = ByronToAllegraEraByron
-
-instance IsByronToAllegraEra ShelleyEra where
-  byronToAllegraEra = ByronToAllegraEraShelley
-
-instance IsByronToAllegraEra AllegraEra where
-  byronToAllegraEra = ByronToAllegraEraAllegra
-
-instance Eon ByronToAllegraEra where
-  inEonForEra no yes = \case
-    ByronEra    -> yes ByronToAllegraEraByron
-    ShelleyEra  -> yes ByronToAllegraEraShelley
-    AllegraEra  -> yes ByronToAllegraEraAllegra
-    MaryEra     -> no
-    AlonzoEra   -> no
-    BabbageEra  -> no
-    ConwayEra   -> no
 
 instance ToCardanoEra ByronToAllegraEra where
   toCardanoEra = \case
@@ -58,7 +35,6 @@ instance ToCardanoEra ByronToAllegraEra where
 
 type ByronToAllegraEraConstraints era =
   ( IsCardanoEra era
-  , IsByronToAllegraEra era
   , Typeable era
   )
 

--- a/cardano-api/internal/Cardano/Api/Eon/ByronToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronToAlonzoEra.hs
@@ -9,7 +9,6 @@
 
 module Cardano.Api.Eon.ByronToAlonzoEra
   ( ByronToAlonzoEra(..)
-  , IsByronToAlonzoEra(..)
   , byronToAlonzoEraConstraints
   , byronToAlonzoEraToCardanoEra
 
@@ -20,9 +19,6 @@ import           Cardano.Api.Eras.Core
 
 import           Data.Typeable (Typeable)
 
-class IsByronToAlonzoEra era where
-  byronToAlonzoEra :: ByronToAlonzoEra era
-
 data ByronToAlonzoEra era where
   ByronToAlonzoEraByron   :: ByronToAlonzoEra ByronEra
   ByronToAlonzoEraShelley :: ByronToAlonzoEra ShelleyEra
@@ -32,21 +28,6 @@ data ByronToAlonzoEra era where
 
 deriving instance Show (ByronToAlonzoEra era)
 deriving instance Eq (ByronToAlonzoEra era)
-
-instance IsByronToAlonzoEra ByronEra where
-  byronToAlonzoEra = ByronToAlonzoEraByron
-
-instance IsByronToAlonzoEra ShelleyEra where
-  byronToAlonzoEra = ByronToAlonzoEraShelley
-
-instance IsByronToAlonzoEra AllegraEra where
-  byronToAlonzoEra = ByronToAlonzoEraAllegra
-
-instance IsByronToAlonzoEra MaryEra where
-  byronToAlonzoEra = ByronToAlonzoEraMary
-
-instance IsByronToAlonzoEra AlonzoEra where
-  byronToAlonzoEra = ByronToAlonzoEraAlonzo
 
 instance Eon ByronToAlonzoEra where
   inEonForEra no yes = \case
@@ -68,7 +49,6 @@ instance ToCardanoEra ByronToAlonzoEra where
 
 type ByronToAlonzoEraConstraints era =
   ( IsCardanoEra era
-  , IsByronToAlonzoEra era
   , Typeable era
   )
 

--- a/cardano-api/internal/Cardano/Api/Eon/ByronToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronToMaryEra.hs
@@ -9,7 +9,6 @@
 
 module Cardano.Api.Eon.ByronToMaryEra
   ( ByronToMaryEra(..)
-  , IsByronToMaryEra(..)
   , byronToMaryEraConstraints
   , byronToMaryEraToCardanoEra
 
@@ -20,9 +19,6 @@ import           Cardano.Api.Eras.Core
 
 import           Data.Typeable (Typeable)
 
-class IsByronToMaryEra era where
-  byronToMaryEra :: ByronToMaryEra era
-
 data ByronToMaryEra era where
   ByronToMaryEraByron   :: ByronToMaryEra ByronEra
   ByronToMaryEraShelley :: ByronToMaryEra ShelleyEra
@@ -31,18 +27,6 @@ data ByronToMaryEra era where
 
 deriving instance Show (ByronToMaryEra era)
 deriving instance Eq (ByronToMaryEra era)
-
-instance IsByronToMaryEra ByronEra where
-  byronToMaryEra = ByronToMaryEraByron
-
-instance IsByronToMaryEra ShelleyEra where
-  byronToMaryEra = ByronToMaryEraShelley
-
-instance IsByronToMaryEra AllegraEra where
-  byronToMaryEra = ByronToMaryEraAllegra
-
-instance IsByronToMaryEra MaryEra where
-  byronToMaryEra = ByronToMaryEraMary
 
 instance Eon ByronToMaryEra where
   inEonForEra no yes = \case
@@ -63,7 +47,6 @@ instance ToCardanoEra ByronToMaryEra where
 
 type ByronToMaryEraConstraints era =
   ( IsCardanoEra era
-  , IsByronToMaryEra era
   , Typeable era
   )
 

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eon.MaryEraOnwards
   ( MaryEraOnwards(..)
-  , IsMaryEraOnwards(..)
   , maryEraOnwardsConstraints
   , maryEraOnwardsToCardanoEra
   , maryEraOnwardsToShelleyBasedEra
@@ -39,9 +38,6 @@ import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 import           Data.Aeson
 import           Data.Typeable (Typeable)
 
-class IsShelleyBasedEra era => IsMaryEraOnwards era where
-  maryEraOnwards :: MaryEraOnwards era
-
 data MaryEraOnwards era where
   MaryEraOnwardsMary  :: MaryEraOnwards MaryEra
   MaryEraOnwardsAlonzo  :: MaryEraOnwards AlonzoEra
@@ -50,18 +46,6 @@ data MaryEraOnwards era where
 
 deriving instance Show (MaryEraOnwards era)
 deriving instance Eq (MaryEraOnwards era)
-
-instance IsMaryEraOnwards MaryEra where
-  maryEraOnwards = MaryEraOnwardsMary
-
-instance IsMaryEraOnwards AlonzoEra where
-  maryEraOnwards = MaryEraOnwardsAlonzo
-
-instance IsMaryEraOnwards BabbageEra where
-  maryEraOnwards = MaryEraOnwardsBabbage
-
-instance IsMaryEraOnwards ConwayEra where
-  maryEraOnwards = MaryEraOnwardsConway
 
 instance Eon MaryEraOnwards where
   inEonForEra no yes = \case
@@ -100,7 +84,6 @@ type MaryEraOnwardsConstraints era =
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
-  , IsMaryEraOnwards era
   , IsCardanoEra era
   , IsShelleyBasedEra era
   , ToJSON (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Eon.ShelleyEraOnly
+  ( ShelleyEraOnly(..)
+  , shelleyEraOnlyConstraints
+  , shelleyEraOnlyToCardanoEra
+  , shelleyEraOnlyToShelleyBasedEra
+
+  , ShelleyEraOnlyConstraints
+  ) where
+
+import           Cardano.Api.Eon.ShelleyBasedEra
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Coin as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+data ShelleyEraOnly era where
+  ShelleyEraOnlyShelley  :: ShelleyEraOnly ShelleyEra
+
+deriving instance Show (ShelleyEraOnly era)
+deriving instance Eq (ShelleyEraOnly era)
+
+instance Eon ShelleyEraOnly where
+  inEonForEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyEraOnlyShelley
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyEraOnly where
+  toCardanoEra = \case
+    ShelleyEraOnlyShelley  -> ShelleyEra
+
+type ShelleyEraOnlyConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.ExactEra L.ShelleyEra (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 2
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 6
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 8
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , L.Value (ShelleyLedgerEra era) ~ L.Coin
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+shelleyEraOnlyConstraints :: ()
+  => ShelleyEraOnly era
+  -> (ShelleyEraOnlyConstraints era => a)
+  -> a
+shelleyEraOnlyConstraints = \case
+  ShelleyEraOnlyShelley  -> id
+
+shelleyEraOnlyToCardanoEra :: ShelleyEraOnly era -> CardanoEra era
+shelleyEraOnlyToCardanoEra = shelleyBasedToCardanoEra . shelleyEraOnlyToShelleyBasedEra
+
+shelleyEraOnlyToShelleyBasedEra :: ShelleyEraOnly era -> ShelleyBasedEra era
+shelleyEraOnlyToShelleyBasedEra = \case
+  ShelleyEraOnlyShelley  -> ShelleyBasedEraShelley

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -10,6 +10,7 @@ module Cardano.Api.Eras.Case
   , caseByronToAllegraOrMaryEraOnwards
   , caseByronToMaryOrAlonzoEraOnwards
   , caseByronToAlonzoOrBabbageEraOnwards
+  , caseByronAndAllegraEraOnwardsOrShelleyEraOnly
 
     -- Case on ShelleyBasedEra
   , caseShelleyToAllegraOrMaryEraOnwards
@@ -26,6 +27,7 @@ module Cardano.Api.Eras.Case
 
 import           Cardano.Api.Eon.AlonzoEraOnwards
 import           Cardano.Api.Eon.BabbageEraOnwards
+import           Cardano.Api.Eon.ByronAndAllegraEraOnwards
 import           Cardano.Api.Eon.ByronEraOnly
 import           Cardano.Api.Eon.ByronToAllegraEra
 import           Cardano.Api.Eon.ByronToAlonzoEra
@@ -33,6 +35,7 @@ import           Cardano.Api.Eon.ByronToMaryEra
 import           Cardano.Api.Eon.ConwayEraOnwards
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
+import           Cardano.Api.Eon.ShelleyEraOnly
 import           Cardano.Api.Eon.ShelleyToAllegraEra
 import           Cardano.Api.Eon.ShelleyToAlonzoEra
 import           Cardano.Api.Eon.ShelleyToBabbageEra
@@ -95,6 +98,21 @@ caseByronToAlonzoOrBabbageEraOnwards l r = \case
   AlonzoEra  -> l ByronToAlonzoEraAlonzo
   BabbageEra -> r BabbageEraOnwardsBabbage
   ConwayEra  -> r BabbageEraOnwardsConway
+
+caseByronAndAllegraEraOnwardsOrShelleyEraOnly :: ()
+  => (ByronAndAllegraEraOnwardsConstraints era => ByronAndAllegraEraOnwards era -> a)
+  -> (ShelleyEraOnlyConstraints era => ShelleyEraOnly era -> a)
+  -> CardanoEra era
+  -> a
+caseByronAndAllegraEraOnwardsOrShelleyEraOnly l r = \case
+  ByronEra   -> l ByronAndAllegraEraOnwardsByron
+  ShelleyEra -> r ShelleyEraOnlyShelley
+  AllegraEra -> l ByronAndAllegraEraOnwardsAllegra
+  MaryEra    -> l ByronAndAllegraEraOnwardsMary
+  AlonzoEra  -> l ByronAndAllegraEraOnwardsAlonzo
+  BabbageEra -> l ByronAndAllegraEraOnwardsBabbage
+  ConwayEra  -> l ByronAndAllegraEraOnwardsConway
+
 
 caseShelleyToAllegraOrMaryEraOnwards :: ()
   => (ShelleyToAllegraEraConstraints era => ShelleyToAllegraEra era -> a)

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -72,6 +72,11 @@ module Cardano.Api (
 
     -- ** From Shelley
 
+    ShelleyEraOnly(..),
+    shelleyEraOnlyConstraints,
+    shelleyEraOnlyToCardanoEra,
+    shelleyEraOnlyToShelleyBasedEra,
+
     ShelleyToAllegraEra(..),
     shelleyToAllegraEraConstraints,
     shelleyToAllegraEraToCardanoEra,
@@ -1028,6 +1033,7 @@ import           Cardano.Api.Eon.ByronToMaryEra
 import           Cardano.Api.Eon.ConwayEraOnwards
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
+import           Cardano.Api.Eon.ShelleyEraOnly
 import           Cardano.Api.Eon.ShelleyToAllegraEra
 import           Cardano.Api.Eon.ShelleyToAlonzoEra
 import           Cardano.Api.Eon.ShelleyToBabbageEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -56,17 +56,14 @@ module Cardano.Api (
     byronAndAllegraEraOnwardsToCardanoEra,
 
     ByronToAllegraEra(..),
-    IsByronToAllegraEra(..),
     byronToAllegraEraConstraints,
     byronToAllegraEraToCardanoEra,
 
     ByronToMaryEra(..),
-    IsByronToMaryEra(..),
     byronToMaryEraConstraints,
     byronToMaryEraToCardanoEra,
 
     ByronToAlonzoEra(..),
-    IsByronToAlonzoEra(..),
     byronToAlonzoEraConstraints,
     byronToAlonzoEraToCardanoEra,
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -382,14 +382,10 @@ module Cardano.Api (
 
     -- ** Era-dependent transaction body features
     CollateralSupportedInEra(..),
-    ValidityUpperBoundSupportedInEra(..),
-    ValidityNoUpperBoundSupportedInEra(..),
     AuxScriptsSupportedInEra(..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,
-    validityUpperBoundSupportedInEra,
-    validityNoUpperBoundSupportedInEra,
     auxScriptsSupportedInEra,
 
     -- ** Era-dependent protocol features

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -51,6 +51,10 @@ module Cardano.Api (
     byronEraOnlyConstraints,
     byronEraOnlyToCardanoEra,
 
+    ByronAndAllegraEraOnwards(..),
+    byronAndAllegraEraOnwardsConstraints,
+    byronAndAllegraEraOnwardsToCardanoEra,
+
     ByronToAllegraEra(..),
     IsByronToAllegraEra(..),
     byronToAllegraEraConstraints,
@@ -1016,6 +1020,7 @@ import           Cardano.Api.DRepMetadata
 import           Cardano.Api.Eon.AlonzoEraOnly
 import           Cardano.Api.Eon.AlonzoEraOnwards
 import           Cardano.Api.Eon.BabbageEraOnwards
+import           Cardano.Api.Eon.ByronAndAllegraEraOnwards
 import           Cardano.Api.Eon.ByronEraOnly
 import           Cardano.Api.Eon.ByronToAllegraEra
 import           Cardano.Api.Eon.ByronToAlonzoEra


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `ValidityUpperBoundSupportedInEra`.  Use `ShelleyBasedEra` instead.
    Delete `ValidityNoUpperBoundSupportedInEra`. Use `ByronAndAllegraEraOnwards` instead.
    New `caseByronAndAllegraEraOnwardsOrShelleyEraOnly` function.
    New `ShelleyEraOnly` eon
    New `ByronAndAllegraEraOnwards` eon
    Delete `validityUpperBoundSupportedInEra`.  Use `inEonForEra` instead.
    Delete `validityNoUpperBoundSupportedInEra`.  Use `inEonForEra` instead.
    Delete `IsByronToAllegraEra`.
    Delete `IsByronToMaryEra`.
    Delete `IsByronToAlonzoEra`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
