### PR TITLE
New `caseAlonzoOnlyOrBabbageEraOnwards` and `alonzoEraOnlyToAlonzoEraOnwards` functions

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -19,14 +19,20 @@ module Cardano.Api.Eras.Case
   , caseShelleyToAlonzoOrBabbageEraOnwards
   , caseShelleyToBabbageOrConwayEraOnwards
 
+    -- Case on AlonzoEraOnwards
+  , caseAlonzoOnlyOrBabbageEraOnwards
+
+    -- Proofs
   , noByronEraInShelleyBasedEra
 
     -- Conversions
   , shelleyToAllegraEraToByronToAllegraEra
+  , alonzoEraOnlyToAlonzoEraOnwards
   , alonzoEraOnwardsToMaryEraOnwards
   ) where
 
 import           Cardano.Api.Eon.AllegraEraOnwards
+import           Cardano.Api.Eon.AlonzoEraOnly
 import           Cardano.Api.Eon.AlonzoEraOnwards
 import           Cardano.Api.Eon.BabbageEraOnwards
 import           Cardano.Api.Eon.ByronAndAllegraEraOnwards
@@ -180,6 +186,16 @@ caseShelleyToBabbageOrConwayEraOnwards l r = \case
   ShelleyBasedEraBabbage -> l ShelleyToBabbageEraBabbage
   ShelleyBasedEraConway  -> r ConwayEraOnwardsConway
 
+caseAlonzoOnlyOrBabbageEraOnwards :: ()
+  => (AlonzoEraOnly era -> a)
+  -> (BabbageEraOnwards era -> a)
+  -> AlonzoEraOnwards era
+  -> a
+caseAlonzoOnlyOrBabbageEraOnwards l r = \case
+  AlonzoEraOnwardsAlonzo -> l AlonzoEraOnlyAlonzo
+  AlonzoEraOnwardsBabbage -> r BabbageEraOnwardsBabbage
+  AlonzoEraOnwardsConway  -> r BabbageEraOnwardsConway
+
 noByronEraInShelleyBasedEra :: ShelleyBasedEra era -> ByronEraOnly era -> a
 noByronEraInShelleyBasedEra sbe ByronEraOnlyByron = case sbe of {}
 
@@ -195,3 +211,9 @@ alonzoEraOnwardsToMaryEraOnwards = \case
   AlonzoEraOnwardsAlonzo  -> MaryEraOnwardsAlonzo
   AlonzoEraOnwardsBabbage -> MaryEraOnwardsBabbage
   AlonzoEraOnwardsConway  -> MaryEraOnwardsConway
+
+alonzoEraOnlyToAlonzoEraOnwards :: ()
+  => AlonzoEraOnly era
+  -> AlonzoEraOnwards era
+alonzoEraOnlyToAlonzoEraOnwards = \case
+  AlonzoEraOnlyAlonzo -> AlonzoEraOnwardsAlonzo

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -155,9 +155,13 @@ module Cardano.Api (
     caseShelleyToMaryOrAlonzoEraOnwards,
     caseShelleyToAlonzoOrBabbageEraOnwards,
     caseShelleyToBabbageOrConwayEraOnwards,
+    caseAlonzoOnlyOrBabbageEraOnwards,
 
     -- ** Eon relaxation
     shelleyToAllegraEraToByronToAllegraEra,
+    alonzoEraOnlyToAlonzoEraOnwards,
+
+    -- Case on AlonzoEraOnwards
     alonzoEraOnwardsToMaryEraOnwards,
 
     -- * Assertions on era


### PR DESCRIPTION


# Changelog

```yaml
- description: |
    New `caseAlonzoOnlyOrBabbageEraOnwards` and `alonzoEraOnlyToAlonzoEraOnwards` functions
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
