### PR TITLE
Rename eon functions

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -17,7 +17,7 @@ module Cardano.Api.Eon.ShelleyBasedEra
   , shelleyBasedToCardanoEra
   , inEonForShelleyBasedEra
   , forShelleyBasedEraInEon
-  , inShelleyBasedEraEonMaybe
+  , forShelleyBasedEraInEonMaybe
   , forShelleyBasedEraMaybeEon
 
     -- * Cardano eras, as Byron vs Shelley-based
@@ -70,12 +70,12 @@ forShelleyBasedEraInEon :: ()
 forShelleyBasedEraInEon era no yes =
   inEonForShelleyBasedEra no yes era
 
-inShelleyBasedEraEonMaybe :: ()
+forShelleyBasedEraInEonMaybe :: ()
   => Eon eon
   => ShelleyBasedEra era
   -> (eon era -> a)
   -> Maybe a
-inShelleyBasedEraEonMaybe era yes =
+forShelleyBasedEraInEonMaybe era yes =
   forShelleyBasedEraInEon era Nothing (Just . yes)
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -16,6 +16,7 @@ module Cardano.Api.Eon.ShelleyBasedEra
   , InAnyShelleyBasedEra(..)
   , shelleyBasedToCardanoEra
   , inEonForShelleyBasedEra
+  , inEonForShelleyBasedEraMaybe
   , forShelleyBasedEraInEon
   , forShelleyBasedEraInEonMaybe
   , forShelleyBasedEraMaybeEon
@@ -53,6 +54,14 @@ inEonForShelleyBasedEra :: ()
   -> a
 inEonForShelleyBasedEra no yes =
   inEonForEra no yes . shelleyBasedToCardanoEra
+
+inEonForShelleyBasedEraMaybe :: ()
+  => Eon eon
+  => (eon era -> a)
+  -> ShelleyBasedEra era
+  -> Maybe a
+inEonForShelleyBasedEraMaybe yes =
+  inEonForShelleyBasedEra Nothing (Just . yes)
 
 forShelleyBasedEraMaybeEon :: ()
   => Eon eon

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -16,7 +16,7 @@ module Cardano.Api.Eon.ShelleyBasedEra
   , InAnyShelleyBasedEra(..)
   , shelleyBasedToCardanoEra
   , inEonForShelleyBasedEra
-  , inShelleyBasedEraEon
+  , forShelleyBasedEraInEon
   , inShelleyBasedEraEonMaybe
   , forShelleyBasedEraMaybeEon
 
@@ -61,13 +61,13 @@ forShelleyBasedEraMaybeEon :: ()
 forShelleyBasedEraMaybeEon =
   inEonForEra Nothing Just . shelleyBasedToCardanoEra
 
-inShelleyBasedEraEon :: ()
+forShelleyBasedEraInEon :: ()
   => Eon eon
   => ShelleyBasedEra era
   -> a
   -> (eon era -> a)
   -> a
-inShelleyBasedEraEon era no yes =
+forShelleyBasedEraInEon era no yes =
   inEonForShelleyBasedEra no yes era
 
 inShelleyBasedEraEonMaybe :: ()
@@ -76,7 +76,7 @@ inShelleyBasedEraEonMaybe :: ()
   -> (eon era -> a)
   -> Maybe a
 inShelleyBasedEraEonMaybe era yes =
-  inShelleyBasedEraEon era Nothing (Just . yes)
+  forShelleyBasedEraInEon era Nothing (Just . yes)
 
 -- ----------------------------------------------------------------------------
 -- Shelley-based eras

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -15,7 +15,7 @@ module Cardano.Api.Eon.ShelleyBasedEra
   , AnyShelleyBasedEra(..)
   , InAnyShelleyBasedEra(..)
   , shelleyBasedToCardanoEra
-  , eonInShelleyBasedEra
+  , inEonForShelleyBasedEra
   , inShelleyBasedEraEon
   , inShelleyBasedEraEonMaybe
   , maybeEonInShelleyBasedEra
@@ -45,13 +45,13 @@ import qualified Data.Text as Text
 import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 
 -- | Determine the value to use for a feature in a given 'ShelleyBasedEra'.
-eonInShelleyBasedEra :: ()
+inEonForShelleyBasedEra :: ()
   => Eon eon
   => a
   -> (eon era -> a)
   -> ShelleyBasedEra era
   -> a
-eonInShelleyBasedEra no yes =
+inEonForShelleyBasedEra no yes =
   inEonForEra no yes . shelleyBasedToCardanoEra
 
 maybeEonInShelleyBasedEra :: ()
@@ -68,7 +68,7 @@ inShelleyBasedEraEon :: ()
   -> (eon era -> a)
   -> a
 inShelleyBasedEraEon era no yes =
-  eonInShelleyBasedEra no yes era
+  inEonForShelleyBasedEra no yes era
 
 inShelleyBasedEraEonMaybe :: ()
   => Eon eon

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -18,7 +18,7 @@ module Cardano.Api.Eon.ShelleyBasedEra
   , inEonForShelleyBasedEra
   , inShelleyBasedEraEon
   , inShelleyBasedEraEonMaybe
-  , maybeEonInShelleyBasedEra
+  , forShelleyBasedEraMaybeEon
 
     -- * Cardano eras, as Byron vs Shelley-based
   , CardanoEraStyle(..)
@@ -54,11 +54,11 @@ inEonForShelleyBasedEra :: ()
 inEonForShelleyBasedEra no yes =
   inEonForEra no yes . shelleyBasedToCardanoEra
 
-maybeEonInShelleyBasedEra :: ()
+forShelleyBasedEraMaybeEon :: ()
   => Eon eon
   => ShelleyBasedEra era
   -> Maybe (eon era)
-maybeEonInShelleyBasedEra =
+forShelleyBasedEraMaybeEon =
   inEonForEra Nothing Just . shelleyBasedToCardanoEra
 
 inShelleyBasedEraEon :: ()

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -23,6 +23,8 @@ module Cardano.Api.Eras
     -- * IsEon
   , Eon(..)
   , AnyEraInEon(..)
+
+  , inEonForEraMaybe
   , forEraInEon
   , forEraInEonMaybe
   , forEraMaybeEon

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -24,7 +24,7 @@ module Cardano.Api.Eras
   , Eon(..)
   , AnyEraInEon(..)
   , forEraInEon
-  , inEraEonMaybe
+  , forEraInEonMaybe
   , maybeEonInEra
 
     -- * Data family instances

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -25,7 +25,7 @@ module Cardano.Api.Eras
   , AnyEraInEon(..)
   , forEraInEon
   , forEraInEonMaybe
-  , maybeEonInEra
+  , forEraMaybeEon
 
     -- * Data family instances
   , AsType(AsByronEra, AsShelleyEra, AsAllegraEra, AsMaryEra, AsAlonzoEra, AsBabbageEra, AsConwayEra)

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -31,6 +31,7 @@ module Cardano.Api.Eras.Core
     -- * IsEon
   , Eon(..)
   , AnyEraInEon(..)
+  , inEonForEraMaybe
   , forEraInEon
   , forEraInEonMaybe
   , forEraMaybeEon
@@ -115,6 +116,14 @@ class Eon (eon :: Type -> Type) where
     -> (eon era -> a) -- ^ Function to get the value to use if the eon includes the era
     -> CardanoEra era -- ^ Era to check
     -> a              -- ^ The value to use
+
+inEonForEraMaybe :: ()
+  => Eon eon
+  => (eon era -> a)   -- ^ Function to get the value to use if the eon includes the era
+  -> CardanoEra era   -- ^ Era to check
+  -> Maybe a          -- ^ The value to use
+inEonForEraMaybe yes =
+  inEonForEra Nothing (Just . yes)
 
 forEraInEon :: ()
   => Eon eon

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -33,7 +33,7 @@ module Cardano.Api.Eras.Core
   , AnyEraInEon(..)
   , forEraInEon
   , forEraInEonMaybe
-  , maybeEonInEra
+  , forEraMaybeEon
 
     -- * Data family instances
   , AsType(AsByronEra, AsShelleyEra, AsAllegraEra, AsMaryEra, AsAlonzoEra, AsBabbageEra, AsConwayEra)
@@ -133,11 +133,11 @@ forEraInEonMaybe :: ()
 forEraInEonMaybe era yes =
   forEraInEon era Nothing (Just . yes)
 
-maybeEonInEra :: ()
+forEraMaybeEon :: ()
   => Eon eon
   => CardanoEra era   -- ^ Era to check
   -> Maybe (eon era)  -- ^ The eon if supported in the era
-maybeEonInEra =
+forEraMaybeEon =
   inEonForEra Nothing Just
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -32,7 +32,7 @@ module Cardano.Api.Eras.Core
   , Eon(..)
   , AnyEraInEon(..)
   , forEraInEon
-  , inEraEonMaybe
+  , forEraInEonMaybe
   , maybeEonInEra
 
     -- * Data family instances
@@ -125,12 +125,12 @@ forEraInEon :: ()
 forEraInEon era no yes =
   inEonForEra no yes era
 
-inEraEonMaybe :: ()
+forEraInEonMaybe :: ()
   => Eon eon
   => CardanoEra era   -- ^ Era to check
   -> (eon era -> a)   -- ^ Function to get the value to use if the eon includes the era
   -> Maybe a          -- ^ The value to use
-inEraEonMaybe era yes =
+forEraInEonMaybe era yes =
   forEraInEon era Nothing (Just . yes)
 
 maybeEonInEra :: ()

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -313,7 +313,7 @@ txScriptValidityToScriptValidity (TxScriptValidity _ scriptValidity) = scriptVal
 
 scriptValidityToTxScriptValidity :: ShelleyBasedEra era -> ScriptValidity -> TxScriptValidity era
 scriptValidityToTxScriptValidity sbe scriptValidity =
-  inShelleyBasedEraEon sbe TxScriptValidityNone $ \w -> TxScriptValidity w scriptValidity
+  forShelleyBasedEraInEon sbe TxScriptValidityNone $ \w -> TxScriptValidity w scriptValidity
 
 txScriptValidityToIsValid :: TxScriptValidity era -> L.IsValid
 txScriptValidityToIsValid = scriptValidityToIsValid . txScriptValidityToScriptValidity
@@ -1779,7 +1779,7 @@ deserialiseShelleyBasedTxBody sbe bs =
               (flip CBOR.runAnnotator fbs (return TxScriptValidityNone))
         4 -> do
           sValiditySupported <-
-            inShelleyBasedEraEon sbe
+            forShelleyBasedEraInEon sbe
               ( fail $ mconcat
                   [ "deserialiseShelleyBasedTxBody: Expected an era that supports the "
                   , "script validity flag but got: "
@@ -1811,7 +1811,7 @@ deserialiseShelleyBasedTxBody sbe bs =
               pure
 
           sValiditySupported <-
-            inShelleyBasedEraEon sbe
+            forShelleyBasedEraInEon sbe
               ( fail $ mconcat
                   [ "deserialiseShelleyBasedTxBody: Expected an era that supports the "
                   , "script validity flag but got: "

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -2306,7 +2306,7 @@ fromLedgerProposalProcedures
   -> Ledger.TxBody (ShelleyLedgerEra era)
   -> Maybe (Featured ConwayEraOnwards era [Proposal era])
 fromLedgerProposalProcedures sbe body =
-  inShelleyBasedEraEonMaybe sbe $ \w ->
+  forShelleyBasedEraInEonMaybe sbe $ \w ->
     conwayEraOnwardsConstraints w
       $ Featured w
       $ fmap Proposal
@@ -2318,7 +2318,7 @@ fromLedgerVotingProcedures :: ()
   -> Ledger.TxBody (ShelleyLedgerEra era)
   -> Maybe (Featured ConwayEraOnwards era (VotingProcedures era))
 fromLedgerVotingProcedures sbe body =
-  inShelleyBasedEraEonMaybe sbe $ \w ->
+  forShelleyBasedEraInEonMaybe sbe $ \w ->
     conwayEraOnwardsConstraints w
       $ Featured w
       $ VotingProcedures

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -36,7 +36,7 @@ module Cardano.Api (
 
     inEonForShelleyBasedEra,
     forShelleyBasedEraInEon,
-    inShelleyBasedEraEonMaybe,
+    forShelleyBasedEraInEonMaybe,
     forShelleyBasedEraMaybeEon,
 
     Featured(..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -35,7 +35,7 @@ module Cardano.Api (
     forEraMaybeEon,
 
     inEonForShelleyBasedEra,
-    inShelleyBasedEraEon,
+    forShelleyBasedEraInEon,
     inShelleyBasedEraEonMaybe,
     forShelleyBasedEraMaybeEon,
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -30,6 +30,8 @@ module Cardano.Api (
     -- * Eon support
     Eon(..),
     AnyEraInEon(..),
+
+    inEonForEraMaybe,
     forEraInEon,
     forEraInEonMaybe,
     forEraMaybeEon,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -27,12 +27,12 @@ module Cardano.Api (
     InAnyCardanoEra(..),
     ToCardanoEra(..),
 
-    -- * Feature support
+    -- * Eon support
     Eon(..),
     AnyEraInEon(..),
     forEraInEon,
     forEraInEonMaybe,
-    maybeEonInEra,
+    forEraMaybeEon,
 
     eonInShelleyBasedEra,
     inShelleyBasedEraEon,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -31,7 +31,7 @@ module Cardano.Api (
     Eon(..),
     AnyEraInEon(..),
     forEraInEon,
-    inEraEonMaybe,
+    forEraInEonMaybe,
     maybeEonInEra,
 
     eonInShelleyBasedEra,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -34,7 +34,7 @@ module Cardano.Api (
     forEraInEonMaybe,
     forEraMaybeEon,
 
-    eonInShelleyBasedEra,
+    inEonForShelleyBasedEra,
     inShelleyBasedEraEon,
     inShelleyBasedEraEonMaybe,
     maybeEonInShelleyBasedEra,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -37,7 +37,7 @@ module Cardano.Api (
     inEonForShelleyBasedEra,
     inShelleyBasedEraEon,
     inShelleyBasedEraEonMaybe,
-    maybeEonInShelleyBasedEra,
+    forShelleyBasedEraMaybeEon,
 
     Featured(..),
     asFeaturedInEra,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -35,6 +35,7 @@ module Cardano.Api (
     forEraMaybeEon,
 
     inEonForShelleyBasedEra,
+    inEonForShelleyBasedEraMaybe,
     forShelleyBasedEraInEon,
     forShelleyBasedEraInEonMaybe,
     forShelleyBasedEraMaybeEon,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    - Rename `inShelleyBasedEraEonMaybe` to `forShelleyBasedEraInEonMaybe`
    - Rename `inShelleyBasedEraEon` to `forShelleyBasedEraInEon`
    - Rename `maybeEonInShelleyBasedEra` to `forShelleyBasedEraMaybeEon`
    - Rename `eonInShelleyBasedEra` to `inEonForShelleyBasedEra`
    - Rename `maybeEonInEra` to `forEraMaybeEon`
    - Rename `inEraEonMaybe` to `forEraInEonMaybe`
    - New `inEonForEraMaybe` function
    - New `inEonForShelleyBasedEraMaybe` function
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The function names are composed on smaller positional components:

* `forEra` - corresponds to `CardanoEra era`
* `forShelleyBasedEra` - corresponds to `ShelleyBasedEra era`
* `inEon` - corresponds to `a` and `eon era -> a` if not coupled with `maybe` otherwise corresponds to just `eon era -> a`
* `maybe - corresponds to `Maybe a`
* `maybeEon` - corresponds to `Maybe (eon era)`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
