### PR TITLE
New `MaryEraOnly` eon. Disjoint functions

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -66,6 +66,7 @@ library internal
                         Cardano.Api.Eon.ByronToAlonzoEra
                         Cardano.Api.Eon.ByronToMaryEra
                         Cardano.Api.Eon.ConwayEraOnwards
+                        Cardano.Api.Eon.MaryEraOnly
                         Cardano.Api.Eon.MaryEraOnwards
                         Cardano.Api.Eon.ShelleyBasedEra
                         Cardano.Api.Eon.ShelleyEraOnly

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnly.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Eon.MaryEraOnly
+  ( MaryEraOnly(..)
+  , maryEraOnlyConstraints
+  , maryEraOnlyToCardanoEra
+  , maryEraOnlyToShelleyBasedEra
+
+  , MaryEraOnlyConstraints
+  ) where
+
+import           Cardano.Api.Eon.ShelleyBasedEra
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.Mary.Value as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.UTxO as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+data MaryEraOnly era where
+  MaryEraOnlyMary  :: MaryEraOnly MaryEra
+
+deriving instance Show (MaryEraOnly era)
+deriving instance Eq (MaryEraOnly era)
+
+instance Eon MaryEraOnly where
+  inEonForEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> yes MaryEraOnlyMary
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra MaryEraOnly where
+  toCardanoEra = \case
+    MaryEraOnlyMary    -> MaryEra
+
+type MaryEraOnlyConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.EraUTxO (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.MaryEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+maryEraOnlyConstraints :: ()
+  => MaryEraOnly era
+  -> (MaryEraOnlyConstraints era => a)
+  -> a
+maryEraOnlyConstraints = \case
+  MaryEraOnlyMary    -> id
+
+maryEraOnlyToCardanoEra :: MaryEraOnly era -> CardanoEra era
+maryEraOnlyToCardanoEra = shelleyBasedToCardanoEra . maryEraOnlyToShelleyBasedEra
+
+maryEraOnlyToShelleyBasedEra :: MaryEraOnly era -> ShelleyBasedEra era
+maryEraOnlyToShelleyBasedEra = \case
+  MaryEraOnlyMary    -> ShelleyBasedEraMary

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -27,6 +27,8 @@ module Cardano.Api.Eras.Case
 
     -- Proofs
   , noByronEraInShelleyBasedEra
+  , disjointAlonzoEraOnlyAndBabbageEraOnwards
+  , disjointByronEraOnlyAndShelleyBasedEra
 
     -- Conversions
   , shelleyToAllegraEraToByronToAllegraEra
@@ -213,8 +215,17 @@ caseAlonzoOnlyOrBabbageEraOnwards l r = \case
   AlonzoEraOnwardsBabbage -> r BabbageEraOnwardsBabbage
   AlonzoEraOnwardsConway  -> r BabbageEraOnwardsConway
 
+{-# DEPRECATED noByronEraInShelleyBasedEra "Use disjointByronEraOnlyAndShelleyBasedEra instead" #-}
 noByronEraInShelleyBasedEra :: ShelleyBasedEra era -> ByronEraOnly era -> a
-noByronEraInShelleyBasedEra sbe ByronEraOnlyByron = case sbe of {}
+noByronEraInShelleyBasedEra = flip disjointByronEraOnlyAndShelleyBasedEra
+
+disjointByronEraOnlyAndShelleyBasedEra :: ByronEraOnly era -> ShelleyBasedEra era -> a
+disjointByronEraOnlyAndShelleyBasedEra ByronEraOnlyByron sbe = case sbe of {}
+
+disjointAlonzoEraOnlyAndBabbageEraOnwards :: AlonzoEraOnly era -> BabbageEraOnwards era -> a
+disjointAlonzoEraOnlyAndBabbageEraOnwards eonL eonR =
+  case eonL of
+    AlonzoEraOnlyAlonzo -> case eonR of {}
 
 shelleyToAllegraEraToByronToAllegraEra :: ShelleyToAllegraEra era -> ByronToAllegraEra era
 shelleyToAllegraEraToByronToAllegraEra = \case

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -19,6 +19,9 @@ module Cardano.Api.Eras.Case
   , caseShelleyToAlonzoOrBabbageEraOnwards
   , caseShelleyToBabbageOrConwayEraOnwards
 
+    -- Case on MaryEraOnwards
+  , caseMaryEraOnlyOrAlonzoEraOnwards
+
     -- Case on AlonzoEraOnwards
   , caseAlonzoOnlyOrBabbageEraOnwards
 
@@ -43,6 +46,7 @@ import           Cardano.Api.Eon.ByronToAllegraEra
 import           Cardano.Api.Eon.ByronToAlonzoEra
 import           Cardano.Api.Eon.ByronToMaryEra
 import           Cardano.Api.Eon.ConwayEraOnwards
+import           Cardano.Api.Eon.MaryEraOnly
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eon.ShelleyEraOnly
@@ -187,6 +191,17 @@ caseShelleyToBabbageOrConwayEraOnwards l r = \case
   ShelleyBasedEraAlonzo  -> l ShelleyToBabbageEraAlonzo
   ShelleyBasedEraBabbage -> l ShelleyToBabbageEraBabbage
   ShelleyBasedEraConway  -> r ConwayEraOnwardsConway
+
+caseMaryEraOnlyOrAlonzoEraOnwards :: ()
+  => (MaryEraOnly era -> a)
+  -> (AlonzoEraOnwards era -> a)
+  -> MaryEraOnwards era
+  -> a
+caseMaryEraOnlyOrAlonzoEraOnwards l r = \case
+  MaryEraOnwardsMary    -> l MaryEraOnlyMary
+  MaryEraOnwardsAlonzo  -> r AlonzoEraOnwardsAlonzo
+  MaryEraOnwardsBabbage -> r AlonzoEraOnwardsBabbage
+  MaryEraOnwardsConway  -> r AlonzoEraOnwardsConway
 
 caseAlonzoOnlyOrBabbageEraOnwards :: ()
   => (AlonzoEraOnly era -> a)

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -2656,7 +2656,7 @@ convWithdrawals txWithdrawals =
 
 convTransactionFee :: ShelleyBasedEra era -> TxFee era -> Ledger.Coin
 convTransactionFee sbe = \case
-  TxFeeImplicit w  -> noByronEraInShelleyBasedEra sbe w
+  TxFeeImplicit w  -> disjointByronEraOnlyAndShelleyBasedEra w sbe
   TxFeeExplicit _ fee -> toShelleyLovelace fee
 
 convValidityInterval

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -110,6 +110,11 @@ module Cardano.Api (
     -- ** From Allegra
 
     -- ** From Mary
+    MaryEraOnly(..),
+    maryEraOnlyConstraints,
+    maryEraOnlyToCardanoEra,
+    maryEraOnlyToShelleyBasedEra,
+
     MaryEraOnwards(..),
     maryEraOnwardsConstraints,
     maryEraOnwardsToCardanoEra,
@@ -1026,6 +1031,7 @@ import           Cardano.Api.Eon.ByronToAllegraEra
 import           Cardano.Api.Eon.ByronToAlonzoEra
 import           Cardano.Api.Eon.ByronToMaryEra
 import           Cardano.Api.Eon.ConwayEraOnwards
+import           Cardano.Api.Eon.MaryEraOnly
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eon.ShelleyEraOnly


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New `MaryEraOnly` eon
    New functions:
    - `caseMaryEraOnlyOrAlonzoEraOnwards`
    - `disjointByronEraOnlyAndShelleyBasedEra`
    - `disjointAlonzoEraOnlyAndBabbageEraOnwards`
    Deprecate:
    - `noByronEraInShelleyBasedEra`.  Use `disjointByronEraOnlyAndShelleyBasedEra` instead.
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`MaryEraOnly` is not used yet, its use is anticipated as there some Mary-specific code exists.

The `disjointX` functions are used to prove that two eons don't overlap so the cases associated with those eons don't have to be handled.

This is similar to how use sometimes do this `case someValue of {}`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
