### PR TITLE
Move DRep reg certificate anchor types from cardano-cli to cardano-api

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -48,6 +48,7 @@ library internal
   -- to expose new functionality is via Cardano.Api or
   -- Cardano.Api.Shelley
   exposed-modules:      Cardano.Api.Address
+                        Cardano.Api.Anchor
                         Cardano.Api.Block
                         Cardano.Api.Certificate
                         Cardano.Api.Convenience.Construction

--- a/cardano-api/internal/Cardano/Api/Anchor.hs
+++ b/cardano-api/internal/Cardano/Api/Anchor.hs
@@ -1,0 +1,19 @@
+module Cardano.Api.Anchor (
+    AnchorUrl(..),
+    AnchorDataHash(..)
+  ) where
+
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Crypto as Crypto
+import qualified Cardano.Ledger.SafeHash as L
+
+
+-- | The URL to build the anchor to pass to DRep registration certificate
+newtype AnchorUrl = AnchorUrl
+  { unAnchorUrl :: L.Url
+  } deriving (Eq, Show)
+
+-- | The hash to build the anchor to pass to DRep registration certificate
+newtype AnchorDataHash = AnchorDataHash
+  { unAnchorDataHash :: L.SafeHash Crypto.StandardCrypto L.AnchorData
+  } deriving (Eq, Show)

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -999,6 +999,8 @@ module Cardano.Api (
     validateAndHashDRepMetadata,
 
     -- ** Governance related certificates
+    AnchorDataHash(..),
+    AnchorUrl(..),
     CommitteeColdkeyResignationRequirements(..),
     CommitteeHotKeyAuthorizationRequirements(..),
     DRepRegistrationRequirements(..),
@@ -1012,6 +1014,7 @@ module Cardano.Api (
   ) where
 
 import           Cardano.Api.Address
+import           Cardano.Api.Anchor
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.Convenience.Construction


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Introduce anchor newtypes for drep registration certificate
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Contributes to fixing https://github.com/input-output-hk/cardano-api/issues/301

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes
- [X] Self-reviewed the diff