### PR TITLE
Replace `ValidityLowerBoundSupportedInEra`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -54,6 +54,7 @@ library internal
                         Cardano.Api.Convenience.Query
                         Cardano.Api.DeserialiseAnyOf
                         Cardano.Api.DRepMetadata
+                        Cardano.Api.Eon.AllegraEraOnwards
                         Cardano.Api.Eon.AlonzoEraOnly
                         Cardano.Api.Eon.AlonzoEraOnwards
                         Cardano.Api.Eon.BabbageEraOnwards

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -535,10 +535,10 @@ genTtl = genSlotNo
 
 -- TODO: Accept a range for generating ttl.
 genTxValidityLowerBound :: CardanoEra era -> Gen (TxValidityLowerBound era)
-genTxValidityLowerBound era =
-  case validityLowerBoundSupportedInEra era of
-    Nothing        -> pure TxValidityNoLowerBound
-    Just supported -> TxValidityLowerBound supported <$> genTtl
+genTxValidityLowerBound =
+  inEonForEra
+    (pure TxValidityNoLowerBound)
+    (\w -> TxValidityLowerBound w <$> genTtl)
 
 -- TODO: Accept a range for generating ttl.
 genTxValidityUpperBound :: CardanoEra era -> Gen (TxValidityUpperBound era)

--- a/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Eon.AllegraEraOnwards
+  ( AllegraEraOnwards(..)
+  , allegraEraOnwardsConstraints
+  , allegraEraOnwardsToCardanoEra
+  , allegraEraOnwardsToShelleyBasedEra
+
+  , AllegraEraOnwardsConstraints
+  ) where
+
+import           Cardano.Api.Eon.ShelleyBasedEra
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+data AllegraEraOnwards era where
+  AllegraEraOnwardsAllegra  :: AllegraEraOnwards AllegraEra
+  AllegraEraOnwardsMary     :: AllegraEraOnwards MaryEra
+  AllegraEraOnwardsAlonzo   :: AllegraEraOnwards AlonzoEra
+  AllegraEraOnwardsBabbage  :: AllegraEraOnwards BabbageEra
+  AllegraEraOnwardsConway   :: AllegraEraOnwards ConwayEra
+
+deriving instance Show (AllegraEraOnwards era)
+deriving instance Eq (AllegraEraOnwards era)
+
+instance Eon AllegraEraOnwards where
+  inEonForEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> yes AllegraEraOnwardsAllegra
+    MaryEra     -> yes AllegraEraOnwardsMary
+    AlonzoEra   -> yes AllegraEraOnwardsAlonzo
+    BabbageEra  -> yes AllegraEraOnwardsBabbage
+    ConwayEra   -> yes AllegraEraOnwardsConway
+
+instance ToCardanoEra AllegraEraOnwards where
+  toCardanoEra = \case
+    AllegraEraOnwardsAllegra -> AllegraEra
+    AllegraEraOnwardsMary    -> MaryEra
+    AllegraEraOnwardsAlonzo  -> AlonzoEra
+    AllegraEraOnwardsBabbage -> BabbageEra
+    AllegraEraOnwardsConway  -> ConwayEra
+
+type AllegraEraOnwardsConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.AllegraEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+allegraEraOnwardsConstraints :: ()
+  => AllegraEraOnwards era
+  -> (AllegraEraOnwardsConstraints era => a)
+  -> a
+allegraEraOnwardsConstraints = \case
+  AllegraEraOnwardsAllegra -> id
+  AllegraEraOnwardsMary    -> id
+  AllegraEraOnwardsAlonzo  -> id
+  AllegraEraOnwardsBabbage -> id
+  AllegraEraOnwardsConway  -> id
+
+allegraEraOnwardsToCardanoEra :: AllegraEraOnwards era -> CardanoEra era
+allegraEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . allegraEraOnwardsToShelleyBasedEra
+
+allegraEraOnwardsToShelleyBasedEra :: AllegraEraOnwards era -> ShelleyBasedEra era
+allegraEraOnwardsToShelleyBasedEra = \case
+  AllegraEraOnwardsAllegra -> ShelleyBasedEraAllegra
+  AllegraEraOnwardsMary    -> ShelleyBasedEraMary
+  AllegraEraOnwardsAlonzo  -> ShelleyBasedEraAlonzo
+  AllegraEraOnwardsBabbage -> ShelleyBasedEraBabbage
+  AllegraEraOnwardsConway  -> ShelleyBasedEraConway

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -390,14 +390,12 @@ module Cardano.Api (
     CollateralSupportedInEra(..),
     ValidityUpperBoundSupportedInEra(..),
     ValidityNoUpperBoundSupportedInEra(..),
-    ValidityLowerBoundSupportedInEra(..),
     AuxScriptsSupportedInEra(..),
 
     -- ** Feature availability functions
     collateralSupportedInEra,
     validityUpperBoundSupportedInEra,
     validityNoUpperBoundSupportedInEra,
-    validityLowerBoundSupportedInEra,
     auxScriptsSupportedInEra,
 
     -- ** Era-dependent protocol features


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `ValidityLowerBoundSupportedInEra`.  Use `AllegraEraOnwards` instead
    Delete `validityLowerBoundSupportedInEra`.  Use `inEonForEra` or equivalent instead
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
