### PR TITLE
Support DRep extended keys

### DIFF
--- a/cardano-api/internal/Cardano/Api/DeserialiseAnyOf.hs
+++ b/cardano-api/internal/Cardano/Api/DeserialiseAnyOf.hs
@@ -245,6 +245,8 @@ data SomeAddressVerificationKey
   | AVrfVerificationKey             (VerificationKey VrfKey)
   | AStakeVerificationKey           (VerificationKey StakeKey)
   | AStakeExtendedVerificationKey   (VerificationKey StakeExtendedKey)
+  | ADRepVerificationKey            (VerificationKey DRepKey)
+  | ADRepExtendedVerificationKey    (VerificationKey DRepExtendedKey)
   deriving (Show)
 
 renderSomeAddressVerificationKey :: SomeAddressVerificationKey -> Text
@@ -267,6 +269,8 @@ renderSomeAddressVerificationKey (AKesVerificationKey vk) = serialiseToBech32 vk
 renderSomeAddressVerificationKey (AVrfVerificationKey vk) = serialiseToBech32 vk
 renderSomeAddressVerificationKey (AStakeVerificationKey vk) = serialiseToBech32 vk
 renderSomeAddressVerificationKey (AStakeExtendedVerificationKey vk) = serialiseToBech32 vk
+renderSomeAddressVerificationKey (ADRepVerificationKey vk) = serialiseToBech32 vk
+renderSomeAddressVerificationKey (ADRepExtendedVerificationKey vk) = serialiseToBech32 vk
 
 
 mapSomeAddressVerificationKey :: ()
@@ -284,6 +288,8 @@ mapSomeAddressVerificationKey f = \case
   AVrfVerificationKey                       vk -> f vk
   AStakeVerificationKey                     vk -> f vk
   AStakeExtendedVerificationKey             vk -> f vk
+  ADRepVerificationKey                      vk -> f vk
+  ADRepExtendedVerificationKey              vk -> f vk
 
 -- | Internal function to pretty render byron keys
 prettyByronVerificationKey :: VerificationKey ByronKey-> Text
@@ -311,7 +317,9 @@ deserialiseAnyVerificationKeyBech32 =
   allBech32VerKey
     :: [FromSomeType SerialiseAsBech32 SomeAddressVerificationKey]
   allBech32VerKey =
-    [ FromSomeType (AsVerificationKey AsPaymentKey) APaymentVerificationKey
+    [ FromSomeType (AsVerificationKey AsDRepKey) ADRepVerificationKey
+    , FromSomeType (AsVerificationKey AsDRepExtendedKey) ADRepExtendedVerificationKey
+    , FromSomeType (AsVerificationKey AsPaymentKey) APaymentVerificationKey
     , FromSomeType (AsVerificationKey AsPaymentExtendedKey) APaymentExtendedVerificationKey
     , FromSomeType (AsVerificationKey AsKesKey) AKesVerificationKey
     , FromSomeType (AsVerificationKey AsVrfKey) AVrfVerificationKey
@@ -329,6 +337,8 @@ deserialiseAnyVerificationKeyTextEnvelope bs =
     :: [FromSomeType HasTextEnvelope SomeAddressVerificationKey]
   allTextEnvelopeCBOR =
     [ FromSomeType (AsVerificationKey AsByronKey) AByronVerificationKey
+    , FromSomeType (AsVerificationKey AsDRepKey) ADRepVerificationKey
+    , FromSomeType (AsVerificationKey AsDRepExtendedKey) ADRepExtendedVerificationKey
     , FromSomeType (AsVerificationKey AsPaymentKey) APaymentVerificationKey
     , FromSomeType (AsVerificationKey AsPaymentExtendedKey) APaymentExtendedVerificationKey
     , FromSomeType (AsVerificationKey AsStakeExtendedKey) AStakeExtendedVerificationKey


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add support for DRep extended keys
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Main PR to fix https://github.com/input-output-hk/cardano-cli/issues/358

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff