### PR TITLE
Rename `AnyEraInEon` to `EraInEon`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -23,7 +23,7 @@ module Cardano.Api.Eras
     -- * IsEon
   , Eon(..)
   , AnyEon(..)
-  , AnyEraInEon(..)
+  , EraInEon(..)
 
   , inEonForEraMaybe
   , forEraInEon

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -22,7 +22,6 @@ module Cardano.Api.Eras
 
     -- * IsEon
   , Eon(..)
-  , AnyEon(..)
   , EraInEon(..)
 
   , inEonForEraMaybe

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -31,7 +31,7 @@ module Cardano.Api.Eras.Core
     -- * IsEon
   , Eon(..)
   , AnyEon(..)
-  , AnyEraInEon(..)
+  , EraInEon(..)
   , inEonForEraMaybe
   , forEraInEon
   , forEraInEonMaybe
@@ -163,21 +163,22 @@ maybeEon =
 -- ----------------------------------------------------------------------------
 -- Era and eon existential types
 
-data AnyEraInEon eon where
-  AnyEraInEon
+data EraInEon eon where
+  EraInEon
     :: ( Typeable era
        , Typeable (eon era)
-       , Eon eon )
+       , Eon eon
+       )
     => eon era
-    -> AnyEraInEon eon
+    -> EraInEon eon
 
 -- | Assumes that eons are singletons
-instance Show (AnyEraInEon eon) where
-  showsPrec _ (AnyEraInEon eonEra) = showsTypeRep (typeOf eonEra)
+instance Show (EraInEon eon) where
+  showsPrec _ (EraInEon eonEra) = showsTypeRep (typeOf eonEra)
 
 -- | Assumes that eons are singletons
-instance TestEquality eon => Eq (AnyEraInEon eon) where
-  AnyEraInEon era1 == AnyEraInEon era2 =
+instance TestEquality eon => Eq (EraInEon eon) where
+  EraInEon era1 == EraInEon era2 =
     isJust $ testEquality era1 era2
 
 data AnyEon where

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -30,7 +30,6 @@ module Cardano.Api.Eras.Core
 
     -- * IsEon
   , Eon(..)
-  , AnyEon(..)
   , EraInEon(..)
   , inEonForEraMaybe
   , forEraInEon
@@ -180,21 +179,6 @@ instance Show (EraInEon eon) where
 instance TestEquality eon => Eq (EraInEon eon) where
   EraInEon era1 == EraInEon era2 =
     isJust $ testEquality era1 era2
-
-data AnyEon where
-  AnyEon
-    :: ( Typeable era
-       , Typeable (eon era)
-       , ToCardanoEra eon
-       , IsCardanoEra era
-       , Eon eon )
-    => eon era
-    -> AnyEon
-
--- | Assumes that eons are singletons
-instance Show AnyEon where
-  showsPrec _ (AnyEon eonEra) = showsTypeRep (typeOf eonEra)
-
 
 -- ----------------------------------------------------------------------------
 -- ToCardanoEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -30,7 +30,7 @@ module Cardano.Api (
     -- * Eon support
     Eon(..),
     AnyEon(..),
-    AnyEraInEon(..),
+    EraInEon(..),
 
     inEonForEraMaybe,
     forEraInEon,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -29,7 +29,6 @@ module Cardano.Api (
 
     -- * Eon support
     Eon(..),
-    AnyEon(..),
     EraInEon(..),
 
     inEonForEraMaybe,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Rename `AnyEraInEon` to `EraInEon`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This simplifies the type name.  The `Any` prefix is not needed to understand what the type does.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
