### PR TITLE
Make Byron constructors and functions propagate `ByronEraOnly` eon. Delete `CardanoEraStyle`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Address.hs
+++ b/cardano-api/internal/Cardano/Api/Address.hs
@@ -489,13 +489,13 @@ anyAddressInShelleyBasedEra sbe = \case
 anyAddressInEra :: CardanoEra era
                 -> AddressAny
                 -> Either String (AddressInEra era)
-anyAddressInEra _ (AddressByron addr) =
+anyAddressInEra era = \case
+  AddressByron addr ->
     Right (AddressInEra ByronAddressInAnyEra addr)
-
-anyAddressInEra era (AddressShelley addr) =
-    case cardanoEraStyle era of
-      LegacyByronEra       -> Left "Expected Byron based era address"
-      ShelleyBasedEra era' -> Right (AddressInEra (ShelleyAddressInEra era') addr)
+  AddressShelley addr ->
+    forEraInEon era
+      (Left "Expected Byron based era address")
+      (\sbe -> Right (AddressInEra (ShelleyAddressInEra sbe) addr))
 
 toAddressAny :: Address addr -> AddressAny
 toAddressAny a@ShelleyAddress{} = AddressShelley a

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -51,6 +51,7 @@ module Cardano.Api.Block (
     makeChainTip,
   ) where
 
+import           Cardano.Api.Eon.ByronEraOnly
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras
 import           Cardano.Api.Hash
@@ -172,7 +173,7 @@ getBlockTxs = \case
             Byron.ABody {
               Byron.bodyTxPayload = Byron.ATxPayload txs
             }
-        } -> map ByronTx txs
+        } -> map (ByronTx ByronEraOnlyByron) txs
   ShelleyBlock sbe Consensus.ShelleyBlock{Consensus.shelleyBlockRaw} ->
     shelleyBasedEraConstraints sbe $
       getShelleyBlockTxs sbe shelleyBlockRaw

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -384,7 +384,4 @@ requireShelleyBasedEra :: ()
   => Applicative m
   => CardanoEra era
   -> m (Maybe (ShelleyBasedEra era))
-requireShelleyBasedEra era =
-  case cardanoEraStyle era of
-    LegacyByronEra -> pure Nothing
-    ShelleyBasedEra sbe -> pure (Just sbe)
+requireShelleyBasedEra = inEonForEra (pure Nothing) (pure . Just)

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -25,10 +25,6 @@ module Cardano.Api.Eon.ShelleyBasedEra
   , forShelleyBasedEraInEonMaybe
   , forShelleyBasedEraMaybeEon
 
-    -- * Cardano eras, as Byron vs Shelley-based
-  , CardanoEraStyle(..)
-  , cardanoEraStyle
-
     -- * Assertions on era
   , requireShelleyBasedEra
 
@@ -315,40 +311,6 @@ shelleyBasedToCardanoEra ShelleyBasedEraMary    = MaryEra
 shelleyBasedToCardanoEra ShelleyBasedEraAlonzo  = AlonzoEra
 shelleyBasedToCardanoEra ShelleyBasedEraBabbage = BabbageEra
 shelleyBasedToCardanoEra ShelleyBasedEraConway  = ConwayEra
-
--- ----------------------------------------------------------------------------
--- Cardano eras factored as Byron vs Shelley-based
---
-
--- | This is the same essential information as 'CardanoEra' but instead of a
--- flat set of alternative eras, it is factored into the legcy Byron era and
--- the current Shelley-based eras.
---
--- This way of factoring the eras is useful because in many cases the
--- major differences are between the Byron and Shelley-based eras, and
--- the Shelley-based eras can often be treated uniformly.
---
-data CardanoEraStyle era where
-  LegacyByronEra  :: CardanoEraStyle ByronEra
-
-  ShelleyBasedEra
-    :: ShelleyBasedEra era
-    -> CardanoEraStyle era
-
-deriving instance Eq   (CardanoEraStyle era)
-deriving instance Ord  (CardanoEraStyle era)
-deriving instance Show (CardanoEraStyle era)
-
--- | The 'CardanoEraStyle' for a 'CardanoEra'.
---
-cardanoEraStyle :: CardanoEra era -> CardanoEraStyle era
-cardanoEraStyle ByronEra   = LegacyByronEra
-cardanoEraStyle ShelleyEra = ShelleyBasedEra ShelleyBasedEraShelley
-cardanoEraStyle AllegraEra = ShelleyBasedEra ShelleyBasedEraAllegra
-cardanoEraStyle MaryEra    = ShelleyBasedEra ShelleyBasedEraMary
-cardanoEraStyle AlonzoEra  = ShelleyBasedEra ShelleyBasedEraAlonzo
-cardanoEraStyle BabbageEra = ShelleyBasedEra ShelleyBasedEraBabbage
-cardanoEraStyle ConwayEra  = ShelleyBasedEra ShelleyBasedEraConway
 
 -- ----------------------------------------------------------------------------
 -- Conversion to Shelley ledger library types

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -48,6 +48,7 @@ module Cardano.Api.Fees (
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eon.BabbageEraOnwards
+import           Cardano.Api.Eon.ByronEraOnly
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eon.ShelleyToAllegraEra
@@ -120,7 +121,7 @@ transactionFee sbe txFeeFixed txFeePerByte tx =
     ShelleyTx _ tx' ->
       let x = shelleyBasedEraConstraints sbe $ tx' ^. L.sizeTxF in Lovelace (a * x + b)
       --TODO: This can be made to work for Byron txs too.
-    ByronTx _ -> case sbe of {}
+    ByronTx ByronEraOnlyByron _ -> case sbe of {}
 
 {-# DEPRECATED transactionFee "Use 'evaluateTransactionFee' instead" #-}
 
@@ -148,7 +149,7 @@ estimateTransactionFee :: ()
   -> Lovelace
 estimateTransactionFee sbe nw txFeeFixed txFeePerByte = \case
   -- TODO: This can be made to work for Byron txs too.
-  ByronTx _ ->
+  ByronTx ByronEraOnlyByron _ ->
     case sbe of {}
   ShelleyTx era tx ->
     let Lovelace baseFee = transactionFee sbe txFeeFixed txFeePerByte (ShelleyTx era tx)
@@ -218,7 +219,7 @@ evaluateTransactionFee _ _ _ _ byronwitcount | byronwitcount > 0 =
 evaluateTransactionFee sbe pp txbody keywitcount _byronwitcount =
   shelleyBasedEraConstraints sbe $
     case makeSignedTransaction [] txbody of
-      ByronTx{} -> case sbe of {}
+      ByronTx ByronEraOnlyByron _ -> case sbe of {}
       --TODO: we could actually support Byron here, it'd be different but simpler
 
       ShelleyTx _ tx -> fromShelleyLovelace $ Ledger.evaluateTransactionFee pp tx keywitcount
@@ -566,7 +567,7 @@ evaluateTransactionBalance :: forall era. ()
                            -> UTxO era
                            -> TxBody era
                            -> TxOutValue era
-evaluateTransactionBalance sbe _ _ _ _ _ (ByronTxBody _) =
+evaluateTransactionBalance sbe _ _ _ _ _ (ByronTxBody ByronEraOnlyByron _) =
   -- TODO: we could actually support Byron here, it'd be different but simpler
   case sbe of {}
 

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -25,6 +25,7 @@ module Cardano.Api.InMode (
     fromConsensusApplyTxErr,
   ) where
 
+import           Cardano.Api.Eon.ByronEraOnly
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras
 import           Cardano.Api.Modes
@@ -111,12 +112,12 @@ fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (
 toConsensusGenTx :: ConsensusBlockForMode mode ~ block
                  => TxInMode mode
                  -> Consensus.GenTx block
-toConsensusGenTx (TxInMode (ByronTx tx) ByronEraInByronMode) =
+toConsensusGenTx (TxInMode (ByronTx ByronEraOnlyByron tx) ByronEraInByronMode) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (Z tx'))
   where
     tx' = Consensus.ByronTx (Consensus.byronIdTx tx) tx
 
-toConsensusGenTx (TxInMode (ByronTx tx) ByronEraInCardanoMode) =
+toConsensusGenTx (TxInMode (ByronTx ByronEraOnlyByron tx) ByronEraInCardanoMode) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (Z tx'))
   where
     tx' = Consensus.ByronTx (Consensus.byronIdTx tx) tx

--- a/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
@@ -269,10 +269,9 @@ deserialiseFromTextEnvelopeCddlAnyOf types teCddl =
 
       Just (FromCDDLWitness ttoken f) -> do
          AnyCardanoEra era <- cddlTypeToEra ttoken
-         case cardanoEraStyle era of
-           LegacyByronEra -> Left TextEnvelopeCddlErrByronKeyWitnessUnsupported
-           ShelleyBasedEra sbe ->
-             f . InAnyCardanoEra era <$> deserialiseWitnessLedgerCddl sbe teCddl
+         forEraInEon era
+           (Left TextEnvelopeCddlErrByronKeyWitnessUnsupported)
+           (\sbe -> f . InAnyCardanoEra era <$> deserialiseWitnessLedgerCddl sbe teCddl)
   where
    actualType :: Text
    actualType = teCddlType teCddl

--- a/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
@@ -30,7 +30,6 @@ module Cardano.Api.SerialiseLedgerCddl
   )
   where
 
-import           Cardano.Api.Eon.ByronEraOnly
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
@@ -161,11 +160,10 @@ deserialiseTx :: ()
   -> ByteString
   -> Either DecoderError (Tx era)
 deserialiseTx era bs =
-  case era of
-    ByronEra ->
-      ByronTx ByronEraOnlyByron
-        <$> CBOR.decodeFullAnnotatedBytes CBOR.byronProtVer "Byron Tx" CBOR.decCBOR (LBS.fromStrict bs)
-    _ -> cardanoEraConstraints era $ deserialiseFromCBOR (AsTx (proxyToAsType Proxy)) bs
+  caseByronOrShelleyBasedEra
+    (\w -> ByronTx w <$> CBOR.decodeFullAnnotatedBytes CBOR.byronProtVer "Byron Tx" CBOR.decCBOR (LBS.fromStrict bs))
+    (const $ cardanoEraConstraints era $ deserialiseFromCBOR (AsTx (proxyToAsType Proxy)) bs)
+    era
 
 serialiseWitnessLedgerCddl :: forall era. ShelleyBasedEra era -> KeyWitness era -> TextEnvelopeCddl
 serialiseWitnessLedgerCddl sbe kw =

--- a/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
@@ -30,6 +30,7 @@ module Cardano.Api.SerialiseLedgerCddl
   )
   where
 
+import           Cardano.Api.Eon.ByronEraOnly
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras
 import           Cardano.Api.Error
@@ -162,7 +163,7 @@ deserialiseTx :: ()
 deserialiseTx era bs =
   case era of
     ByronEra ->
-      ByronTx
+      ByronTx ByronEraOnlyByron
         <$> CBOR.decodeFullAnnotatedBytes CBOR.byronProtVer "Byron Tx" CBOR.decCBOR (LBS.fromStrict bs)
     _ -> cardanoEraConstraints era $ deserialiseFromCBOR (AsTx (proxyToAsType Proxy)) bs
 

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -2125,10 +2125,8 @@ createAndValidateTransactionBody :: ()
   => CardanoEra era
   -> TxBodyContent BuildTx era
   -> Either TxBodyError (TxBody era)
-createAndValidateTransactionBody era =
-  case cardanoEraStyle era of
-    LegacyByronEra      -> makeByronTransactionBody ByronEraOnlyByron
-    ShelleyBasedEra sbe -> makeShelleyTransactionBody sbe
+createAndValidateTransactionBody =
+  caseByronOrShelleyBasedEra makeByronTransactionBody makeShelleyTransactionBody
 
 pattern TxBody :: TxBodyContent ViewTx era -> TxBody era
 pattern TxBody txbodycontent <- (getTxBodyContent -> txbodycontent)

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -105,8 +105,6 @@ module Cardano.Api (
     anyShelleyBasedEra,
     InAnyShelleyBasedEra(..),
     inAnyShelleyBasedEra,
-    CardanoEraStyle(..),
-    cardanoEraStyle,
     shelleyBasedToCardanoEra,
     shelleyBasedEraConstraints,
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    In `Tx`, `ByronTx` now carries additional `ByronEraOnly` witness
    In `TxBody`, `TxBodyByron` now carries additional `ByronEraOnly` witness
    Delete `CardanoEraStyle` because eons solve the same problem more generally
    Delete `cardanoEraStyle`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Modify Byron constructors and functions propagate `ByronEraOnly` eon because that makes the code more compatible with eon support.

Delete `CardanoEraStyle` because it is unnecessary as eons solve the same problem more generally.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
