### PR TITLE
Delete `withShelleyBasedEraConstraintsForLedger`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -33,8 +33,6 @@ module Cardano.Api.Eras
     -- * Data family instances
   , AsType(AsByronEra, AsShelleyEra, AsAllegraEra, AsMaryEra, AsAlonzoEra, AsBabbageEra, AsConwayEra)
 
-  , withShelleyBasedEraConstraintsForLedger
-
     -- * Era case handling
 
     -- ** Case on CardanoEra

--- a/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Api.Eras.Constraints
   ( cardanoEraConstraints
-  , withShelleyBasedEraConstraintsForLedger
   , shelleyBasedEraConstraints
 
   , CardanoEraConstraints
@@ -21,7 +20,6 @@ import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
 import           Cardano.Api.Orphans ()
-import           Cardano.Api.Query.Types
 
 import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
 import qualified Cardano.Crypto.Hash.Class as C
@@ -72,11 +70,9 @@ type ShelleyBasedEraConstraints era =
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
-  , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
-  , ToJSON (DebugLedgerState era)
   , Typeable era
   )
 
@@ -91,10 +87,3 @@ shelleyBasedEraConstraints = \case
   ShelleyBasedEraAlonzo  -> id
   ShelleyBasedEraBabbage -> id
   ShelleyBasedEraConway  -> id
-
--- Deprecated: Use shelleyBasedEraConstraints instead.
-withShelleyBasedEraConstraintsForLedger :: ()
-  => ShelleyBasedEra era
-  -> (ShelleyBasedEraConstraints era => a)
-  -> a
-withShelleyBasedEraConstraintsForLedger = shelleyBasedEraConstraints

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -14,7 +14,6 @@ module Cardano.Api.Governance.Actions.ProposalProcedure where
 
 import           Cardano.Api.Address
 import           Cardano.Api.Eon.ShelleyBasedEra
-import           Cardano.Api.Eras
 import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley
@@ -133,21 +132,21 @@ newtype Proposal era = Proposal { unProposal :: Gov.ProposalProcedure (ShelleyLe
 
 instance IsShelleyBasedEra era => Show (Proposal era) where
   show (Proposal pp) = do
-    let ppStr = withShelleyBasedEraConstraintsForLedger (shelleyBasedEra @era) $ show pp
+    let ppStr = shelleyBasedEraConstraints (shelleyBasedEra @era) $ show pp
     "Proposal {unProposal = " <> ppStr <> "}"
 
 instance IsShelleyBasedEra era => Eq (Proposal era) where
-  (Proposal pp1) == (Proposal pp2) = withShelleyBasedEraConstraintsForLedger (shelleyBasedEra @era) $ pp1 == pp2
+  (Proposal pp1) == (Proposal pp2) = shelleyBasedEraConstraints (shelleyBasedEra @era) $ pp1 == pp2
 
 instance IsShelleyBasedEra era => ToCBOR (Proposal era) where
-  toCBOR (Proposal vp) = withShelleyBasedEraConstraintsForLedger (shelleyBasedEra @era) $ Shelley.toEraCBOR @Conway.Conway vp
+  toCBOR (Proposal vp) = shelleyBasedEraConstraints (shelleyBasedEra @era) $ Shelley.toEraCBOR @Conway.Conway vp
 
 instance IsShelleyBasedEra era => FromCBOR (Proposal era) where
-  fromCBOR = Proposal <$> withShelleyBasedEraConstraintsForLedger (shelleyBasedEra @era) (Shelley.fromEraCBOR @Conway.Conway)
+  fromCBOR = Proposal <$> shelleyBasedEraConstraints (shelleyBasedEra @era) (Shelley.fromEraCBOR @Conway.Conway)
 
 instance IsShelleyBasedEra era => SerialiseAsCBOR (Proposal era) where
-  serialiseToCBOR = withShelleyBasedEraConstraintsForLedger (shelleyBasedEra @era) CBOR.serialize'
-  deserialiseFromCBOR _proxy = withShelleyBasedEraConstraintsForLedger (shelleyBasedEra @era) CBOR.decodeFull'
+  serialiseToCBOR = shelleyBasedEraConstraints (shelleyBasedEra @era) CBOR.serialize'
+  deserialiseFromCBOR _proxy = shelleyBasedEraConstraints (shelleyBasedEra @era) CBOR.decodeFull'
 
 instance IsShelleyBasedEra era => HasTextEnvelope (Proposal era) where
   textEnvelopeType _ = "Governance proposal"

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -1502,7 +1502,7 @@ nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (Vr
                                 decodeCurrentEpochState sbe serCurrEpochState
 
   let snapshot :: ShelleyAPI.SnapShot Shelley.StandardCrypto
-      snapshot = ShelleyAPI.ssStakeMark $ withShelleyBasedEraConstraintsForLedger sbe $ ShelleyAPI.esSnapshots cEstate
+      snapshot = ShelleyAPI.ssStakeMark $ shelleyBasedEraConstraints sbe $ ShelleyAPI.esSnapshots cEstate
       markSnapshotPoolDistr :: Map (SL.KeyHash 'SL.StakePool Shelley.StandardCrypto) (SL.IndividualPoolStake Shelley.StandardCrypto)
       markSnapshotPoolDistr = ShelleyAPI.unPoolDistr . ShelleyAPI.calculatePoolDistr $ snapshot
 

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -1806,7 +1806,7 @@ getTxId (ByronTxBody tx) =
       error "getTxId: byron and shelley hash sizes do not match"
 
 getTxId (ShelleyTxBody sbe tx _ _ _ _) =
-  withShelleyBasedEraConstraintsForLedger sbe $ getTxIdShelley sbe tx
+  shelleyBasedEraConstraints sbe $ getTxIdShelley sbe tx
 
 getTxIdShelley
   :: Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
@@ -1993,7 +1993,7 @@ createTransactionBody sbe txBodyContent =
           case sData of
             TxBodyNoScriptData -> pure SNothing
             TxBodyScriptData _sDataSupported datums redeemers ->
-              withShelleyBasedEraConstraintsForLedger sbe
+              shelleyBasedEraConstraints sbe
                 $ convPParamsToScriptIntegrityHash
                     sbe
                     apiProtocolParameters
@@ -2027,7 +2027,7 @@ createTransactionBody sbe txBodyContent =
           case sData of
             TxBodyNoScriptData -> pure SNothing
             TxBodyScriptData _sDataSupported datums redeemers ->
-              withShelleyBasedEraConstraintsForLedger sbe
+              shelleyBasedEraConstraints sbe
                 $ convPParamsToScriptIntegrityHash
                     sbe
                     apiProtocolParameters
@@ -2729,7 +2729,7 @@ convReturnCollateral
 convReturnCollateral sbe txReturnCollateral =
   case txReturnCollateral of
     TxReturnCollateralNone -> SNothing
-    TxReturnCollateral _ colTxOut -> SJust $ withShelleyBasedEraConstraintsForLedger sbe $ toShelleyTxOutAny sbe colTxOut
+    TxReturnCollateral _ colTxOut -> SJust $ shelleyBasedEraConstraints sbe $ toShelleyTxOutAny sbe colTxOut
 
 convTotalCollateral :: TxTotalCollateral era -> StrictMaybe Ledger.Coin
 convTotalCollateral txTotalCollateral =

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -106,7 +106,6 @@ module Cardano.Api (
     cardanoEraStyle,
     shelleyBasedToCardanoEra,
     shelleyBasedEraConstraints,
-    withShelleyBasedEraConstraintsForLedger,
 
     -- ** From Allegra
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `withShelleyBasedEraConstraintsForLedger`. Use `shelleyBasedEraConstraints` instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`withShelleyBasedEraConstraintsForLedger` only delegated to `shelleyBasedEraConstraints` anyway.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
