### PR TITLE
DRep extended key: add CastVerificationKeyRole

### DIFF
--- a/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
@@ -1723,6 +1723,18 @@ instance SerialiseAsBech32 (SigningKey DRepExtendedKey) where
     bech32PrefixFor         _ =  "drep_xsk"
     bech32PrefixesPermitted _ = ["drep_xsk"]
 
+instance CastVerificationKeyRole DRepExtendedKey DRepKey where
+    castVerificationKey (DRepExtendedVerificationKey vk) =
+        DRepVerificationKey
+      . Shelley.VKey
+      . fromMaybe impossible
+      . Crypto.rawDeserialiseVerKeyDSIGN
+      . Crypto.HD.xpubPublicKey
+      $ vk
+      where
+        impossible =
+          error "castVerificationKey (DRep): byron and shelley key sizes do not match!"
+
 --
 -- Committee keys
 --


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    DRep extended key: add CastVerificationKeyRole
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Required for https://github.com/input-output-hk/cardano-cli/pull/377. Should have been part of https://github.com/input-output-hk/cardano-api/pull/320 but somehow I lost this part during my local rebases :upside_down_face: 

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff