### PR TITLE
New `AnyEraInEon`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnly.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eon.AlonzoEraOnly
   ( AlonzoEraOnly(..)
-  , AnyAlonzoEraOnly(..)
   , alonzoEraOnlyConstraints
   , alonzoEraOnlyToCardanoEra
   , alonzoEraOnlyToShelleyBasedEra
@@ -57,11 +56,6 @@ instance Eon AlonzoEraOnly where
 instance ToCardanoEra AlonzoEraOnly where
   toCardanoEra = \case
     AlonzoEraOnlyAlonzo  -> AlonzoEra
-
-data AnyAlonzoEraOnly where
-  AnyAlonzoEraOnly :: AlonzoEraOnly era -> AnyAlonzoEraOnly
-
-deriving instance Show AnyAlonzoEraOnly
 
 type AlonzoEraOnlyConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))

--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eon.AlonzoEraOnwards
   ( AlonzoEraOnwards(..)
-  , AnyAlonzoEraOnwards(..)
   , alonzoEraOnwardsConstraints
   , alonzoEraOnwardsToCardanoEra
   , alonzoEraOnwardsToShelleyBasedEra
@@ -61,11 +60,6 @@ instance ToCardanoEra AlonzoEraOnwards where
     AlonzoEraOnwardsAlonzo  -> AlonzoEra
     AlonzoEraOnwardsBabbage -> BabbageEra
     AlonzoEraOnwardsConway  -> ConwayEra
-
-data AnyAlonzoEraOnwards where
-  AnyAlonzoEraOnwards :: AlonzoEraOnwards era -> AnyAlonzoEraOnwards
-
-deriving instance Show AnyAlonzoEraOnwards
 
 type AlonzoEraOnwardsConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))

--- a/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eon.BabbageEraOnwards
   ( BabbageEraOnwards(..)
-  , AnyBabbageEraOnwards(..)
   , babbageEraOnwardsConstraints
   , babbageEraOnwardsToCardanoEra
   , babbageEraOnwardsToShelleyBasedEra
@@ -59,11 +58,6 @@ instance ToCardanoEra BabbageEraOnwards where
   toCardanoEra = \case
     BabbageEraOnwardsBabbage -> BabbageEra
     BabbageEraOnwardsConway  -> ConwayEra
-
-data AnyBabbageEraOnwards where
-  AnyBabbageEraOnwards :: BabbageEraOnwards era -> AnyBabbageEraOnwards
-
-deriving instance Show AnyBabbageEraOnwards
 
 type BabbageEraOnwardsConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))

--- a/cardano-api/internal/Cardano/Api/Eon/ByronEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronEraOnly.hs
@@ -8,7 +8,6 @@
 
 module Cardano.Api.Eon.ByronEraOnly
   ( ByronEraOnly(..)
-  , AnyByronEraOnly(..)
   , byronEraOnlyConstraints
   , byronEraOnlyToCardanoEra
 
@@ -38,11 +37,6 @@ instance Eon ByronEraOnly where
 instance ToCardanoEra ByronEraOnly where
   toCardanoEra = \case
     ByronEraOnlyByron  -> ByronEra
-
-data AnyByronEraOnly where
-  AnyByronEraOnly :: ByronEraOnly era -> AnyByronEraOnly
-
-deriving instance Show AnyByronEraOnly
 
 type ByronEraOnlyConstraints era =
   ( IsCardanoEra era

--- a/cardano-api/internal/Cardano/Api/Eon/ByronToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronToAllegraEra.hs
@@ -10,7 +10,6 @@
 module Cardano.Api.Eon.ByronToAllegraEra
   ( ByronToAllegraEra(..)
   , IsByronToAllegraEra(..)
-  , AnyByronToAllegraEra(..)
   , byronToAllegraEraConstraints
   , byronToAllegraEraToCardanoEra
 
@@ -62,11 +61,6 @@ type ByronToAllegraEraConstraints era =
   , IsByronToAllegraEra era
   , Typeable era
   )
-
-data AnyByronToAllegraEra where
-  AnyByronToAllegraEra :: ByronToAllegraEra era -> AnyByronToAllegraEra
-
-deriving instance Show AnyByronToAllegraEra
 
 byronToAllegraEraConstraints :: ()
   => ByronToAllegraEra era

--- a/cardano-api/internal/Cardano/Api/Eon/ByronToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronToAlonzoEra.hs
@@ -10,7 +10,6 @@
 module Cardano.Api.Eon.ByronToAlonzoEra
   ( ByronToAlonzoEra(..)
   , IsByronToAlonzoEra(..)
-  , AnyByronToAlonzoEra(..)
   , byronToAlonzoEraConstraints
   , byronToAlonzoEraToCardanoEra
 
@@ -72,11 +71,6 @@ type ByronToAlonzoEraConstraints era =
   , IsByronToAlonzoEra era
   , Typeable era
   )
-
-data AnyByronToAlonzoEra where
-  AnyByronToAlonzoEra :: ByronToAlonzoEra era -> AnyByronToAlonzoEra
-
-deriving instance Show AnyByronToAlonzoEra
 
 byronToAlonzoEraConstraints :: ()
   => ByronToAlonzoEra era

--- a/cardano-api/internal/Cardano/Api/Eon/ByronToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronToMaryEra.hs
@@ -10,7 +10,6 @@
 module Cardano.Api.Eon.ByronToMaryEra
   ( ByronToMaryEra(..)
   , IsByronToMaryEra(..)
-  , AnyByronToMaryEra(..)
   , byronToMaryEraConstraints
   , byronToMaryEraToCardanoEra
 
@@ -67,11 +66,6 @@ type ByronToMaryEraConstraints era =
   , IsByronToMaryEra era
   , Typeable era
   )
-
-data AnyByronToMaryEra where
-  AnyByronToMaryEra :: ByronToMaryEra era -> AnyByronToMaryEra
-
-deriving instance Show AnyByronToMaryEra
 
 byronToMaryEraConstraints :: ()
   => ByronToMaryEra era

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eon.ConwayEraOnwards
   ( ConwayEraOnwards(..)
-  , AnyConwayEraOnwards(..)
   , conwayEraOnwardsConstraints
   , conwayEraOnwardsToCardanoEra
   , conwayEraOnwardsToShelleyBasedEra
@@ -59,11 +58,6 @@ instance Eon ConwayEraOnwards where
 instance ToCardanoEra ConwayEraOnwards where
   toCardanoEra = \case
     ConwayEraOnwardsConway -> ConwayEra
-
-data AnyConwayEraOnwards where
-  AnyConwayEraOnwards :: ConwayEraOnwards era -> AnyConwayEraOnwards
-
-deriving instance Show AnyConwayEraOnwards
 
 type ConwayEraOnwardsConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.MaryEraOnwards
   ( MaryEraOnwards(..)
   , IsMaryEraOnwards(..)
-  , AnyMaryEraOnwards(..)
   , maryEraOnwardsConstraints
   , maryEraOnwardsToCardanoEra
   , maryEraOnwardsToShelleyBasedEra
@@ -80,11 +79,6 @@ instance ToCardanoEra MaryEraOnwards where
     MaryEraOnwardsAlonzo  -> AlonzoEra
     MaryEraOnwardsBabbage -> BabbageEra
     MaryEraOnwardsConway  -> ConwayEra
-
-data AnyMaryEraOnwards where
-  AnyMaryEraOnwards :: MaryEraOnwards era -> AnyMaryEraOnwards
-
-deriving instance Show AnyMaryEraOnwards
 
 type MaryEraOnwardsConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eon.ShelleyToAllegraEra
   ( ShelleyToAllegraEra(..)
-  , AnyShelleyToAllegraEra(..)
   , shelleyToAllegraEraConstraints
   , shelleyToAllegraEraToCardanoEra
   , shelleyToAllegraEraToShelleyBasedEra
@@ -90,11 +89,6 @@ type ShelleyToAllegraEraConstraints era =
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )
-
-data AnyShelleyToAllegraEra where
-  AnyShelleyToAllegraEra :: ShelleyToAllegraEra era -> AnyShelleyToAllegraEra
-
-deriving instance Show AnyShelleyToAllegraEra
 
 shelleyToAllegraEraConstraints :: ()
   => ShelleyToAllegraEra era

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eon.ShelleyToAlonzoEra
   ( ShelleyToAlonzoEra(..)
-  , AnyShelleyToAlonzoEra(..)
   , shelleyToAlonzoEraConstraints
   , shelleyToAlonzoEraToCardanoEra
   , shelleyToAlonzoEraToShelleyBasedEra
@@ -91,11 +90,6 @@ type ShelleyToAlonzoEraConstraints era =
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )
-
-data AnyShelleyToAlonzoEra where
-  AnyShelleyToAlonzoEra :: ShelleyToAlonzoEra era -> AnyShelleyToAlonzoEra
-
-deriving instance Show AnyShelleyToAlonzoEra
 
 shelleyToAlonzoEraConstraints :: ()
   => ShelleyToAlonzoEra era

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eon.ShelleyToBabbageEra
   ( ShelleyToBabbageEra(..)
-  , AnyShelleyToBabbageEra(..)
   , shelleyToBabbageEraConstraints
   , shelleyToBabbageEraToCardanoEra
   , shelleyToBabbageEraToShelleyBasedEra
@@ -92,11 +91,6 @@ type ShelleyToBabbageEraConstraints era =
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )
-
-data AnyShelleyToBabbageEra where
-  AnyShelleyToBabbageEra :: ShelleyToBabbageEra era -> AnyShelleyToBabbageEra
-
-deriving instance Show AnyShelleyToBabbageEra
 
 shelleyToBabbageEraConstraints :: ()
   => ShelleyToBabbageEra era

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eon.ShelleyToMaryEra
   ( ShelleyToMaryEra(..)
-  , AnyShelleyToMaryEra(..)
   , shelleyToMaryEraConstraints
   , shelleyToMaryEraToCardanoEra
   , shelleyToMaryEraToShelleyBasedEra
@@ -90,11 +89,6 @@ type ShelleyToMaryEraConstraints era =
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )
-
-data AnyShelleyToMaryEra where
-  AnyShelleyToMaryEra :: ShelleyToMaryEra era -> AnyShelleyToMaryEra
-
-deriving instance Show AnyShelleyToMaryEra
 
 shelleyToMaryEraConstraints :: ()
   => ShelleyToMaryEra era

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -22,6 +22,7 @@ module Cardano.Api.Eras
 
     -- * IsEon
   , Eon(..)
+  , AnyEraInEon(..)
   , forEraInEon
   , inEraEonMaybe
   , maybeEonInEra

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -30,6 +30,7 @@ module Cardano.Api.Eras.Core
 
     -- * IsEon
   , Eon(..)
+  , AnyEraInEon(..)
   , forEraInEon
   , inEraEonMaybe
   , maybeEonInEra
@@ -138,6 +139,15 @@ maybeEonInEra :: ()
   -> Maybe (eon era)  -- ^ The eon if supported in the era
 maybeEonInEra =
   inEonForEra Nothing Just
+
+-- ----------------------------------------------------------------------------
+-- AnyEraInEon
+
+data AnyEraInEon where
+  AnyEraInEon
+    :: Eon eon
+    => eon era
+    -> AnyEraInEon
 
 -- ----------------------------------------------------------------------------
 -- ToCardanoEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -29,6 +29,7 @@ module Cardano.Api (
 
     -- * Feature support
     Eon(..),
+    AnyEraInEon(..),
     forEraInEon,
     inEraEonMaybe,
     maybeEonInEra,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -48,50 +48,42 @@ module Cardano.Api (
     -- ** From Byron
 
     ByronEraOnly(..),
-    AnyByronEraOnly(..),
     byronEraOnlyConstraints,
     byronEraOnlyToCardanoEra,
 
     ByronToAllegraEra(..),
     IsByronToAllegraEra(..),
-    AnyByronToAllegraEra(..),
     byronToAllegraEraConstraints,
     byronToAllegraEraToCardanoEra,
 
     ByronToMaryEra(..),
     IsByronToMaryEra(..),
-    AnyByronToMaryEra(..),
     byronToMaryEraConstraints,
     byronToMaryEraToCardanoEra,
 
     ByronToAlonzoEra(..),
     IsByronToAlonzoEra(..),
-    AnyByronToAlonzoEra(..),
     byronToAlonzoEraConstraints,
     byronToAlonzoEraToCardanoEra,
 
     -- ** From Shelley
 
     ShelleyToAllegraEra(..),
-    AnyShelleyToAllegraEra(..),
     shelleyToAllegraEraConstraints,
     shelleyToAllegraEraToCardanoEra,
     shelleyToAllegraEraToShelleyBasedEra,
 
     ShelleyToMaryEra(..),
-    AnyShelleyToMaryEra(..),
     shelleyToMaryEraConstraints,
     shelleyToMaryEraToCardanoEra,
     shelleyToMaryEraToShelleyBasedEra,
 
     ShelleyToAlonzoEra(..),
-    AnyShelleyToAlonzoEra(..),
     shelleyToAlonzoEraConstraints,
     shelleyToAlonzoEraToCardanoEra,
     shelleyToAlonzoEraToShelleyBasedEra,
 
     ShelleyToBabbageEra(..),
-    AnyShelleyToBabbageEra(..),
     shelleyToBabbageEraConstraints,
     shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
@@ -110,7 +102,6 @@ module Cardano.Api (
 
     -- ** From Mary
     MaryEraOnwards(..),
-    AnyMaryEraOnwards(..),
     maryEraOnwardsConstraints,
     maryEraOnwardsToCardanoEra,
     maryEraOnwardsToShelleyBasedEra,
@@ -118,13 +109,11 @@ module Cardano.Api (
     -- ** From Alonzo
 
     AlonzoEraOnly(..),
-    AnyAlonzoEraOnly(..),
     alonzoEraOnlyConstraints,
     alonzoEraOnlyToCardanoEra,
     alonzoEraOnlyToShelleyBasedEra,
 
     AlonzoEraOnwards(..),
-    AnyAlonzoEraOnwards(..),
     alonzoEraOnwardsConstraints,
     alonzoEraOnwardsToCardanoEra,
     alonzoEraOnwardsToShelleyBasedEra,
@@ -132,7 +121,6 @@ module Cardano.Api (
     -- ** From Babbage
 
     BabbageEraOnwards(..),
-    AnyBabbageEraOnwards(..),
     babbageEraOnwardsConstraints,
     babbageEraOnwardsToCardanoEra,
     babbageEraOnwardsToShelleyBasedEra,
@@ -140,7 +128,6 @@ module Cardano.Api (
     -- ** From Conway
 
     ConwayEraOnwards(..),
-    AnyConwayEraOnwards(..),
     conwayEraOnwardsConstraints,
     conwayEraOnwardsToCardanoEra,
     conwayEraOnwardsToShelleyBasedEra,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New `AnyEraInEon`.
    Delete:
    * AnyByronEraOnly
    * AnyByronToAllegraEra
    * AnyByronToMaryEra
    * AnyByronToAlonzoEra
    * AnyShelleyToAllegraEra
    * AnyShelleyToMaryEra
    * AnyShelleyToAlonzoEra
    * AnyShelleyToBabbageEra
    * AnyShelleyBasedEra
    * AnyMaryEraOnwards
    * AnyAlonzoEraOnly
    * AnyAlonzoEraOnwards
    * AnyBabbageEraOnwards
    * AnyConwayEraOnwards
    Use `AnyEraInEon` instead.
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context



# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
