### PR TITLE
Reduce constraint usage with eons

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnly.hs
@@ -29,6 +29,7 @@ import qualified Cardano.Crypto.VRF as C
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.Mary.Value as L
 import qualified Cardano.Ledger.SafeHash as L
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
@@ -80,6 +81,7 @@ type AlonzoEraOnlyConstraints era =
   , L.ProtVerAtMost (ShelleyLedgerEra era) 8
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
@@ -35,6 +35,7 @@ import qualified Cardano.Ledger.Alonzo.UTxO as L
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.Mary.Value as L
 import qualified Cardano.Ledger.SafeHash as L
 import qualified Cardano.Ledger.UTxO as L
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
@@ -93,6 +94,7 @@ type AlonzoEraOnwardsConstraints era =
   , L.ScriptsNeeded (ShelleyLedgerEra era) ~ L.AlonzoScriptsNeeded (ShelleyLedgerEra era)
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
@@ -33,6 +33,7 @@ import qualified Cardano.Ledger.Alonzo.UTxO as L
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.Mary.Value as L
 import qualified Cardano.Ledger.SafeHash as L
 import qualified Cardano.Ledger.UTxO as L
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
@@ -87,6 +88,7 @@ type BabbageEraOnwardsConstraints era =
   , L.ScriptsNeeded (ShelleyLedgerEra era) ~ L.AlonzoScriptsNeeded (ShelleyLedgerEra era)
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -36,6 +36,7 @@ import qualified Cardano.Ledger.Conway.Core as L
 import qualified Cardano.Ledger.Conway.Governance as L
 import qualified Cardano.Ledger.Conway.PParams as L
 import qualified Cardano.Ledger.Conway.TxCert as L
+import qualified Cardano.Ledger.Mary.Value as L
 import qualified Cardano.Ledger.SafeHash as L
 import qualified Cardano.Ledger.UTxO as L
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
@@ -92,6 +93,7 @@ type ConwayEraOnwardsConstraints era =
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
   , L.TxCert (ShelleyLedgerEra era) ~ L.ConwayTxCert (ShelleyLedgerEra era)
+  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
@@ -31,6 +31,7 @@ import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Core as L
 import qualified Cardano.Ledger.Mary.Value as L
 import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.UTxO as L
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
 import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
@@ -76,6 +77,7 @@ type MaryEraOnwardsConstraints era =
   , L.EraPParams (ShelleyLedgerEra era)
   , L.EraTx (ShelleyLedgerEra era)
   , L.EraTxBody (ShelleyLedgerEra era)
+  , L.EraUTxO (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
   , L.MaryEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
@@ -32,6 +32,7 @@ import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Core as L
 import qualified Cardano.Ledger.SafeHash as L
 import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Cardano.Ledger.UTxO as L
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
 import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
@@ -73,6 +74,7 @@ type ShelleyToAllegraEraConstraints era =
   , L.EraPParams (ShelleyLedgerEra era)
   , L.EraTx (ShelleyLedgerEra era)
   , L.EraTxBody (ShelleyLedgerEra era)
+  , L.EraUTxO (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
   , L.ProtVerAtMost (ShelleyLedgerEra era) 4
   , L.ProtVerAtMost (ShelleyLedgerEra era) 6

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -29,6 +29,8 @@ module Cardano.Api.Eras.Case
   , shelleyToAllegraEraToByronToAllegraEra
   , alonzoEraOnlyToAlonzoEraOnwards
   , alonzoEraOnwardsToMaryEraOnwards
+  , babbageEraOnwardsToMaryEraOnwards
+  , babbageEraOnwardsToAlonzoEraOnwards
   ) where
 
 import           Cardano.Api.Eon.AllegraEraOnwards
@@ -217,3 +219,17 @@ alonzoEraOnlyToAlonzoEraOnwards :: ()
   -> AlonzoEraOnwards era
 alonzoEraOnlyToAlonzoEraOnwards = \case
   AlonzoEraOnlyAlonzo -> AlonzoEraOnwardsAlonzo
+
+babbageEraOnwardsToMaryEraOnwards :: ()
+  => BabbageEraOnwards era
+  -> MaryEraOnwards era
+babbageEraOnwardsToMaryEraOnwards = \case
+  BabbageEraOnwardsBabbage -> MaryEraOnwardsBabbage
+  BabbageEraOnwardsConway  -> MaryEraOnwardsConway
+
+babbageEraOnwardsToAlonzoEraOnwards :: ()
+  => BabbageEraOnwards era
+  -> AlonzoEraOnwards era
+babbageEraOnwardsToAlonzoEraOnwards = \case
+  BabbageEraOnwardsBabbage  -> AlonzoEraOnwardsBabbage
+  BabbageEraOnwardsConway   -> AlonzoEraOnwardsConway

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -1588,22 +1588,17 @@ instance IsCardanoEra era => SerialiseAsCBOR (TxBody era) where
         serialiseShelleyBasedTxBody sbe txbody txscripts redeemers txmetadata scriptValidity
 
     deserialiseFromCBOR _ bs =
-      case cardanoEra :: CardanoEra era of
-        ByronEra ->
+      caseByronOrShelleyBasedEra
+        (\ByronEraOnlyByron ->
           ByronTxBody <$>
             CBOR.decodeFullAnnotatedBytes
               CBOR.byronProtVer
               "Byron TxBody"
               CBOR.decCBORAnnotated
               (LBS.fromStrict bs)
-
-        -- Use the same deserialisation impl, but at different types:
-        ShelleyEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraShelley bs
-        AllegraEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraAllegra bs
-        MaryEra    -> deserialiseShelleyBasedTxBody ShelleyBasedEraMary    bs
-        AlonzoEra  -> deserialiseShelleyBasedTxBody ShelleyBasedEraAlonzo  bs
-        BabbageEra -> deserialiseShelleyBasedTxBody ShelleyBasedEraBabbage bs
-        ConwayEra  -> deserialiseShelleyBasedTxBody ShelleyBasedEraConway  bs
+        )
+        (\sbe -> deserialiseShelleyBasedTxBody sbe bs)
+        (cardanoEra :: CardanoEra era)
 
 -- | The serialisation format for the different Shelley-based eras are not the
 -- same, but they can be handled generally with one overloaded implementation.

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -1881,10 +1881,11 @@ createTransactionBody sbe txBodyContent =
             ttl = case upperBound of
                     TxValidityNoUpperBound sbe' -> case sbe' of {}
                     TxValidityUpperBound _ ttl'  -> ttl'
-            ledgerTxBody = mkTxBody ShelleyBasedEraShelley txBodyContent txAuxData
-                           & L.certsTxBodyL  .~ certs
-                           & L.ttlTxBodyL    .~ ttl
-                           & L.updateTxBodyL .~ update
+            ledgerTxBody =
+              mkTxBody ShelleyBasedEraShelley txBodyContent txAuxData
+                & L.certsTxBodyL  .~ certs
+                & L.ttlTxBodyL    .~ ttl
+                & L.updateTxBodyL .~ update
 
             sData = convScriptData sbe apiTxOuts apiScriptWitnesses
 
@@ -1897,10 +1898,11 @@ createTransactionBody sbe txBodyContent =
 
        ShelleyBasedEraAllegra -> do
         update <- convTxUpdateProposal sbe (txUpdateProposal txBodyContent)
-        let ledgerTxBody = mkTxBody ShelleyBasedEraAllegra txBodyContent txAuxData
-                           & L.certsTxBodyL  .~ certs
-                           & L.updateTxBodyL .~ update
-                           & L.vldtTxBodyL   .~ validityInterval
+        let ledgerTxBody =
+              mkTxBody ShelleyBasedEraAllegra txBodyContent txAuxData
+                & L.certsTxBodyL  .~ certs
+                & L.updateTxBodyL .~ update
+                & L.vldtTxBodyL   .~ validityInterval
         pure $ ShelleyTxBody sbe
               ledgerTxBody
               scripts
@@ -1910,11 +1912,12 @@ createTransactionBody sbe txBodyContent =
 
        ShelleyBasedEraMary -> do
         update <- convTxUpdateProposal sbe (txUpdateProposal txBodyContent)
-        let ledgerTxBody = mkTxBody ShelleyBasedEraMary txBodyContent txAuxData
-                           & L.certsTxBodyL  .~ certs
-                           & L.updateTxBodyL .~ update
-                           & L.vldtTxBodyL   .~ validityInterval
-                           & L.mintTxBodyL   .~ convMintValue apiMintValue
+        let ledgerTxBody =
+              mkTxBody ShelleyBasedEraMary txBodyContent txAuxData
+                & L.certsTxBodyL  .~ certs
+                & L.updateTxBodyL .~ update
+                & L.vldtTxBodyL   .~ validityInterval
+                & L.mintTxBodyL   .~ convMintValue apiMintValue
         pure $ ShelleyTxBody sbe
               ledgerTxBody
               scripts
@@ -1930,22 +1933,22 @@ createTransactionBody sbe txBodyContent =
             TxBodyNoScriptData -> pure SNothing
             TxBodyScriptData _ datums redeemers ->
               convPParamsToScriptIntegrityHash
-                sbe
+                AlonzoEraOnwardsAlonzo
                 apiProtocolParameters
                 redeemers
                 datums
                 languages
-        let ledgerTxBody = mkTxBody ShelleyBasedEraAlonzo txBodyContent txAuxData
-                           & L.certsTxBodyL               .~ certs
-                           & L.updateTxBodyL              .~ update
-                           & L.vldtTxBodyL                .~ validityInterval
-                           & L.collateralInputsTxBodyL    .~ collTxIns
-                           & L.reqSignerHashesTxBodyL     .~ convExtraKeyWitnesses
-                                                               apiExtraKeyWitnesses
-                           & L.mintTxBodyL                .~ convMintValue apiMintValue
-                           & L.scriptIntegrityHashTxBodyL .~ scriptIntegrityHash
-                           -- TODO: NetworkId for hardware wallets. We don't always want this
-                           -- & L.networkIdTxBodyL .~ ...
+        let ledgerTxBody =
+              mkTxBody ShelleyBasedEraAlonzo txBodyContent txAuxData
+                & L.certsTxBodyL               .~ certs
+                & L.updateTxBodyL              .~ update
+                & L.vldtTxBodyL                .~ validityInterval
+                & L.collateralInputsTxBodyL    .~ collTxIns
+                & L.reqSignerHashesTxBodyL     .~ convExtraKeyWitnesses apiExtraKeyWitnesses
+                & L.mintTxBodyL                .~ convMintValue apiMintValue
+                & L.scriptIntegrityHashTxBodyL .~ scriptIntegrityHash
+                -- TODO: NetworkId for hardware wallets. We don't always want this
+                -- & L.networkIdTxBodyL .~ ...
         pure $ ShelleyTxBody sbe
               ledgerTxBody
               scripts
@@ -1960,27 +1963,26 @@ createTransactionBody sbe txBodyContent =
           case sData of
             TxBodyNoScriptData -> pure SNothing
             TxBodyScriptData _sDataSupported datums redeemers ->
-              shelleyBasedEraConstraints sbe
-                $ convPParamsToScriptIntegrityHash
-                    sbe
-                    apiProtocolParameters
-                    redeemers
-                    datums
-                    languages
-        let ledgerTxBody = mkTxBody ShelleyBasedEraBabbage txBodyContent txAuxData
-                           & L.certsTxBodyL               .~ certs
-                           & L.updateTxBodyL              .~ update
-                           & L.vldtTxBodyL                .~ validityInterval
-                           & L.collateralInputsTxBodyL    .~ collTxIns
-                           & L.reqSignerHashesTxBodyL     .~ convExtraKeyWitnesses
-                                                               apiExtraKeyWitnesses
-                           & L.mintTxBodyL                .~ convMintValue apiMintValue
-                           & L.scriptIntegrityHashTxBodyL .~ scriptIntegrityHash
-                           & L.referenceInputsTxBodyL     .~ refTxIns
-                           & L.collateralReturnTxBodyL    .~ returnCollateral
-                           & L.totalCollateralTxBodyL     .~ totalCollateral
-                           -- TODO: NetworkId for hardware wallets. We don't always want this
-                           -- & L.networkIdTxBodyL .~ ...
+              convPParamsToScriptIntegrityHash
+                AlonzoEraOnwardsBabbage
+                apiProtocolParameters
+                redeemers
+                datums
+                languages
+        let ledgerTxBody =
+              mkTxBody ShelleyBasedEraBabbage txBodyContent txAuxData
+                & L.certsTxBodyL               .~ certs
+                & L.updateTxBodyL              .~ update
+                & L.vldtTxBodyL                .~ validityInterval
+                & L.collateralInputsTxBodyL    .~ collTxIns
+                & L.reqSignerHashesTxBodyL     .~ convExtraKeyWitnesses apiExtraKeyWitnesses
+                & L.mintTxBodyL                .~ convMintValue apiMintValue
+                & L.scriptIntegrityHashTxBodyL .~ scriptIntegrityHash
+                & L.referenceInputsTxBodyL     .~ refTxIns
+                & L.collateralReturnTxBodyL    .~ returnCollateral
+                & L.totalCollateralTxBodyL     .~ totalCollateral
+                -- TODO: NetworkId for hardware wallets. We don't always want this
+                -- & L.networkIdTxBodyL .~ ...
         pure $ ShelleyTxBody sbe
               ledgerTxBody
               scripts
@@ -1996,7 +1998,7 @@ createTransactionBody sbe txBodyContent =
             TxBodyScriptData _sDataSupported datums redeemers ->
               shelleyBasedEraConstraints sbe
                 $ convPParamsToScriptIntegrityHash
-                    sbe
+                    AlonzoEraOnwardsConway
                     apiProtocolParameters
                     redeemers
                     datums
@@ -2006,8 +2008,7 @@ createTransactionBody sbe txBodyContent =
                 & L.certsTxBodyL               .~ certs
                 & L.vldtTxBodyL                .~ validityInterval
                 & L.collateralInputsTxBodyL    .~ collTxIns
-                & L.reqSignerHashesTxBodyL     .~ convExtraKeyWitnesses
-                                                    apiExtraKeyWitnesses
+                & L.reqSignerHashesTxBodyL     .~ convExtraKeyWitnesses apiExtraKeyWitnesses
                 & L.mintTxBodyL                .~ convMintValue apiMintValue
                 & L.scriptIntegrityHashTxBodyL .~ scriptIntegrityHash
                 & L.referenceInputsTxBodyL     .~ refTxIns
@@ -2806,41 +2807,18 @@ convScriptData sbe txOuts scriptWitnesses =
     sbe
 
 convPParamsToScriptIntegrityHash :: ()
-  => ShelleyBasedEra era
-  -> L.AlonzoEraPParams (ShelleyLedgerEra era)
-  => BuildTxWith BuildTx (Maybe (LedgerProtocolParameters era))
+  => AlonzoEraOnwards era
+  -> BuildTxWith BuildTx (Maybe (LedgerProtocolParameters era))
   -> Alonzo.Redeemers (ShelleyLedgerEra era)
   -> Alonzo.TxDats (ShelleyLedgerEra era)
   -> Set Alonzo.Language
   -> Either TxBodyError (StrictMaybe (L.ScriptIntegrityHash (Ledger.EraCrypto (ShelleyLedgerEra era))))
-convPParamsToScriptIntegrityHash sbe txProtocolParams redeemers datums languages = do
-  lang <- case txProtocolParams of
-               BuildTxWith Nothing -> return Nothing
-               BuildTxWith (Just (LedgerProtocolParameters pp)) ->
-                 case sbe of
-                   ShelleyBasedEraShelley ->
-                     return Nothing
-                   ShelleyBasedEraAllegra ->
-                     return Nothing
-                   ShelleyBasedEraMary ->
-                     return Nothing
-                   ShelleyBasedEraAlonzo ->
-                     return . Just $ L.getLanguageView pp
-                   ShelleyBasedEraBabbage ->
-                     return . Just $ L.getLanguageView pp
-                   ShelleyBasedEraConway ->
-                     return . Just $ L.getLanguageView pp
-
-  case lang of
-    Nothing -> return SNothing
-    Just l ->
-      pure $ Alonzo.hashScriptIntegrity
-        (Set.map
-           l
-           languages
-        )
-        redeemers
-        datums
+convPParamsToScriptIntegrityHash w txProtocolParams redeemers datums languages =
+  alonzoEraOnwardsConstraints w $
+    case txProtocolParams of
+      BuildTxWith Nothing -> return SNothing
+      BuildTxWith (Just (LedgerProtocolParameters pp)) ->
+        pure $ Alonzo.hashScriptIntegrity (Set.map (L.getLanguageView pp) languages ) redeemers datums
 
 convLanguages :: [(ScriptWitnessIndex, AnyScriptWitness era)] -> Set Alonzo.Language
 convLanguages witnesses =
@@ -3021,7 +2999,7 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraAlonzo
 
     validateTxBodyContent sbe txbodycontent
     update <- convTxUpdateProposal sbe txUpdateProposal
-    scriptIntegrityHash <- convPParamsToScriptIntegrityHash sbe txProtocolParams redeemers datums languages
+    scriptIntegrityHash <- convPParamsToScriptIntegrityHash AlonzoEraOnwardsAlonzo txProtocolParams redeemers datums languages
     return $
       ShelleyTxBody sbe
         (mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
@@ -3107,7 +3085,7 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraBabbage
 
     validateTxBodyContent sbe txbodycontent
     update <- convTxUpdateProposal sbe txUpdateProposal
-    scriptIntegrityHash <- convPParamsToScriptIntegrityHash sbe txProtocolParams redeemers datums languages
+    scriptIntegrityHash <- convPParamsToScriptIntegrityHash AlonzoEraOnwardsBabbage txProtocolParams redeemers datums languages
     return $
       ShelleyTxBody sbe
         (mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
@@ -3208,7 +3186,7 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraConway
                            } = do
 
     validateTxBodyContent sbe txbodycontent
-    scriptIntegrityHash <- convPParamsToScriptIntegrityHash sbe txProtocolParams redeemers datums languages
+    scriptIntegrityHash <- convPParamsToScriptIntegrityHash AlonzoEraOnwardsConway txProtocolParams redeemers datums languages
     return $
       ShelleyTxBody sbe
         (mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -2321,22 +2321,19 @@ fromLedgerTxOuts sbe body scriptdata =
     selectTxDatums  TxBodyNoScriptData                            = Map.empty
     selectTxDatums (TxBodyScriptData _ (Alonzo.TxDats' datums) _) = datums
 
-fromAlonzoTxOut :: forall era ledgerera.
-                   IsShelleyBasedEra era
-                => L.AlonzoEraTxOut ledgerera
-                => Ledger.EraCrypto ledgerera ~ StandardCrypto
-                => Ledger.Value ledgerera ~ MaryValue StandardCrypto
-                => MaryEraOnwards era
-                -> AlonzoEraOnwards era
-                -> Map (L.DataHash StandardCrypto)
-                       (L.Data ledgerera)
-                -> L.TxOut ledgerera
-                -> TxOut CtxTx era
+fromAlonzoTxOut :: ()
+  => MaryEraOnwards era
+  -> AlonzoEraOnwards era
+  -> Map (L.DataHash StandardCrypto) (L.Data ledgerera)
+  -> L.TxOut (ShelleyLedgerEra era)
+  -> TxOut CtxTx era
 fromAlonzoTxOut multiAssetInEra scriptDataInEra txdatums txOut =
-   TxOut (fromShelleyAddr shelleyBasedEra (txOut ^. L.addrTxOutL))
-         (TxOutValue multiAssetInEra (fromMaryValue (txOut ^. L.valueTxOutL)))
-         (fromAlonzoTxOutDatum scriptDataInEra (txOut ^. L.dataHashTxOutL))
-         ReferenceScriptNone
+  alonzoEraOnwardsConstraints scriptDataInEra $
+    TxOut
+      (fromShelleyAddr shelleyBasedEra (txOut ^. L.addrTxOutL))
+      (TxOutValue multiAssetInEra (fromMaryValue (txOut ^. L.valueTxOutL)))
+      (fromAlonzoTxOutDatum scriptDataInEra (txOut ^. L.dataHashTxOutL))
+      ReferenceScriptNone
   where
     fromAlonzoTxOutDatum :: AlonzoEraOnwards era
                          -> StrictMaybe (L.DataHash StandardCrypto)

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -1644,27 +1644,20 @@ serialiseShelleyBasedTxBody _ txbody txscripts
       , CBOR.encodeNullMaybe CBOR.encCBOR txmetadata
       ]
 
-deserialiseShelleyBasedTxBody
-  :: forall era ledgerera.
-     L.Era ledgerera
-  => ShelleyLedgerEra era ~ ledgerera
-  => CBOR.DecCBOR (CBOR.Annotator (Ledger.TxBody ledgerera))
-  => CBOR.DecCBOR (CBOR.Annotator (Ledger.Script ledgerera))
-  => CBOR.DecCBOR (CBOR.Annotator (Alonzo.TxDats ledgerera))
-  => CBOR.DecCBOR (CBOR.Annotator (Alonzo.Redeemers ledgerera))
-  => CBOR.DecCBOR (CBOR.Annotator (L.TxAuxData ledgerera))
+deserialiseShelleyBasedTxBody :: forall era. ()
   => ShelleyBasedEra era
   -> ByteString
   -> Either CBOR.DecoderError (TxBody era)
 deserialiseShelleyBasedTxBody sbe bs =
+  shelleyBasedEraConstraints sbe $
     CBOR.decodeFullAnnotator
-      (L.eraProtVerLow @ledgerera)
+      (L.eraProtVerLow @(ShelleyLedgerEra era))
       "Shelley TxBody"
       decodeAnnotatedTuple
       (LBS.fromStrict bs)
   where
     decodeAnnotatedTuple :: CBOR.Decoder s (CBOR.Annotator (TxBody era))
-    decodeAnnotatedTuple = do
+    decodeAnnotatedTuple = shelleyBasedEraConstraints sbe $ do
       len <- CBOR.decodeListLen
 
       case len of

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -1860,13 +1860,11 @@ createTransactionBody sbe txBodyContent =
       languages = convLanguages apiScriptWitnesses
 
       mkTxBody :: ()
-        => L.EraTxBody (ShelleyLedgerEra era)
-        => L.EraTxAuxData (ShelleyLedgerEra era)
         => ShelleyBasedEra era
         -> TxBodyContent BuildTx era
         -> Maybe (L.TxAuxData (ShelleyLedgerEra era))
         -> L.TxBody (ShelleyLedgerEra era)
-      mkTxBody sbe' bc = shelleyBasedEraConstraints sbe' $
+      mkTxBody sbe' bc =
         mkCommonTxBody
           sbe'
           (txIns bc)
@@ -2824,11 +2822,7 @@ guardShelleyTxInsOverflow txIns = do
 
 -- | A helper function that constructs a TxBody with all of the fields that are common for
 -- all eras
-mkCommonTxBody ::
-     ( L.EraTxBody (ShelleyLedgerEra era)
-     , L.EraTxAuxData (ShelleyLedgerEra era)
-     , L.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
-     )
+mkCommonTxBody :: ()
   => ShelleyBasedEra era
   -> TxIns BuildTx era
   -> [TxOut ctx era]
@@ -2837,12 +2831,13 @@ mkCommonTxBody ::
   -> Maybe (L.TxAuxData (ShelleyLedgerEra era))
   -> L.TxBody (ShelleyLedgerEra era)
 mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData =
-  L.mkBasicTxBody
-  & L.inputsTxBodyL .~ convTxIns txIns
-  & L.outputsTxBodyL .~ convTxOuts sbe txOuts
-  & L.feeTxBodyL .~ convTransactionFee sbe txFee
-  & L.withdrawalsTxBodyL .~ convWithdrawals txWithdrawals
-  & L.auxDataHashTxBodyL .~ maybe SNothing (SJust . Ledger.hashTxAuxData) txAuxData
+  shelleyBasedEraConstraints sbe $
+    L.mkBasicTxBody
+      & L.inputsTxBodyL .~ convTxIns txIns
+      & L.outputsTxBodyL .~ convTxOuts sbe txOuts
+      & L.feeTxBodyL .~ convTransactionFee sbe txFee
+      & L.withdrawalsTxBodyL .~ convWithdrawals txWithdrawals
+      & L.auxDataHashTxBodyL .~ maybe SNothing (SJust . Ledger.hashTxAuxData) txAuxData
 
 
 makeShelleyTransactionBody :: forall era. ()

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -159,12 +159,18 @@ module Cardano.Api (
 
     -- ** Eon relaxation
     shelleyToAllegraEraToByronToAllegraEra,
+
+    -- *** Case on AlonzoEraOnly
     alonzoEraOnlyToAlonzoEraOnwards,
 
-    -- Case on AlonzoEraOnwards
+    -- *** Case on AlonzoEraOnwards
     alonzoEraOnwardsToMaryEraOnwards,
 
-    -- * Assertions on era
+    -- *** Case on BabbageEraOnwards
+    babbageEraOnwardsToMaryEraOnwards,
+    babbageEraOnwardsToAlonzoEraOnwards,
+
+    -- *** Assertions on era
     requireShelleyBasedEra,
 
     -- ** IO


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Reduce constraint usage with eons
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

By using eons to summon constraints our functions can have fewer or no constraints in their type signatures which simplifies code here as well as later in `cardano-cli`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
