### PR TITLE
Replace `TxTotalAndReturnCollateralSupportedInEra`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -707,17 +707,15 @@ genTxInsReference =
 
 genTxReturnCollateral :: CardanoEra era -> Gen (TxReturnCollateral CtxTx era)
 genTxReturnCollateral era =
-  case totalAndReturnCollateralSupportedInEra  era of
-    Nothing -> return TxReturnCollateralNone
-    Just supp ->
-      TxReturnCollateral supp <$>  genTxOutTxContext era
+  forEraInEon era
+    (pure TxReturnCollateralNone)
+    (\w -> TxReturnCollateral w <$>  genTxOutTxContext era)
 
 genTxTotalCollateral :: CardanoEra era -> Gen (TxTotalCollateral era)
-genTxTotalCollateral era =
-  case totalAndReturnCollateralSupportedInEra  era of
-    Nothing -> return TxTotalCollateralNone
-    Just supp ->
-      TxTotalCollateral supp <$> genPositiveLovelace
+genTxTotalCollateral =
+  inEonForEra
+    (pure TxTotalCollateralNone)
+    (\w -> TxTotalCollateral w <$> genPositiveLovelace)
 
 genTxFee :: CardanoEra era -> Gen (TxFee era)
 genTxFee =

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -71,6 +71,7 @@ type ConwayEraOnwardsConstraints era =
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.BabbageEraTxBody (ShelleyLedgerEra era)
   , L.ConwayEraGov (ShelleyLedgerEra era)
   , L.ConwayEraPParams (ShelleyLedgerEra era)
   , L.ConwayEraTxBody (ShelleyLedgerEra era)

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -393,7 +393,6 @@ module Cardano.Api (
     ValidityLowerBoundSupportedInEra(..),
     AuxScriptsSupportedInEra(..),
     TxExtraKeyWitnessesSupportedInEra(..),
-    TxTotalAndReturnCollateralSupportedInEra(..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,
@@ -402,7 +401,6 @@ module Cardano.Api (
     validityLowerBoundSupportedInEra,
     auxScriptsSupportedInEra,
     extraKeyWitnessesSupportedInEra,
-    totalAndReturnCollateralSupportedInEra,
 
     -- ** Era-dependent protocol features
     ProtocolUTxOCostPerByteFeature(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `TxTotalAndReturnCollateralSupportedInEra`.  Use `BabbageEraOnwards` instead.
    Delete `totalAndReturnCollateralSupportedInEra`.  Use `inEonForEra` or related instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
