### PR TITLE
Delete unnecessary calls to `shelleyBasedEraConstraints`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -287,7 +287,7 @@ anyShelleyBasedEra :: ()
   => ShelleyBasedEra era
   -> AnyShelleyBasedEra
 anyShelleyBasedEra sbe =
-  shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe
+  AnyShelleyBasedEra sbe
 
 -- | This pairs up some era-dependent type with a 'ShelleyBasedEra' value that
 -- tells us what era it is, but hides the era type. This is useful when the era

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -951,7 +951,7 @@ makeTransactionBodyAutoBalance sbe systemstart history lpp@(LedgerProtocolParame
    calcReturnAndTotalCollateral _ _ _ TxInsCollateralNone _ _ _ _= (TxReturnCollateralNone, TxTotalCollateralNone)
    calcReturnAndTotalCollateral _ _ _ _ rc@TxReturnCollateral{} tc@TxTotalCollateral{} _ _ = (rc,tc)
    calcReturnAndTotalCollateral retColSup fee pp' (TxInsCollateral _ collIns) txReturnCollateral txTotalCollateral cAddr (UTxO utxo') =
-      shelleyBasedEraConstraints sbe $ do
+      do
         let colPerc = pp' ^. Ledger.ppCollateralPercentageL
         -- We must first figure out how much lovelace we have committed
         -- as collateral and we must determine if we have enough lovelace at our

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -162,7 +162,7 @@ createProposalProcedure
   -> Ledger.Anchor StandardCrypto
   -> Proposal era
 createProposalProcedure sbe nw dep (StakeKeyHash retAddrh) govAct anchor =
-  shelleyBasedEraConstraints sbe $ shelleyBasedEraConstraints sbe $
+  shelleyBasedEraConstraints sbe $
     Proposal Gov.ProposalProcedure
       { Gov.pProcDeposit = toShelleyLovelace dep
       , Gov.pProcReturnAddr = L.mkRwdAcnt nw (L.KeyHashObj retAddrh)

--- a/cardano-api/internal/Cardano/Api/Query/Types.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Types.hs
@@ -30,10 +30,10 @@ instance IsShelleyBasedEra era => FromCBOR (DebugLedgerState era) where
 instance IsShelleyBasedEra era => ToJSON (DebugLedgerState era) where
   toJSON =
     let sbe = shelleyBasedEra @era in
-    shelleyBasedEraConstraints sbe $ object . toDebugLedgerStatePair sbe
+    object . toDebugLedgerStatePair sbe
   toEncoding =
     let sbe = shelleyBasedEra @era in
-    shelleyBasedEraConstraints sbe $ Aeson.pairs . mconcat . toDebugLedgerStatePair sbe
+    Aeson.pairs . mconcat . toDebugLedgerStatePair sbe
 
 toDebugLedgerStatePair :: ()
   => Aeson.KeyValue a

--- a/cardano-api/internal/Cardano/Api/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Tx.hs
@@ -273,13 +273,13 @@ instance Eq (KeyWitness era) where
     (==) (ByronKeyWitness wA)
          (ByronKeyWitness wB) = wA == wB
 
-    (==) (ShelleyBootstrapWitness sbe wA)
-         (ShelleyBootstrapWitness _   wB) =
-      shelleyBasedEraConstraints sbe $ wA == wB
+    (==) (ShelleyBootstrapWitness _ wA)
+         (ShelleyBootstrapWitness _ wB) =
+      wA == wB
 
-    (==) (ShelleyKeyWitness sbe wA)
-         (ShelleyKeyWitness _   wB) =
-      shelleyBasedEraConstraints sbe $ wA == wB
+    (==) (ShelleyKeyWitness _ wA)
+         (ShelleyKeyWitness _ wB) =
+      wA == wB
 
     (==) _ _ = False
 

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -1547,8 +1547,7 @@ instance IsCardanoEra era => SerialiseAsCBOR (TxBody era) where
       recoverBytes txbody
 
     serialiseToCBOR (ShelleyTxBody sbe txbody txscripts redeemers txmetadata scriptValidity) =
-      shelleyBasedEraConstraints sbe $
-        serialiseShelleyBasedTxBody sbe txbody txscripts redeemers txmetadata scriptValidity
+      serialiseShelleyBasedTxBody sbe txbody txscripts redeemers txmetadata scriptValidity
 
     deserialiseFromCBOR _ bs =
       caseByronOrShelleyBasedEra
@@ -2632,7 +2631,7 @@ convReturnCollateral
 convReturnCollateral sbe txReturnCollateral =
   case txReturnCollateral of
     TxReturnCollateralNone -> SNothing
-    TxReturnCollateral _ colTxOut -> SJust $ shelleyBasedEraConstraints sbe $ toShelleyTxOutAny sbe colTxOut
+    TxReturnCollateral _ colTxOut -> SJust $ toShelleyTxOutAny sbe colTxOut
 
 convTotalCollateral :: TxTotalCollateral era -> StrictMaybe Ledger.Coin
 convTotalCollateral txTotalCollateral =
@@ -2650,10 +2649,9 @@ convCertificates
   :: ShelleyBasedEra era
   -> TxCertificates build era
   -> Seq.StrictSeq (Shelley.TxCert (ShelleyLedgerEra era))
-convCertificates sbe txCertificates = shelleyBasedEraConstraints sbe $
-  case txCertificates of
-    TxCertificatesNone    -> Seq.empty
-    TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs)
+convCertificates _ = \case
+  TxCertificatesNone    -> Seq.empty
+  TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs)
 
 
 convWithdrawals :: TxWithdrawals build era -> L.Withdrawals StandardCrypto
@@ -3351,7 +3349,7 @@ fromAlonzoRdmrPtr (Alonzo.RdmrPtr tag n) =
 collectTxBodyScriptWitnesses :: forall era. ShelleyBasedEra era
                              -> TxBodyContent BuildTx era
                              -> [(ScriptWitnessIndex, AnyScriptWitness era)]
-collectTxBodyScriptWitnesses sbe TxBodyContent {
+collectTxBodyScriptWitnesses _ TxBodyContent {
                                txIns,
                                txWithdrawals,
                                txCertificates,
@@ -3394,7 +3392,7 @@ collectTxBodyScriptWitnesses sbe TxBodyContent {
           -- The certs are indexed in list order
         | (ix, cert) <- zip [0..] certs
         , ScriptWitness _ witness <- maybeToList $ do
-                                       stakecred <- shelleyBasedEraConstraints sbe $ selectStakeCredential cert
+                                       stakecred <- selectStakeCredential cert
                                        Map.lookup stakecred witnesses
         ]
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete unnecessary calls to `shelleyBasedEraConstraints`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
