### PR TITLE
Delete `ProtocolUTxOCostPerByteFeature`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -908,7 +908,7 @@ genProtocolParameters era = do
   protocolParamMaxValueSize <- Gen.maybe genNat
   protocolParamCollateralPercent <- Gen.maybe genNat
   protocolParamMaxCollateralInputs <- Gen.maybe genNat
-  protocolParamUTxOCostPerByte <- inEonForEra @ProtocolUTxOCostPerByteFeature (pure Nothing) (const (Just <$> genLovelace)) era
+  protocolParamUTxOCostPerByte <- inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genLovelace)) era
 
   pure ProtocolParameters {..}
 
@@ -945,7 +945,7 @@ genProtocolParametersUpdate era = do
   protocolUpdateMaxValueSize        <- Gen.maybe genNat
   protocolUpdateCollateralPercent   <- Gen.maybe genNat
   protocolUpdateMaxCollateralInputs <- Gen.maybe genNat
-  protocolUpdateUTxOCostPerByte     <- inEonForEra @ProtocolUTxOCostPerByteFeature (pure Nothing) (const (Just <$> genLovelace)) era
+  protocolUpdateUTxOCostPerByte     <- inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genLovelace)) era
 
   pure ProtocolParametersUpdate{..}
 

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -92,7 +92,6 @@ module Cardano.Api.ProtocolParameters (
     AsType(..),
 
     -- ** Era-dependent protocol features
-    ProtocolUTxOCostPerByteFeature(..),
     ProtocolUTxOCostPerWordFeature(..),
   ) where
 
@@ -982,37 +981,6 @@ instance FromCBOR ProtocolParametersUpdate where
         <*> fromCBOR
         <*> fromCBOR
         <*> fromCBOR
-
--- ----------------------------------------------------------------------------
--- Features
---
-
--- | A representation of whether the era supports the 'UTxO Cost Per Byte'
--- protocol parameter.
---
--- The Babbage and subsequent eras support such a protocol parameter.
---
-data ProtocolUTxOCostPerByteFeature era where
-  ProtocolUTxOCostPerByteInBabbageEra :: ProtocolUTxOCostPerByteFeature BabbageEra
-  ProtocolUTxOCostPerByteInConwayEra  :: ProtocolUTxOCostPerByteFeature ConwayEra
-
-deriving instance Eq   (ProtocolUTxOCostPerByteFeature era)
-deriving instance Show (ProtocolUTxOCostPerByteFeature era)
-
-instance Eon ProtocolUTxOCostPerByteFeature where
-  inEonForEra no yes = \case
-    ByronEra    -> no
-    ShelleyEra  -> no
-    AllegraEra  -> no
-    MaryEra     -> no
-    AlonzoEra   -> no
-    BabbageEra  -> yes ProtocolUTxOCostPerByteInBabbageEra
-    ConwayEra   -> yes ProtocolUTxOCostPerByteInConwayEra
-
-instance ToCardanoEra ProtocolUTxOCostPerByteFeature where
-  toCardanoEra = \case
-    ProtocolUTxOCostPerByteInBabbageEra -> BabbageEra
-    ProtocolUTxOCostPerByteInConwayEra  -> ConwayEra
 
 -- | A representation of whether the era supports the 'UTxO Cost Per Word'
 -- protocol parameter.

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -404,7 +404,6 @@ module Cardano.Api (
     ViewTx,
 
     -- ** Era-dependent protocol features
-    ProtocolUTxOCostPerByteFeature(..),
     ProtocolUTxOCostPerWordFeature(..),
 
     -- ** Fee calculation


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `ProtocolUTxOCostPerByteFeature`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Stray feature pretending to be an eon.  Directly use the eon instead.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
