### PR TITLE
Replace `AuxScriptsSupportedInEra`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -571,12 +571,9 @@ genTxMetadataInEra =
 
 genTxAuxScripts :: CardanoEra era -> Gen (TxAuxScripts era)
 genTxAuxScripts era =
-  case auxScriptsSupportedInEra era of
-    Nothing -> pure TxAuxScriptsNone
-    Just supported ->
-      TxAuxScripts supported <$>
-        Gen.list (Range.linear 0 3)
-                 (genScriptInEra era)
+  forEraInEon era
+    (pure TxAuxScriptsNone)
+    (\w -> TxAuxScripts w <$> Gen.list (Range.linear 0 3) (genScriptInEra era))
 
 genTxWithdrawals :: CardanoEra era -> Gen (TxWithdrawals BuildTx era)
 genTxWithdrawals =

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -13,6 +13,7 @@ module Cardano.Api.Eras.Case
   , caseByronAndAllegraEraOnwardsOrShelleyEraOnly
 
     -- Case on ShelleyBasedEra
+  , caseShelleyEraOnlyOrAllegraEraOnwards
   , caseShelleyToAllegraOrMaryEraOnwards
   , caseShelleyToMaryOrAlonzoEraOnwards
   , caseShelleyToAlonzoOrBabbageEraOnwards
@@ -25,6 +26,7 @@ module Cardano.Api.Eras.Case
   , alonzoEraOnwardsToMaryEraOnwards
   ) where
 
+import           Cardano.Api.Eon.AllegraEraOnwards
 import           Cardano.Api.Eon.AlonzoEraOnwards
 import           Cardano.Api.Eon.BabbageEraOnwards
 import           Cardano.Api.Eon.ByronAndAllegraEraOnwards
@@ -113,6 +115,18 @@ caseByronAndAllegraEraOnwardsOrShelleyEraOnly l r = \case
   BabbageEra -> l ByronAndAllegraEraOnwardsBabbage
   ConwayEra  -> l ByronAndAllegraEraOnwardsConway
 
+caseShelleyEraOnlyOrAllegraEraOnwards :: ()
+  => (ShelleyEraOnlyConstraints era => ShelleyEraOnly era -> a)
+  -> (AllegraEraOnwardsConstraints era => AllegraEraOnwards era -> a)
+  -> ShelleyBasedEra era
+  -> a
+caseShelleyEraOnlyOrAllegraEraOnwards l r = \case
+  ShelleyBasedEraShelley  -> l ShelleyEraOnlyShelley
+  ShelleyBasedEraAllegra  -> r AllegraEraOnwardsAllegra
+  ShelleyBasedEraMary     -> r AllegraEraOnwardsMary
+  ShelleyBasedEraAlonzo   -> r AllegraEraOnwardsAlonzo
+  ShelleyBasedEraBabbage  -> r AllegraEraOnwardsBabbage
+  ShelleyBasedEraConway   -> r AllegraEraOnwardsConway
 
 caseShelleyToAllegraOrMaryEraOnwards :: ()
   => (ShelleyToAllegraEraConstraints era => ShelleyToAllegraEra era -> a)

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -2563,29 +2563,14 @@ fromLedgerTxAuxiliaryData sbe (Just auxData) =
     metadata = if null ms then TxMetadataNone else TxMetadataInEra sbe $ TxMetadata ms
 
     auxdata =
-      case sbe of
-        ShelleyBasedEraShelley ->
-          TxAuxScriptsNone
-        ShelleyBasedEraAllegra ->
+      caseShelleyEraOnlyOrAllegraEraOnwards
+        (const TxAuxScriptsNone)
+        (\w ->
           case ss of
               [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AllegraEraOnwardsAllegra ss
-        ShelleyBasedEraMary ->
-          case ss of
-              [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AllegraEraOnwardsMary ss
-        ShelleyBasedEraAlonzo ->
-          case ss of
-              [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AllegraEraOnwardsAlonzo ss
-        ShelleyBasedEraBabbage ->
-          case ss of
-              [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AllegraEraOnwardsBabbage ss
-        ShelleyBasedEraConway ->
-          case ss of
-              [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AllegraEraOnwardsConway ss
+              _  -> TxAuxScripts w ss
+        )
+        sbe
 
     (ms, ss) = fromLedgerAuxiliaryData sbe auxData
 

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -112,9 +112,6 @@ module Cardano.Api.TxBody (
     BuildTx,
     ViewTx,
 
-    -- * Era-dependent transaction body features
-    auxScriptsSupportedInEra,
-
     -- * Inspecting 'ScriptWitness'es
     AnyScriptWitness(..),
     ScriptWitnessIndex(..),
@@ -840,38 +837,6 @@ fromBabbageTxOutDatum _ w (Babbage.Datum binData) =
   TxOutDatumInline w $ binaryDataToScriptData w binData
 
 
-
--- ----------------------------------------------------------------------------
--- Era-dependent transaction body features
---
-
--- | A representation of whether the era supports auxiliary scripts in
--- transactions.
---
--- Auxiliary scripts are supported from the Allegra era onwards.
---
-data AuxScriptsSupportedInEra era where
-
-     AuxScriptsInAllegraEra :: AuxScriptsSupportedInEra AllegraEra
-     AuxScriptsInMaryEra    :: AuxScriptsSupportedInEra MaryEra
-     AuxScriptsInAlonzoEra  :: AuxScriptsSupportedInEra AlonzoEra
-     AuxScriptsInBabbageEra :: AuxScriptsSupportedInEra BabbageEra
-     AuxScriptsInConwayEra  :: AuxScriptsSupportedInEra ConwayEra
-
-deriving instance Eq   (AuxScriptsSupportedInEra era)
-deriving instance Show (AuxScriptsSupportedInEra era)
-
-auxScriptsSupportedInEra :: CardanoEra era
-                         -> Maybe (AuxScriptsSupportedInEra era)
-auxScriptsSupportedInEra ByronEra   = Nothing
-auxScriptsSupportedInEra ShelleyEra = Nothing
-auxScriptsSupportedInEra AllegraEra = Just AuxScriptsInAllegraEra
-auxScriptsSupportedInEra MaryEra    = Just AuxScriptsInMaryEra
-auxScriptsSupportedInEra AlonzoEra  = Just AuxScriptsInAlonzoEra
-auxScriptsSupportedInEra BabbageEra = Just AuxScriptsInBabbageEra
-auxScriptsSupportedInEra ConwayEra  = Just AuxScriptsInConwayEra
-
-
 -- ----------------------------------------------------------------------------
 -- Building vs viewing transactions
 --
@@ -1197,11 +1162,13 @@ deriving instance Show (TxMetadataInEra era)
 
 data TxAuxScripts era where
 
-     TxAuxScriptsNone :: TxAuxScripts era
+  TxAuxScriptsNone
+    :: TxAuxScripts era
 
-     TxAuxScripts     :: AuxScriptsSupportedInEra era
-                      -> [ScriptInEra era]
-                      -> TxAuxScripts era
+  TxAuxScripts
+    :: AllegraEraOnwards era
+    -> [ScriptInEra era]
+    -> TxAuxScripts era
 
 deriving instance Eq   (TxAuxScripts era)
 deriving instance Show (TxAuxScripts era)
@@ -2602,23 +2569,23 @@ fromLedgerTxAuxiliaryData sbe (Just auxData) =
         ShelleyBasedEraAllegra ->
           case ss of
               [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AuxScriptsInAllegraEra ss
+              _  -> TxAuxScripts AllegraEraOnwardsAllegra ss
         ShelleyBasedEraMary ->
           case ss of
               [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AuxScriptsInMaryEra ss
+              _  -> TxAuxScripts AllegraEraOnwardsMary ss
         ShelleyBasedEraAlonzo ->
           case ss of
               [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AuxScriptsInAlonzoEra ss
+              _  -> TxAuxScripts AllegraEraOnwardsAlonzo ss
         ShelleyBasedEraBabbage ->
           case ss of
               [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AuxScriptsInBabbageEra ss
+              _  -> TxAuxScripts AllegraEraOnwardsBabbage ss
         ShelleyBasedEraConway ->
           case ss of
               [] -> TxAuxScriptsNone
-              _  -> TxAuxScripts AuxScriptsInConwayEra ss
+              _  -> TxAuxScripts AllegraEraOnwardsConway ss
 
     (ms, ss) = fromLedgerAuxiliaryData sbe auxData
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -142,11 +142,12 @@ module Cardano.Api (
 
     -- ** Case on CardanoEra
     caseByronOrShelleyBasedEra,
-
-    -- ** Case on ShelleyBasedEra
     caseByronToAllegraOrMaryEraOnwards,
     caseByronToMaryOrAlonzoEraOnwards,
     caseByronToAlonzoOrBabbageEraOnwards,
+
+    -- ** Case on ShelleyBasedEra
+    caseShelleyEraOnlyOrAllegraEraOnwards,
     caseShelleyToAllegraOrMaryEraOnwards,
     caseShelleyToMaryOrAlonzoEraOnwards,
     caseShelleyToAlonzoOrBabbageEraOnwards,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -380,9 +380,6 @@ module Cardano.Api (
     BuildTx,
     ViewTx,
 
-    -- ** Era-dependent transaction body features
-    auxScriptsSupportedInEra,
-
     -- ** Era-dependent protocol features
     ProtocolUTxOCostPerByteFeature(..),
     ProtocolUTxOCostPerWordFeature(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `AuxScriptsSupportedInEra`.  Use `AllegraEraOnwards` instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context



# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
