### PR TITLE
Delete `ConsensusMode` type

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -29,6 +29,9 @@ common project-config
                         -Wredundant-constraints
                         -Wunused-packages
 
+  if impl(ghc < 9)
+    ghc-options:        -Wno-incomplete-patterns
+
 common maybe-unix
   if !os(windows)
      build-depends:    unix

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -33,7 +33,6 @@ module Cardano.Api.Block (
     toConsensusPoint,
     fromConsensusPoint,
     fromConsensusPointHF,
-    toConsensusPointInMode,
     toConsensusPointHF,
 
     -- * Tip of the chain
@@ -312,15 +311,6 @@ instance FromJSON ChainPoint where
       "ChainPointAtGenesis" -> pure ChainPointAtGenesis
       "ChainPoint" -> ChainPoint <$> o .: "slot" <*> o .: "blockHash"
       _ -> fail "Expected tag to be ChainPointAtGenesis | ChainPoint"
-
-toConsensusPointInMode :: ()
-  => ConsensusMode CardanoMode
-  -> ChainPoint
-  -> Consensus.Point (Consensus.CardanoBlock L.StandardCrypto)
--- It's the same concrete impl in all cases, but we have to show
--- individually for each case that we satisfy the type equality constraint
--- HeaderHash block ~ OneEraHash xs
-toConsensusPointInMode CardanoMode = toConsensusPointHF
 
 -- | Convert a 'Consensus.Point' for multi-era block type
 --

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -200,10 +200,9 @@ deriving instance Show BlockInMode
 
 fromConsensusBlock :: ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block
-  => ConsensusMode CardanoMode
-  -> block
+  => block
   -> BlockInMode
-fromConsensusBlock CardanoMode = \case
+fromConsensusBlock = \case
   Consensus.BlockByron    b' -> BlockInMode cardanoEra $ ByronBlock b'
   Consensus.BlockShelley  b' -> BlockInMode cardanoEra $ ShelleyBlock ShelleyBasedEraShelley b'
   Consensus.BlockAllegra  b' -> BlockInMode cardanoEra $ ShelleyBlock ShelleyBasedEraAllegra b'

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -204,10 +204,10 @@ data BlockInMode mode where
 deriving instance Show (BlockInMode mode)
 
 fromConsensusBlock :: ()
-  => ConsensusBlockForMode mode ~ block
-  => ConsensusMode mode
+  => ConsensusBlockForMode CardanoMode ~ block
+  => ConsensusMode CardanoMode
   -> block
-  -> BlockInMode mode
+  -> BlockInMode CardanoMode
 fromConsensusBlock CardanoMode = \case
       Consensus.BlockByron b' ->
         BlockInMode cardanoEra (ByronBlock b') ByronEraInCardanoMode
@@ -237,19 +237,17 @@ fromConsensusBlock CardanoMode = \case
                      ConwayEraInCardanoMode
 
 toConsensusBlock :: ()
-  => ConsensusBlockForMode mode ~ block
-  => BlockInMode mode -> block
+  => ConsensusBlockForMode CardanoMode ~ block
+  => BlockInMode CardanoMode
+  -> block
 toConsensusBlock = \case
-    -- Byron mode
-
-    -- Cardano mode
-    BlockInMode _ (ByronBlock b') ByronEraInCardanoMode -> Consensus.BlockByron b'
-    BlockInMode _ (ShelleyBlock ShelleyBasedEraShelley b') ShelleyEraInCardanoMode -> Consensus.BlockShelley b'
-    BlockInMode _ (ShelleyBlock ShelleyBasedEraAllegra b') AllegraEraInCardanoMode -> Consensus.BlockAllegra b'
-    BlockInMode _ (ShelleyBlock ShelleyBasedEraMary b') MaryEraInCardanoMode -> Consensus.BlockMary b'
-    BlockInMode _ (ShelleyBlock ShelleyBasedEraAlonzo b') AlonzoEraInCardanoMode -> Consensus.BlockAlonzo b'
-    BlockInMode _ (ShelleyBlock ShelleyBasedEraBabbage b') BabbageEraInCardanoMode -> Consensus.BlockBabbage b'
-    BlockInMode _ (ShelleyBlock ShelleyBasedEraConway b') ConwayEraInCardanoMode -> Consensus.BlockConway b'
+  BlockInMode _ (ByronBlock b') ByronEraInCardanoMode -> Consensus.BlockByron b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraShelley b') ShelleyEraInCardanoMode -> Consensus.BlockShelley b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraAllegra b') AllegraEraInCardanoMode -> Consensus.BlockAllegra b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraMary b') MaryEraInCardanoMode -> Consensus.BlockMary b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraAlonzo b') AlonzoEraInCardanoMode -> Consensus.BlockAlonzo b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraBabbage b') BabbageEraInCardanoMode -> Consensus.BlockBabbage b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraConway b') ConwayEraInCardanoMode -> Consensus.BlockConway b'
 
 -- ----------------------------------------------------------------------------
 -- Block headers

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -405,21 +405,3 @@ fromConsensusTip = conv
     conv Consensus.TipGenesis = ChainTipAtGenesis
     conv (Consensus.Tip slot (Consensus.OneEraHash h) block) =
       ChainTip slot (HeaderHash h) block
-
-{-
-TODO: In principle we should be able to use this common implementation rather
-      than repeating it for each mode above. It does actually type-check. The
-      problem is that (at least with ghc-8.10.x) ghc's pattern match warning
-      mechanism cannot see that the OneEraHash is a complete pattern match.
-      I'm guessing that while the type checker can use the type equality to
-      see that OneEraHash is a valid pattern, the exhaustiveness checker is for
-      some reason not able to use it to see that it is indeed the only pattern.
-fromConsensusTip =
-    \mode -> case mode of
-      CardanoMode -> conv
-  where
-    conv :: HeaderHash block ~ OneEraHash xs
-         => Tip block -> ChainTip
-    conv TipGenesis                      = ChainTipAtGenesis
-    conv (Tip slot (OneEraHash h) block) = ChainTip slot (HeaderHash h) block
--}

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -34,7 +34,6 @@ module Cardano.Api.Block (
     fromConsensusPoint,
     fromConsensusPointHF,
     toConsensusPointInMode,
-    fromConsensusPointInMode,
     toConsensusPointHF,
 
     -- * Tip of the chain
@@ -322,13 +321,6 @@ toConsensusPointInMode :: ()
 -- individually for each case that we satisfy the type equality constraint
 -- HeaderHash block ~ OneEraHash xs
 toConsensusPointInMode CardanoMode = toConsensusPointHF
-
-fromConsensusPointInMode :: ()
-  => ConsensusMode CardanoMode
-  -> Consensus.Point (Consensus.CardanoBlock L.StandardCrypto)
-  -> ChainPoint
-fromConsensusPointInMode CardanoMode = fromConsensusPointHF
-
 
 -- | Convert a 'Consensus.Point' for multi-era block type
 --

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -189,65 +189,42 @@ getShelleyBlockTxs era (Ledger.Block _header txs) =
 -- Block in a consensus mode
 --
 
--- | A 'Block' in one of the eras supported by a given protocol mode.
---
--- For multi-era modes such as the 'CardanoMode' this type is a sum of the
--- different block types for all the eras. It is used in the ChainSync protocol.
---
-data BlockInMode mode where
+-- | A 'Block' in one of the eras.
+-- TODO Rename this to BlockInEra
+data BlockInMode where
   BlockInMode
     :: CardanoEra era
     -> Block era
-    -> EraInMode era mode
-    -> BlockInMode mode
+    -> BlockInMode
 
-deriving instance Show (BlockInMode mode)
+deriving instance Show BlockInMode
 
 fromConsensusBlock :: ()
   => ConsensusBlockForMode CardanoMode ~ block
   => ConsensusMode CardanoMode
   -> block
-  -> BlockInMode CardanoMode
+  -> BlockInMode
 fromConsensusBlock CardanoMode = \case
-      Consensus.BlockByron b' ->
-        BlockInMode cardanoEra (ByronBlock b') ByronEraInCardanoMode
-
-      Consensus.BlockShelley b' ->
-        BlockInMode cardanoEra (ShelleyBlock ShelleyBasedEraShelley b')
-                     ShelleyEraInCardanoMode
-
-      Consensus.BlockAllegra b' ->
-        BlockInMode cardanoEra (ShelleyBlock ShelleyBasedEraAllegra b')
-                     AllegraEraInCardanoMode
-
-      Consensus.BlockMary b' ->
-        BlockInMode cardanoEra (ShelleyBlock ShelleyBasedEraMary b')
-                     MaryEraInCardanoMode
-
-      Consensus.BlockAlonzo b' ->
-        BlockInMode cardanoEra (ShelleyBlock ShelleyBasedEraAlonzo b')
-                     AlonzoEraInCardanoMode
-
-      Consensus.BlockBabbage b' ->
-        BlockInMode cardanoEra (ShelleyBlock ShelleyBasedEraBabbage b')
-                     BabbageEraInCardanoMode
-
-      Consensus.BlockConway b' ->
-        BlockInMode cardanoEra (ShelleyBlock ShelleyBasedEraConway b')
-                     ConwayEraInCardanoMode
+  Consensus.BlockByron    b' -> BlockInMode cardanoEra $ ByronBlock b'
+  Consensus.BlockShelley  b' -> BlockInMode cardanoEra $ ShelleyBlock ShelleyBasedEraShelley b'
+  Consensus.BlockAllegra  b' -> BlockInMode cardanoEra $ ShelleyBlock ShelleyBasedEraAllegra b'
+  Consensus.BlockMary     b' -> BlockInMode cardanoEra $ ShelleyBlock ShelleyBasedEraMary b'
+  Consensus.BlockAlonzo   b' -> BlockInMode cardanoEra $ ShelleyBlock ShelleyBasedEraAlonzo b'
+  Consensus.BlockBabbage  b' -> BlockInMode cardanoEra $ ShelleyBlock ShelleyBasedEraBabbage b'
+  Consensus.BlockConway   b' -> BlockInMode cardanoEra $ ShelleyBlock ShelleyBasedEraConway b'
 
 toConsensusBlock :: ()
   => ConsensusBlockForMode CardanoMode ~ block
-  => BlockInMode CardanoMode
+  => BlockInMode
   -> block
 toConsensusBlock = \case
-  BlockInMode _ (ByronBlock b') ByronEraInCardanoMode -> Consensus.BlockByron b'
-  BlockInMode _ (ShelleyBlock ShelleyBasedEraShelley b') ShelleyEraInCardanoMode -> Consensus.BlockShelley b'
-  BlockInMode _ (ShelleyBlock ShelleyBasedEraAllegra b') AllegraEraInCardanoMode -> Consensus.BlockAllegra b'
-  BlockInMode _ (ShelleyBlock ShelleyBasedEraMary b') MaryEraInCardanoMode -> Consensus.BlockMary b'
-  BlockInMode _ (ShelleyBlock ShelleyBasedEraAlonzo b') AlonzoEraInCardanoMode -> Consensus.BlockAlonzo b'
-  BlockInMode _ (ShelleyBlock ShelleyBasedEraBabbage b') BabbageEraInCardanoMode -> Consensus.BlockBabbage b'
-  BlockInMode _ (ShelleyBlock ShelleyBasedEraConway b') ConwayEraInCardanoMode -> Consensus.BlockConway b'
+  BlockInMode _ (ByronBlock                           b') -> Consensus.BlockByron b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraShelley  b') -> Consensus.BlockShelley b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraAllegra  b') -> Consensus.BlockAllegra b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraMary     b') -> Consensus.BlockMary b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraAlonzo   b') -> Consensus.BlockAlonzo b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraBabbage  b') -> Consensus.BlockBabbage b'
+  BlockInMode _ (ShelleyBlock ShelleyBasedEraConway   b') -> Consensus.BlockConway b'
 
 -- ----------------------------------------------------------------------------
 -- Block headers

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -394,11 +394,11 @@ makeChainTip woBlockNo chainPoint = case woBlockNo of
     ChainPointAtGenesis -> ChainTipAtGenesis
     ChainPoint slotNo headerHash -> ChainTip slotNo headerHash blockNo
 
-fromConsensusTip  :: Consensus.CardanoBlock L.StandardCrypto ~ block
-                  => ConsensusMode CardanoMode
-                  -> Consensus.Tip block
-                  -> ChainTip
-fromConsensusTip CardanoMode = conv
+fromConsensusTip :: ()
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
+  => Consensus.Tip block
+  -> ChainTip
+fromConsensusTip = conv
   where
     conv :: Consensus.Tip (Consensus.CardanoBlock Consensus.StandardCrypto)
          -> ChainTip

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -81,7 +81,7 @@ queryStateForBalancedTx :: ()
   => CardanoEra era
   -> [TxIn]
   -> [Certificate era]
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO
+  -> LocalStateQueryExpr block point QueryInMode r IO
       ( Either
           QueryConvenienceError
           ( UTxO era
@@ -143,7 +143,7 @@ determineEra localNodeConnInfo =
 executeQueryCardanoMode :: ()
   => SocketPath
   -> NetworkId
-  -> QueryInMode CardanoMode (Either EraMismatch result)
+  -> QueryInMode (Either EraMismatch result)
   -> IO (Either QueryConvenienceError result)
 executeQueryCardanoMode socketPath nid q = runExceptT $ do
   let localNodeConnInfo =
@@ -158,7 +158,7 @@ executeQueryCardanoMode socketPath nid q = runExceptT $ do
 -- | Execute a query against the local node in any mode.
 executeQueryAnyMode :: forall result. ()
   => LocalNodeConnectInfo
-  -> QueryInMode CardanoMode (Either EraMismatch result)
+  -> QueryInMode (Either EraMismatch result)
   -> IO (Either QueryConvenienceError result)
 executeQueryAnyMode localNodeConnInfo q = runExceptT $ do
   lift (queryNodeLocalState localNodeConnInfo Nothing q)

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -136,8 +136,8 @@ queryStateForBalancedTx era allTxIns certs = runExceptT $ do
 
 -- | Query the node to determine which era it is in.
 determineEra :: ()
-  => ConsensusModeParams mode
-  -> LocalNodeConnectInfo mode
+  => ConsensusModeParams CardanoMode
+  -> LocalNodeConnectInfo
   -> IO (Either AcquiringFailure AnyCardanoEra)
 determineEra cModeParams localNodeConnInfo =
   case consensusModeOnly cModeParams of
@@ -163,7 +163,7 @@ executeQueryCardanoMode socketPath nid q = runExceptT $ do
 
 -- | Execute a query against the local node in any mode.
 executeQueryAnyMode :: forall result. ()
-  => LocalNodeConnectInfo CardanoMode
+  => LocalNodeConnectInfo
   -> QueryInMode CardanoMode (Either EraMismatch result)
   -> IO (Either QueryConvenienceError result)
 executeQueryAnyMode localNodeConnInfo q = runExceptT $ do

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -142,8 +142,7 @@ determineEra :: ()
 determineEra cModeParams localNodeConnInfo =
   case consensusModeOnly cModeParams of
     CardanoMode ->
-      queryNodeLocalState localNodeConnInfo Nothing
-        $ QueryCurrentEra CardanoModeIsMultiEra
+      queryNodeLocalState localNodeConnInfo Nothing QueryCurrentEra
 
 -- | Execute a query against the local node. The local
 -- node must be in CardanoMode.

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -162,9 +162,9 @@ executeQueryCardanoMode socketPath nid q = runExceptT $ do
   ExceptT $ executeQueryAnyMode localNodeConnInfo q
 
 -- | Execute a query against the local node in any mode.
-executeQueryAnyMode :: forall result mode. ()
-  => LocalNodeConnectInfo mode
-  -> QueryInMode mode (Either EraMismatch result)
+executeQueryAnyMode :: forall result. ()
+  => LocalNodeConnectInfo CardanoMode
+  -> QueryInMode CardanoMode (Either EraMismatch result)
   -> IO (Either QueryConvenienceError result)
 executeQueryAnyMode localNodeConnInfo q = runExceptT $ do
   lift (queryNodeLocalState localNodeConnInfo Nothing q)

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -142,7 +142,6 @@ determineEra
 determineEra cModeParams localNodeConnInfo =
   case consensusModeOnly cModeParams of
     ByronMode -> return . Right $ AnyCardanoEra ByronEra
-    ShelleyMode -> return . Right $ AnyCardanoEra ShelleyEra
     CardanoMode ->
       queryNodeLocalState localNodeConnInfo Nothing
         $ QueryCurrentEra CardanoModeIsMultiEra

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -133,13 +133,10 @@ queryStateForBalancedTx era allTxIns certs = runExceptT $ do
 
 -- | Query the node to determine which era it is in.
 determineEra :: ()
-  => ConsensusModeParams CardanoMode
-  -> LocalNodeConnectInfo
+  => LocalNodeConnectInfo
   -> IO (Either AcquiringFailure AnyCardanoEra)
-determineEra cModeParams localNodeConnInfo =
-  case consensusModeOnly cModeParams of
-    CardanoMode ->
-      queryNodeLocalState localNodeConnInfo Nothing QueryCurrentEra
+determineEra localNodeConnInfo =
+  queryNodeLocalState localNodeConnInfo Nothing QueryCurrentEra
 
 -- | Execute a query against the local node. The local
 -- node must be in CardanoMode.

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -86,7 +86,7 @@ queryStateForBalancedTx :: ()
           QueryConvenienceError
           ( UTxO era
           , LedgerProtocolParameters era
-          , EraHistory CardanoMode
+          , EraHistory
           , SystemStart
           , Set PoolId
           , Map StakeCredential Lovelace

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -24,7 +24,6 @@ import           Cardano.Api.Eras
 import           Cardano.Api.IO
 import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Monad
-import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query
@@ -54,7 +53,6 @@ data QueryConvenienceError
   = AcqFailure AcquiringFailure
   | QueryEraMismatch EraMismatch
   | ByronEraNotSupported
-  | EraConsensusModeMismatch !AnyConsensusMode !AnyCardanoEra
   | QceUnsupportedNtcVersion !UnsupportedNtcVersionError
   deriving Show
 
@@ -67,9 +65,6 @@ renderQueryConvenienceError (QueryEraMismatch (EraMismatch ledgerEraName' otherE
   " era, but the transaction is for the " <> otherEraName' <> " era."
 renderQueryConvenienceError ByronEraNotSupported =
   "Byron era not supported"
-renderQueryConvenienceError (EraConsensusModeMismatch cMode anyCEra) =
-  "Consensus mode and era mismatch. Consensus mode: " <> textShow cMode <>
-  " Era: " <> textShow anyCEra
 renderQueryConvenienceError (QceUnsupportedNtcVersion (UnsupportedNtcVersionError minNtcVersion ntcVersion)) =
   "Unsupported feature for the node-to-client protocol version.\n" <>
   "This query requires at least " <> textShow minNtcVersion <> " but the node negotiated " <> textShow ntcVersion <> ".\n" <>

--- a/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
@@ -69,6 +69,7 @@ type AllegraEraOnwardsConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))

--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
@@ -73,6 +73,7 @@ type AlonzoEraOnwardsConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.AlonzoEraPParams (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
@@ -70,6 +70,7 @@ type BabbageEraOnwardsConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.AlonzoEraTxOut (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -70,6 +70,7 @@ type ConwayEraOnwardsConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.AlonzoEraTxOut (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnly.hs
@@ -63,6 +63,7 @@ type MaryEraOnlyConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
@@ -69,6 +69,7 @@ type MaryEraOnwardsConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -195,6 +195,7 @@ type ShelleyBasedEraConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
@@ -63,6 +63,7 @@ type ShelleyEraOnlyConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
@@ -66,6 +66,7 @@ type ShelleyToAllegraEraConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
@@ -68,6 +68,7 @@ type ShelleyToAlonzoEraConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
@@ -70,6 +70,7 @@ type ShelleyToBabbageEraConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
@@ -66,6 +66,7 @@ type ShelleyToMaryEraConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
   , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -219,9 +219,7 @@ evaluateTransactionFee _ _ _ _ byronwitcount | byronwitcount > 0 =
 evaluateTransactionFee sbe pp txbody keywitcount _byronwitcount =
   shelleyBasedEraConstraints sbe $
     case makeSignedTransaction [] txbody of
-      ByronTx ByronEraOnlyByron _ -> case sbe of {}
-      --TODO: we could actually support Byron here, it'd be different but simpler
-
+      ByronTx w _ -> disjointByronEraOnlyAndShelleyBasedEra w sbe
       ShelleyTx _ tx -> fromShelleyLovelace $ Ledger.evaluateTransactionFee pp tx keywitcount
 
 -- | Give an approximate count of the number of key witnesses (i.e. signatures)

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -218,7 +218,7 @@ evaluateTransactionFee _ _ _ _ byronwitcount | byronwitcount > 0 =
 
 evaluateTransactionFee sbe pp txbody keywitcount _byronwitcount =
   shelleyBasedEraConstraints sbe $
-    case makeSignedTransaction [] txbody of
+    case makeSignedTransaction' (shelleyBasedToCardanoEra sbe) [] txbody of
       ByronTx w _ -> disjointByronEraOnlyAndShelleyBasedEra w sbe
       ShelleyTx _ tx -> fromShelleyLovelace $ Ledger.evaluateTransactionFee pp tx keywitcount
 
@@ -455,15 +455,16 @@ instance Error TransactionValidityError where
 -- are actually used.
 --
 evaluateTransactionExecutionUnits :: forall era. ()
-  => SystemStart
+  => CardanoEra era
+  -> SystemStart
   -> LedgerEpochInfo
   -> LedgerProtocolParameters era
   -> UTxO era
   -> TxBody era
   -> Either TransactionValidityError
             (Map ScriptWitnessIndex (Either ScriptExecutionError ExecutionUnits))
-evaluateTransactionExecutionUnits systemstart epochInfo pp utxo txbody =
-    case makeSignedTransaction [] txbody of
+evaluateTransactionExecutionUnits era systemstart epochInfo pp utxo txbody =
+    case makeSignedTransaction' era [] txbody of
       ByronTx {}        -> evalPreAlonzo
       ShelleyTx sbe tx' -> evaluateTransactionExecutionUnitsShelley sbe systemstart epochInfo pp utxo tx'
   where
@@ -800,6 +801,7 @@ makeTransactionBodyAutoBalance sbe systemstart history lpp@(LedgerProtocolParame
 
     exUnitsMap <- first TxBodyErrorValidityInterval $
                     evaluateTransactionExecutionUnits
+                      era
                       systemstart history
                       lpp
                       utxo

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -656,7 +656,7 @@ instance ToJSON LocalTxMonitoringResult where
           ]
         where
           txId = case txInMode of
-            Just (TxInMode tx _) -> Just $ getTxId $ getTxBody tx
+            Just (TxInMode _ tx) -> Just $ getTxId $ getTxBody tx
             -- TODO: support fetching the ID of a Byron Era transaction
             _ -> Nothing
       LocalTxMonitoringMempoolSizeAndCapacity mempool slot ->

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -463,7 +463,7 @@ convLocalChainSyncClient mode =
     Net.Sync.mapChainSyncClient
       toConsensusPointHF
       fromConsensusPointHF
-      (fromConsensusBlock mode)
+      fromConsensusBlock
       (fromConsensusTip mode)
 
 convLocalChainSyncClientPipelined :: forall block m a. ()
@@ -476,7 +476,7 @@ convLocalChainSyncClientPipelined mode =
   mapChainSyncClientPipelined
     toConsensusPointHF
     fromConsensusPointHF
-    (fromConsensusBlock mode)
+    fromConsensusBlock
     (fromConsensusTip mode)
 
 convLocalTxSubmissionClient :: forall block m a. ()

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -170,14 +170,16 @@ type LocalNodeClientProtocolsInMode =
     (QueryInMode CardanoMode)
     IO
 
-data LocalNodeConnectInfo mode =
+data LocalNodeConnectInfo =
      LocalNodeConnectInfo {
-       localConsensusModeParams :: ConsensusModeParams mode,
+       localConsensusModeParams :: ConsensusModeParams CardanoMode,
        localNodeNetworkId       :: NetworkId,
        localNodeSocketPath      :: SocketPath
      }
 
-localConsensusMode :: LocalNodeConnectInfo mode -> ConsensusMode mode
+localConsensusMode :: ()
+  => LocalNodeConnectInfo
+  -> ConsensusMode CardanoMode
 localConsensusMode LocalNodeConnectInfo {localConsensusModeParams} =
     consensusModeOnly localConsensusModeParams
 
@@ -194,7 +196,7 @@ consensusModeOnly CardanoModeParams{} = CardanoMode
 -- protocol handlers.
 --
 connectToLocalNode :: ()
-  => LocalNodeConnectInfo CardanoMode
+  => LocalNodeConnectInfo
   -> LocalNodeClientProtocolsInMode
   -> IO ()
 connectToLocalNode localNodeConnectInfo handlers
@@ -205,7 +207,7 @@ connectToLocalNode localNodeConnectInfo handlers
 -- version.
 --
 connectToLocalNodeWithVersion :: ()
-  => LocalNodeConnectInfo CardanoMode
+  => LocalNodeConnectInfo
   -> (NodeToClientVersion -> LocalNodeClientProtocolsInMode)
   -> IO ()
 connectToLocalNodeWithVersion LocalNodeConnectInfo {
@@ -554,7 +556,7 @@ toAcquiringFailure AcquireFailurePointTooOld = AFPointTooOld
 toAcquiringFailure AcquireFailurePointNotOnChain = AFPointNotOnChain
 
 queryNodeLocalState :: forall result. ()
-  => LocalNodeConnectInfo CardanoMode
+  => LocalNodeConnectInfo
   -> Maybe ChainPoint
   -> QueryInMode CardanoMode result
   -> IO (Either AcquiringFailure result)
@@ -594,7 +596,7 @@ queryNodeLocalState connctInfo mpoint query = do
           }
 
 submitTxToNodeLocal :: ()
-  => LocalNodeConnectInfo CardanoMode
+  => LocalNodeConnectInfo
   -> TxInMode CardanoMode
   -> IO (Net.Tx.SubmitResult TxValidationErrorInCardanoMode)
 submitTxToNodeLocal connctInfo tx = do
@@ -678,7 +680,7 @@ data LocalTxMonitoringQuery mode
 
 
 queryTxMonitoringLocal :: ()
-  => LocalNodeConnectInfo CardanoMode
+  => LocalNodeConnectInfo
   -> LocalTxMonitoringQuery CardanoMode
   -> IO (LocalTxMonitoringResult CardanoMode)
 queryTxMonitoringLocal connectInfo localTxMonitoringQuery = do
@@ -740,7 +742,7 @@ queryTxMonitoringLocal connectInfo localTxMonitoringQuery = do
 --
 
 getLocalChainTip :: ()
-  => LocalNodeConnectInfo CardanoMode
+  => LocalNodeConnectInfo
   -> IO ChainTip
 getLocalChainTip localNodeConInfo = do
     resultVar <- newEmptyTMVarIO

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -419,11 +419,11 @@ mkLocalNodeClientParams modeparams clients =
          (convLocalNodeClientProtocols CardanoMode . clients)
 
 
-convLocalNodeClientProtocols :: forall mode block.
-                                ConsensusBlockForMode mode ~ block
-                             => ConsensusMode mode
-                             -> LocalNodeClientProtocolsInMode mode
-                             -> LocalNodeClientProtocolsForBlock block
+convLocalNodeClientProtocols :: forall block. ()
+  => ConsensusBlockForMode CardanoMode ~ block
+  => ConsensusMode CardanoMode
+  -> LocalNodeClientProtocolsInMode CardanoMode
+  -> LocalNodeClientProtocolsForBlock block
 convLocalNodeClientProtocols
     mode
     LocalNodeClientProtocols {
@@ -438,15 +438,9 @@ convLocalNodeClientProtocols
         LocalChainSyncClientPipelined clientPipelined -> LocalChainSyncClientPipelined $ convLocalChainSyncClientPipelined mode clientPipelined
         LocalChainSyncClient client -> LocalChainSyncClient $ convLocalChainSyncClient mode client,
 
-      localTxSubmissionClientForBlock = convLocalTxSubmissionClient mode <$>
-                                          localTxSubmissionClient,
-
-      localStateQueryClientForBlock   = convLocalStateQueryClient mode <$>
-                                          localStateQueryClient,
-
-      localTxMonitoringClientForBlock = convLocalTxMonitoringClient mode <$>
-                                          localTxMonitoringClient
-
+      localTxSubmissionClientForBlock = convLocalTxSubmissionClient mode <$> localTxSubmissionClient,
+      localStateQueryClientForBlock   = convLocalStateQueryClient   mode <$> localStateQueryClient,
+      localTxMonitoringClientForBlock = convLocalTxMonitoringClient mode <$> localTxMonitoringClient
     }
 
 convLocalTxMonitoringClient
@@ -500,12 +494,12 @@ convLocalTxSubmissionClient mode =
 
 
 convLocalStateQueryClient
-  :: forall mode block m a.
-     (ConsensusBlockForMode mode ~ block, Functor m)
-  => ConsensusMode mode
-  -> LocalStateQueryClient (BlockInMode mode) ChainPoint (QueryInMode mode) m a
-  -> LocalStateQueryClient block (Consensus.Point block)
-                           (Consensus.Query block) m a
+  :: forall block m a. ()
+  => ConsensusBlockForMode CardanoMode ~ block
+  => Functor m
+  => ConsensusMode CardanoMode
+  -> LocalStateQueryClient (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) m a
+  -> LocalStateQueryClient block (Consensus.Point block) (Consensus.Query block) m a
 convLocalStateQueryClient mode =
     Net.Query.mapLocalStateQueryClient
       (toConsensusPointInMode mode)

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -160,7 +160,7 @@ data LocalChainSyncClient block point tip m
 -- public, exported
 type LocalNodeClientProtocolsInMode =
   LocalNodeClientProtocols
-    (BlockInMode CardanoMode)
+    BlockInMode
     ChainPoint
     ChainTip
     SlotNo
@@ -456,7 +456,7 @@ convLocalChainSyncClient
   => ConsensusBlockForMode CardanoMode ~ block
   => Functor m
   => ConsensusMode CardanoMode
-  -> ChainSyncClient (BlockInMode CardanoMode) ChainPoint ChainTip m a
+  -> ChainSyncClient BlockInMode ChainPoint ChainTip m a
   -> ChainSyncClient block (Net.Point block) (Net.Tip block) m a
 convLocalChainSyncClient mode =
     Net.Sync.mapChainSyncClient
@@ -469,7 +469,7 @@ convLocalChainSyncClientPipelined :: forall block m a. ()
   => ConsensusBlockForMode CardanoMode ~ block
   => Functor m
   => ConsensusMode CardanoMode
-  -> ChainSyncClientPipelined (BlockInMode CardanoMode) ChainPoint ChainTip m a
+  -> ChainSyncClientPipelined BlockInMode ChainPoint ChainTip m a
   -> ChainSyncClientPipelined block (Net.Point block) (Net.Tip block) m a
 convLocalChainSyncClientPipelined mode =
   mapChainSyncClientPipelined
@@ -495,7 +495,7 @@ convLocalStateQueryClient
   => ConsensusBlockForMode CardanoMode ~ block
   => Functor m
   => ConsensusMode CardanoMode
-  -> LocalStateQueryClient (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) m a
+  -> LocalStateQueryClient BlockInMode ChainPoint (QueryInMode CardanoMode) m a
   -> LocalStateQueryClient block (Consensus.Point block) (Consensus.Query block) m a
 convLocalStateQueryClient mode =
     Net.Query.mapLocalStateQueryClient
@@ -576,7 +576,7 @@ queryNodeLocalState connctInfo mpoint query = do
     singleQuery
       :: Maybe ChainPoint
       -> TMVar (Either AcquiringFailure result)
-      -> Net.Query.LocalStateQueryClient (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) IO ()
+      -> Net.Query.LocalStateQueryClient BlockInMode ChainPoint (QueryInMode CardanoMode) IO ()
     singleQuery mPointVar' resultVar' =
       LocalStateQueryClient $ do
       pure $
@@ -759,15 +759,15 @@ getLocalChainTip localNodeConInfo = do
 
 chainSyncGetCurrentTip :: ()
   => TMVar ChainTip
-  -> ChainSyncClient (BlockInMode CardanoMode) ChainPoint ChainTip IO ()
+  -> ChainSyncClient BlockInMode ChainPoint ChainTip IO ()
 chainSyncGetCurrentTip tipVar =
   ChainSyncClient $ pure clientStIdle
  where
-  clientStIdle :: Net.Sync.ClientStIdle (BlockInMode mode) ChainPoint ChainTip IO ()
+  clientStIdle :: Net.Sync.ClientStIdle BlockInMode ChainPoint ChainTip IO ()
   clientStIdle =
     Net.Sync.SendMsgRequestNext clientStNext (pure clientStNext)
 
-  clientStNext :: Net.Sync.ClientStNext (BlockInMode mode) ChainPoint ChainTip IO ()
+  clientStNext :: Net.Sync.ClientStNext BlockInMode ChainPoint ChainTip IO ()
   clientStNext = Net.Sync.ClientStNext
     { Net.Sync.recvMsgRollForward = \_block tip -> ChainSyncClient $ do
         void $ atomically $ tryPutTMVar tipVar tip

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -20,7 +20,6 @@ module Cardano.Api.IPC (
     connectToLocalNode,
     connectToLocalNodeWithVersion,
     LocalNodeConnectInfo(..),
-    localConsensusMode,
     LocalNodeClientParams(..),
     mkLocalNodeClientParams,
     LocalNodeClientProtocols(..),
@@ -72,7 +71,6 @@ module Cardano.Api.IPC (
     -- *** Helpers
     --TODO: These should be exported via Cardano.Api.Mode
     ConsensusMode(..),
-    consensusModeOnly,
     toAcquiringFailure,
 
     NodeToClientVersion(..),
@@ -177,17 +175,6 @@ data LocalNodeConnectInfo =
     , localNodeNetworkId        :: NetworkId
     , localNodeSocketPath       :: SocketPath
     }
-
-localConsensusMode :: ()
-  => LocalNodeConnectInfo
-  -> ConsensusMode CardanoMode
-localConsensusMode LocalNodeConnectInfo {localConsensusModeParams} =
-    consensusModeOnly localConsensusModeParams
-
-consensusModeOnly :: ()
-  => ConsensusModeParams
-  -> ConsensusMode CardanoMode
-consensusModeOnly CardanoModeParams{} = CardanoMode
 
 -- ----------------------------------------------------------------------------
 -- Actually connect to the node

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -92,7 +92,9 @@ import           Cardano.Api.Query
 import           Cardano.Api.Tx (getTxBody)
 import           Cardano.Api.TxBody
 
+import qualified Cardano.Ledger.Api as L
 import qualified Ouroboros.Consensus.Block as Consensus
+import qualified Ouroboros.Consensus.Cardano.Block as Consensus
 import           Ouroboros.Consensus.Cardano.CanHardFork
 import qualified Ouroboros.Consensus.Ledger.Query as Consensus
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Consensus
@@ -101,7 +103,6 @@ import qualified Ouroboros.Consensus.Network.NodeToClient as Consensus
 import qualified Ouroboros.Consensus.Node.NetworkProtocolVersion as Consensus
 import qualified Ouroboros.Consensus.Node.ProtocolInfo as Consensus
 import qualified Ouroboros.Consensus.Protocol.TPraos as Consensus
-import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Consensus
 import           Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 import qualified Ouroboros.Network.Block as Net
@@ -393,7 +394,7 @@ data LocalNodeClientProtocolsForBlock block =
 -- | Convert from the mode-parametrised style to the block-parametrised style.
 --
 mkLocalNodeClientParams :: forall block. ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => ConsensusModeParams CardanoMode
   -> (NodeToClientVersion -> LocalNodeClientProtocolsInMode)
   -> LocalNodeClientParams
@@ -417,7 +418,7 @@ mkLocalNodeClientParams modeparams clients =
 
 
 convLocalNodeClientProtocols :: forall block. ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => ConsensusMode CardanoMode
   -> LocalNodeClientProtocolsInMode
   -> LocalNodeClientProtocolsForBlock block
@@ -441,7 +442,7 @@ convLocalNodeClientProtocols
     }
 
 convLocalTxMonitoringClient :: forall block m a. ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => Functor m
   => ConsensusMode CardanoMode
   -> LocalTxMonitorClient TxIdInMode TxInMode SlotNo m a
@@ -453,7 +454,7 @@ convLocalTxMonitoringClient mode =
 
 convLocalChainSyncClient
   :: forall block m a. ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => Functor m
   => ConsensusMode CardanoMode
   -> ChainSyncClient BlockInMode ChainPoint ChainTip m a
@@ -466,7 +467,7 @@ convLocalChainSyncClient mode =
       (fromConsensusTip mode)
 
 convLocalChainSyncClientPipelined :: forall block m a. ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => Functor m
   => ConsensusMode CardanoMode
   -> ChainSyncClientPipelined BlockInMode ChainPoint ChainTip m a
@@ -479,7 +480,7 @@ convLocalChainSyncClientPipelined mode =
     (fromConsensusTip mode)
 
 convLocalTxSubmissionClient :: forall block m a. ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => Functor m
   => ConsensusMode CardanoMode
   -> LocalTxSubmissionClient TxInMode TxValidationErrorInCardanoMode m a
@@ -492,7 +493,7 @@ convLocalTxSubmissionClient mode =
 
 convLocalStateQueryClient
   :: forall block m a. ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => Functor m
   => ConsensusMode CardanoMode
   -> LocalStateQueryClient BlockInMode ChainPoint (QueryInMode CardanoMode) m a

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -149,7 +149,7 @@ data LocalNodeClientProtocols block point tip slot tx txid txerr query m =
     { localChainSyncClient    :: LocalChainSyncClient block point tip m
     , localTxSubmissionClient :: Maybe (LocalTxSubmissionClient tx txerr m ())
     , localStateQueryClient   :: Maybe (LocalStateQueryClient block point query m ())
-    , localTxMonitoringClient :: Maybe (LocalTxMonitorClient txid tx slot m ())
+    , localTxMonitoringClient :: Maybe (LocalTxMonitorClient (TxIdInMode CardanoMode) tx slot m ())
     }
 
 data LocalChainSyncClient block point tip m

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -28,7 +28,6 @@ module Cardano.Api.IPC (
 
     -- ** Modes
     -- | TODO move to Cardano.Api
-    CardanoMode,
     ConsensusModeParams(..),
     EpochSlots(..),
 
@@ -70,7 +69,6 @@ module Cardano.Api.IPC (
 
     -- *** Helpers
     --TODO: These should be exported via Cardano.Api.Mode
-    ConsensusMode(..),
     toAcquiringFailure,
 
     NodeToClientVersion(..),

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -165,7 +165,7 @@ type LocalNodeClientProtocolsInMode =
     ChainTip
     SlotNo
     TxInMode
-    (TxIdInMode CardanoMode)
+    TxIdInMode
     TxValidationErrorInCardanoMode
     (QueryInMode CardanoMode)
     IO
@@ -444,7 +444,7 @@ convLocalTxMonitoringClient :: forall block m a. ()
   => ConsensusBlockForMode CardanoMode ~ block
   => Functor m
   => ConsensusMode CardanoMode
-  -> LocalTxMonitorClient (TxIdInMode CardanoMode)  TxInMode SlotNo m a
+  -> LocalTxMonitorClient TxIdInMode TxInMode SlotNo m a
   -> LocalTxMonitorClient (Consensus.TxId (Consensus.GenTx block)) (Consensus.GenTx block) SlotNo m a
 convLocalTxMonitoringClient mode =
   mapLocalTxMonitoringClient
@@ -669,7 +669,7 @@ data LocalTxMonitoringQuery
   -- | Query if a particular tx exists in the mempool. Note that, the absence
   -- of a transaction does not imply anything about how the transaction was
   -- processed: it may have been dropped, or inserted in a block.
-  = LocalTxMonitoringQueryTx (TxIdInMode CardanoMode)
+  = LocalTxMonitoringQueryTx TxIdInMode
   -- | The mempool is modeled as an ordered list of transactions and thus, can
   -- be traversed linearly. 'LocalTxMonitoringSendNextTx' requests the next transaction from the
   -- current list. This must be a transaction that was not previously sent to
@@ -706,10 +706,10 @@ queryTxMonitoringLocal connectInfo localTxMonitoringQuery = do
   atomically (takeTMVar resultVar)
  where
   localTxMonitorClientTxExists :: ()
-    => TxIdInMode CardanoMode
+    => TxIdInMode
     -> TMVar LocalTxMonitoringResult
-    -> LocalTxMonitorClient (TxIdInMode CardanoMode) TxInMode SlotNo IO ()
-  localTxMonitorClientTxExists tIdInMode@(TxIdInMode txid _) resultVar = do
+    -> LocalTxMonitorClient TxIdInMode TxInMode SlotNo IO ()
+  localTxMonitorClientTxExists tIdInMode@(TxIdInMode _ txid) resultVar = do
     LocalTxMonitorClient $ return $
       CTxMon.SendMsgAcquire $ \slt -> do
          return $ CTxMon.SendMsgHasTx tIdInMode $ \txPresentBool -> do
@@ -720,7 +720,7 @@ queryTxMonitoringLocal connectInfo localTxMonitoringQuery = do
 
   localTxMonitorNextTx :: ()
     => TMVar LocalTxMonitoringResult
-    -> LocalTxMonitorClient (TxIdInMode CardanoMode) TxInMode SlotNo IO ()
+    -> LocalTxMonitorClient TxIdInMode TxInMode SlotNo IO ()
   localTxMonitorNextTx resultVar =
     LocalTxMonitorClient $ return $ do
       CTxMon.SendMsgAcquire $ \slt -> do
@@ -730,7 +730,7 @@ queryTxMonitoringLocal connectInfo localTxMonitoringQuery = do
 
   localTxMonitorMempoolInfo :: ()
     => TMVar LocalTxMonitoringResult
-    -> LocalTxMonitorClient (TxIdInMode CardanoMode) TxInMode SlotNo IO ()
+    -> LocalTxMonitorClient TxIdInMode TxInMode SlotNo IO ()
   localTxMonitorMempoolInfo resultVar =
      LocalTxMonitorClient $ return $ do
       CTxMon.SendMsgAcquire $ \slt -> do

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -172,11 +172,11 @@ type LocalNodeClientProtocolsInMode =
     IO
 
 data LocalNodeConnectInfo =
-     LocalNodeConnectInfo {
-       localConsensusModeParams :: ConsensusModeParams CardanoMode,
-       localNodeNetworkId       :: NetworkId,
-       localNodeSocketPath      :: SocketPath
-     }
+  LocalNodeConnectInfo
+    { localConsensusModeParams  :: ConsensusModeParams
+    , localNodeNetworkId        :: NetworkId
+    , localNodeSocketPath       :: SocketPath
+    }
 
 localConsensusMode :: ()
   => LocalNodeConnectInfo
@@ -185,7 +185,7 @@ localConsensusMode LocalNodeConnectInfo {localConsensusModeParams} =
     consensusModeOnly localConsensusModeParams
 
 consensusModeOnly :: ()
-  => ConsensusModeParams CardanoMode
+  => ConsensusModeParams
   -> ConsensusMode CardanoMode
 consensusModeOnly CardanoModeParams{} = CardanoMode
 
@@ -395,7 +395,7 @@ data LocalNodeClientProtocolsForBlock block =
 --
 mkLocalNodeClientParams :: forall block. ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block
-  => ConsensusModeParams CardanoMode
+  => ConsensusModeParams
   -> (NodeToClientVersion -> LocalNodeClientProtocolsInMode)
   -> LocalNodeClientParams
 mkLocalNodeClientParams modeparams clients =

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -183,10 +183,10 @@ localConsensusMode :: ()
 localConsensusMode LocalNodeConnectInfo {localConsensusModeParams} =
     consensusModeOnly localConsensusModeParams
 
-consensusModeOnly :: ConsensusModeParams mode
-                  -> ConsensusMode       mode
+consensusModeOnly :: ()
+  => ConsensusModeParams CardanoMode
+  -> ConsensusMode CardanoMode
 consensusModeOnly CardanoModeParams{} = CardanoMode
-
 
 -- ----------------------------------------------------------------------------
 -- Actually connect to the node
@@ -452,10 +452,11 @@ convLocalTxMonitoringClient mode =
     (fromConsensusGenTx mode)
 
 convLocalChainSyncClient
-  :: forall mode block m a.
-     (ConsensusBlockForMode mode ~ block, Functor m)
-  => ConsensusMode mode
-  -> ChainSyncClient (BlockInMode mode) ChainPoint ChainTip m a
+  :: forall block m a. ()
+  => ConsensusBlockForMode CardanoMode ~ block
+  => Functor m
+  => ConsensusMode CardanoMode
+  -> ChainSyncClient (BlockInMode CardanoMode) ChainPoint ChainTip m a
   -> ChainSyncClient block (Net.Point block) (Net.Tip block) m a
 convLocalChainSyncClient mode =
     Net.Sync.mapChainSyncClient
@@ -464,11 +465,11 @@ convLocalChainSyncClient mode =
       (fromConsensusBlock mode)
       (fromConsensusTip mode)
 
-convLocalChainSyncClientPipelined
-  :: forall mode block m a.
-     (ConsensusBlockForMode mode ~ block, Functor m)
-  => ConsensusMode mode
-  -> ChainSyncClientPipelined (BlockInMode mode) ChainPoint ChainTip m a
+convLocalChainSyncClientPipelined :: forall block m a. ()
+  => ConsensusBlockForMode CardanoMode ~ block
+  => Functor m
+  => ConsensusMode CardanoMode
+  -> ChainSyncClientPipelined (BlockInMode CardanoMode) ChainPoint ChainTip m a
   -> ChainSyncClientPipelined block (Net.Point block) (Net.Tip block) m a
 convLocalChainSyncClientPipelined mode =
   mapChainSyncClientPipelined
@@ -504,8 +505,8 @@ convLocalStateQueryClient mode =
 
 
 --TODO: Move to consensus
-mapLocalTxMonitoringClient
-  :: forall txid txid' tx tx' m a. Functor m
+mapLocalTxMonitoringClient :: forall txid txid' tx tx' m a. ()
+  => Functor m
   => (txid -> txid')
   -> (tx'-> tx)
   -> LocalTxMonitorClient txid tx SlotNo m a
@@ -756,9 +757,9 @@ getLocalChainTip localNodeConInfo = do
         }
     atomically $ takeTMVar resultVar
 
-chainSyncGetCurrentTip
-  :: forall mode. TMVar ChainTip
-  -> ChainSyncClient (BlockInMode mode) ChainPoint ChainTip IO ()
+chainSyncGetCurrentTip :: ()
+  => TMVar ChainTip
+  -> ChainSyncClient (BlockInMode CardanoMode) ChainPoint ChainTip IO ()
 chainSyncGetCurrentTip tipVar =
   ChainSyncClient $ pure clientStIdle
  where

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -437,7 +437,7 @@ convLocalNodeClientProtocols
         LocalChainSyncClient client -> LocalChainSyncClient $ convLocalChainSyncClient mode client,
 
       localTxSubmissionClientForBlock = convLocalTxSubmissionClient      <$> localTxSubmissionClient,
-      localStateQueryClientForBlock   = convLocalStateQueryClient   mode <$> localStateQueryClient,
+      localStateQueryClientForBlock   = convLocalStateQueryClient        <$> localStateQueryClient,
       localTxMonitoringClientForBlock = convLocalTxMonitoringClient mode <$> localTxMonitoringClient
     }
 
@@ -461,7 +461,7 @@ convLocalChainSyncClient
   -> ChainSyncClient block (Net.Point block) (Net.Tip block) m a
 convLocalChainSyncClient mode =
     Net.Sync.mapChainSyncClient
-      (toConsensusPointInMode mode)
+      toConsensusPointHF
       fromConsensusPointHF
       (fromConsensusBlock mode)
       (fromConsensusTip mode)
@@ -474,7 +474,7 @@ convLocalChainSyncClientPipelined :: forall block m a. ()
   -> ChainSyncClientPipelined block (Net.Point block) (Net.Tip block) m a
 convLocalChainSyncClientPipelined mode =
   mapChainSyncClientPipelined
-    (toConsensusPointInMode mode)
+    toConsensusPointHF
     fromConsensusPointHF
     (fromConsensusBlock mode)
     (fromConsensusTip mode)
@@ -491,15 +491,13 @@ convLocalStateQueryClient
   :: forall block m a. ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block
   => Functor m
-  => ConsensusMode CardanoMode
-  -> LocalStateQueryClient BlockInMode ChainPoint (QueryInMode CardanoMode) m a
+  => LocalStateQueryClient BlockInMode ChainPoint (QueryInMode CardanoMode) m a
   -> LocalStateQueryClient block (Consensus.Point block) (Consensus.Query block) m a
-convLocalStateQueryClient mode =
+convLocalStateQueryClient =
     Net.Query.mapLocalStateQueryClient
-      (toConsensusPointInMode mode)
+      toConsensusPointHF
       toConsensusQuery
       fromConsensusQueryResult
-
 
 --TODO: Move to consensus
 mapLocalTxMonitoringClient :: forall txid txid' tx tx' m a. ()

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -30,7 +30,6 @@ module Cardano.Api.IPC (
     -- ** Modes
     -- | TODO move to Cardano.Api
     ByronMode,
-    ShelleyMode,
     CardanoMode,
     ConsensusModeParams(..),
     EpochSlots(..),
@@ -193,7 +192,6 @@ localConsensusMode LocalNodeConnectInfo {localConsensusModeParams} =
 consensusModeOnly :: ConsensusModeParams mode
                   -> ConsensusMode       mode
 consensusModeOnly ByronModeParams{}   = ByronMode
-consensusModeOnly ShelleyModeParams{} = ShelleyMode
 consensusModeOnly CardanoModeParams{} = CardanoMode
 
 
@@ -421,11 +419,6 @@ mkLocalNodeClientParams modeparams clients =
         LocalNodeClientParamsSingleBlock
           (ProtocolClientInfoArgsByron epochSlots)
           (convLocalNodeClientProtocols ByronMode . clients)
-
-      ShelleyModeParams ->
-        LocalNodeClientParamsSingleBlock
-          ProtocolClientInfoArgsShelley
-          (convLocalNodeClientProtocols ShelleyMode . clients)
 
       CardanoModeParams epochSlots ->
        LocalNodeClientParamsCardano

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -436,7 +436,7 @@ convLocalNodeClientProtocols
         LocalChainSyncClientPipelined clientPipelined -> LocalChainSyncClientPipelined $ convLocalChainSyncClientPipelined mode clientPipelined
         LocalChainSyncClient client -> LocalChainSyncClient $ convLocalChainSyncClient mode client,
 
-      localTxSubmissionClientForBlock = convLocalTxSubmissionClient mode <$> localTxSubmissionClient,
+      localTxSubmissionClientForBlock = convLocalTxSubmissionClient      <$> localTxSubmissionClient,
       localStateQueryClientForBlock   = convLocalStateQueryClient   mode <$> localStateQueryClient,
       localTxMonitoringClientForBlock = convLocalTxMonitoringClient mode <$> localTxMonitoringClient
     }
@@ -482,14 +482,10 @@ convLocalChainSyncClientPipelined mode =
 convLocalTxSubmissionClient :: forall block m a. ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block
   => Functor m
-  => ConsensusMode CardanoMode
-  -> LocalTxSubmissionClient TxInMode TxValidationErrorInCardanoMode m a
+  => LocalTxSubmissionClient TxInMode TxValidationErrorInCardanoMode m a
   -> LocalTxSubmissionClient (Consensus.GenTx block) (Consensus.ApplyTxErr block) m a
-convLocalTxSubmissionClient mode =
-    Net.Tx.mapLocalTxSubmissionClient
-      toConsensusGenTx
-      (fromConsensusApplyTxErr mode)
-
+convLocalTxSubmissionClient =
+  Net.Tx.mapLocalTxSubmissionClient toConsensusGenTx fromConsensusApplyTxErr
 
 convLocalStateQueryClient
   :: forall block m a. ()

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -168,7 +168,7 @@ type LocalNodeClientProtocolsInMode =
     TxInMode
     TxIdInMode
     TxValidationErrorInCardanoMode
-    (QueryInMode CardanoMode)
+    QueryInMode
     IO
 
 data LocalNodeConnectInfo =
@@ -486,7 +486,7 @@ convLocalStateQueryClient
   :: forall block m a. ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block
   => Functor m
-  => LocalStateQueryClient BlockInMode ChainPoint (QueryInMode CardanoMode) m a
+  => LocalStateQueryClient BlockInMode ChainPoint QueryInMode m a
   -> LocalStateQueryClient block (Consensus.Point block) (Consensus.Query block) m a
 convLocalStateQueryClient =
     Net.Query.mapLocalStateQueryClient
@@ -549,7 +549,7 @@ toAcquiringFailure AcquireFailurePointNotOnChain = AFPointNotOnChain
 queryNodeLocalState :: forall result. ()
   => LocalNodeConnectInfo
   -> Maybe ChainPoint
-  -> QueryInMode CardanoMode result
+  -> QueryInMode result
   -> IO (Either AcquiringFailure result)
 queryNodeLocalState connctInfo mpoint query = do
     resultVar <- newEmptyTMVarIO
@@ -566,7 +566,7 @@ queryNodeLocalState connctInfo mpoint query = do
     singleQuery
       :: Maybe ChainPoint
       -> TMVar (Either AcquiringFailure result)
-      -> Net.Query.LocalStateQueryClient BlockInMode ChainPoint (QueryInMode CardanoMode) IO ()
+      -> Net.Query.LocalStateQueryClient BlockInMode ChainPoint QueryInMode IO ()
     singleQuery mPointVar' resultVar' =
       LocalStateQueryClient $ do
       pure $

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -145,19 +145,12 @@ import           Data.Void (Void)
 -- 'connectToLocalNode'.
 --
 data LocalNodeClientProtocols block point tip slot tx txid txerr query m =
-     LocalNodeClientProtocols {
-       localChainSyncClient
-         :: LocalChainSyncClient block point tip m
-
-     , localTxSubmissionClient
-         :: Maybe (LocalTxSubmissionClient tx txerr          m ())
-
-     , localStateQueryClient
-         :: Maybe (LocalStateQueryClient   block point query m ())
-
-     , localTxMonitoringClient
-         :: Maybe (LocalTxMonitorClient txid tx slot m ())
-     }
+  LocalNodeClientProtocols
+    { localChainSyncClient    :: LocalChainSyncClient block point tip m
+    , localTxSubmissionClient :: Maybe (LocalTxSubmissionClient tx txerr m ())
+    , localStateQueryClient   :: Maybe (LocalStateQueryClient block point query m ())
+    , localTxMonitoringClient :: Maybe (LocalTxMonitorClient txid tx slot m ())
+    }
 
 data LocalChainSyncClient block point tip m
   = NoLocalChainSyncClient
@@ -166,16 +159,16 @@ data LocalChainSyncClient block point tip m
 
 -- public, exported
 type LocalNodeClientProtocolsInMode =
-       LocalNodeClientProtocols
-         (BlockInMode CardanoMode)
-         ChainPoint
-         ChainTip
-         SlotNo
-         (TxInMode CardanoMode)
-         (TxIdInMode CardanoMode)
-         (TxValidationErrorInMode CardanoMode)
-         (QueryInMode CardanoMode)
-         IO
+  LocalNodeClientProtocols
+    (BlockInMode CardanoMode)
+    ChainPoint
+    ChainTip
+    SlotNo
+    (TxInMode CardanoMode)
+    (TxIdInMode CardanoMode)
+    (TxValidationErrorInMode CardanoMode)
+    (QueryInMode CardanoMode)
+    IO
 
 data LocalNodeConnectInfo mode =
      LocalNodeConnectInfo {

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -462,7 +462,7 @@ convLocalChainSyncClient
 convLocalChainSyncClient mode =
     Net.Sync.mapChainSyncClient
       (toConsensusPointInMode mode)
-      (fromConsensusPointInMode mode)
+      fromConsensusPointHF
       (fromConsensusBlock mode)
       (fromConsensusTip mode)
 
@@ -475,7 +475,7 @@ convLocalChainSyncClientPipelined :: forall block m a. ()
 convLocalChainSyncClientPipelined mode =
   mapChainSyncClientPipelined
     (toConsensusPointInMode mode)
-    (fromConsensusPointInMode mode)
+    fromConsensusPointHF
     (fromConsensusBlock mode)
     (fromConsensusTip mode)
 

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -29,7 +29,6 @@ module Cardano.Api.IPC (
 
     -- ** Modes
     -- | TODO move to Cardano.Api
-    ByronMode,
     CardanoMode,
     ConsensusModeParams(..),
     EpochSlots(..),
@@ -191,7 +190,6 @@ localConsensusMode LocalNodeConnectInfo {localConsensusModeParams} =
 
 consensusModeOnly :: ConsensusModeParams mode
                   -> ConsensusMode       mode
-consensusModeOnly ByronModeParams{}   = ByronMode
 consensusModeOnly CardanoModeParams{} = CardanoMode
 
 
@@ -415,11 +413,6 @@ mkLocalNodeClientParams modeparams clients =
     -- block type monomorphic.
     --
     case modeparams of
-      ByronModeParams epochSlots ->
-        LocalNodeClientParamsSingleBlock
-          (ProtocolClientInfoArgsByron epochSlots)
-          (convLocalNodeClientProtocols ByronMode . clients)
-
       CardanoModeParams epochSlots ->
        LocalNodeClientParamsCardano
          (ProtocolClientInfoArgsCardano epochSlots)

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -149,7 +149,7 @@ data LocalNodeClientProtocols block point tip slot tx txid txerr query m =
     { localChainSyncClient    :: LocalChainSyncClient block point tip m
     , localTxSubmissionClient :: Maybe (LocalTxSubmissionClient tx txerr m ())
     , localStateQueryClient   :: Maybe (LocalStateQueryClient block point query m ())
-    , localTxMonitoringClient :: Maybe (LocalTxMonitorClient (TxIdInMode CardanoMode) tx slot m ())
+    , localTxMonitoringClient :: Maybe (LocalTxMonitorClient txid tx slot m ())
     }
 
 data LocalChainSyncClient block point tip m

--- a/cardano-api/internal/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/internal/Cardano/Api/IPC/Monad.hs
@@ -40,8 +40,8 @@ newtype LocalStateQueryExpr block point query r m a = LocalStateQueryExpr
   } deriving (Functor, Applicative, Monad, MonadReader NodeToClientVersion, MonadIO)
 
 -- | Execute a local state query expression.
-executeLocalStateQueryExpr
-  :: LocalNodeConnectInfo CardanoMode
+executeLocalStateQueryExpr :: ()
+  => LocalNodeConnectInfo
   -> Maybe ChainPoint
   -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a
   -> IO (Either AcquiringFailure a)

--- a/cardano-api/internal/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/internal/Cardano/Api/IPC/Monad.hs
@@ -43,7 +43,7 @@ newtype LocalStateQueryExpr block point query r m a = LocalStateQueryExpr
 executeLocalStateQueryExpr :: ()
   => LocalNodeConnectInfo
   -> Maybe ChainPoint
-  -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a
+  -> LocalStateQueryExpr BlockInMode ChainPoint (QueryInMode CardanoMode) () IO a
   -> IO (Either AcquiringFailure a)
 executeLocalStateQueryExpr connectInfo mpoint f = do
   tmvResultLocalState <- newEmptyTMVarIO
@@ -71,8 +71,8 @@ setupLocalStateQueryExpr ::
   -> Maybe ChainPoint
   -> TMVar (Either AcquiringFailure a)
   -> NodeToClientVersion
-  -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a
-  -> Net.Query.LocalStateQueryClient (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) IO ()
+  -> LocalStateQueryExpr BlockInMode ChainPoint (QueryInMode CardanoMode) () IO a
+  -> Net.Query.LocalStateQueryClient BlockInMode ChainPoint (QueryInMode CardanoMode) IO ()
 setupLocalStateQueryExpr waitDone mPointVar' resultVar' ntcVersion f =
   LocalStateQueryClient . pure . Net.Query.SendMsgAcquire mPointVar' $
     Net.Query.ClientStAcquiring

--- a/cardano-api/internal/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/internal/Cardano/Api/IPC/Monad.hs
@@ -43,7 +43,7 @@ newtype LocalStateQueryExpr block point query r m a = LocalStateQueryExpr
 executeLocalStateQueryExpr :: ()
   => LocalNodeConnectInfo
   -> Maybe ChainPoint
-  -> LocalStateQueryExpr BlockInMode ChainPoint (QueryInMode CardanoMode) () IO a
+  -> LocalStateQueryExpr BlockInMode ChainPoint QueryInMode () IO a
   -> IO (Either AcquiringFailure a)
 executeLocalStateQueryExpr connectInfo mpoint f = do
   tmvResultLocalState <- newEmptyTMVarIO
@@ -71,8 +71,8 @@ setupLocalStateQueryExpr ::
   -> Maybe ChainPoint
   -> TMVar (Either AcquiringFailure a)
   -> NodeToClientVersion
-  -> LocalStateQueryExpr BlockInMode ChainPoint (QueryInMode CardanoMode) () IO a
-  -> Net.Query.LocalStateQueryClient BlockInMode ChainPoint (QueryInMode CardanoMode) IO ()
+  -> LocalStateQueryExpr BlockInMode ChainPoint QueryInMode () IO a
+  -> Net.Query.LocalStateQueryClient BlockInMode ChainPoint QueryInMode IO ()
 setupLocalStateQueryExpr waitDone mPointVar' resultVar' ntcVersion f =
   LocalStateQueryClient . pure . Net.Query.SendMsgAcquire mPointVar' $
     Net.Query.ClientStAcquiring
@@ -88,11 +88,11 @@ setupLocalStateQueryExpr waitDone mPointVar' resultVar' ntcVersion f =
     }
 
 -- | Get the node server's Node-to-Client version.
-getNtcVersion :: LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO NodeToClientVersion
+getNtcVersion :: LocalStateQueryExpr block point QueryInMode r IO NodeToClientVersion
 getNtcVersion = LocalStateQueryExpr ask
 
 -- | Use 'queryExpr' in a do block to construct monadic local state queries.
-queryExpr :: QueryInMode CardanoMode a -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError a)
+queryExpr :: QueryInMode a -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError a)
 queryExpr q = do
   let minNtcVersion = nodeToClientVersionOf q
   ntcVersion <- getNtcVersion

--- a/cardano-api/internal/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/internal/Cardano/Api/IPC/Monad.hs
@@ -41,9 +41,9 @@ newtype LocalStateQueryExpr block point query r m a = LocalStateQueryExpr
 
 -- | Execute a local state query expression.
 executeLocalStateQueryExpr
-  :: LocalNodeConnectInfo mode
+  :: LocalNodeConnectInfo CardanoMode
   -> Maybe ChainPoint
-  -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a
+  -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a
   -> IO (Either AcquiringFailure a)
 executeLocalStateQueryExpr connectInfo mpoint f = do
   tmvResultLocalState <- newEmptyTMVarIO

--- a/cardano-api/internal/Cardano/Api/IPC/Monad.hs
+++ b/cardano-api/internal/Cardano/Api/IPC/Monad.hs
@@ -71,8 +71,8 @@ setupLocalStateQueryExpr ::
   -> Maybe ChainPoint
   -> TMVar (Either AcquiringFailure a)
   -> NodeToClientVersion
-  -> LocalStateQueryExpr (BlockInMode mode) ChainPoint (QueryInMode mode) () IO a
-  -> Net.Query.LocalStateQueryClient (BlockInMode mode) ChainPoint (QueryInMode mode) IO ()
+  -> LocalStateQueryExpr (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) () IO a
+  -> Net.Query.LocalStateQueryClient (BlockInMode CardanoMode) ChainPoint (QueryInMode CardanoMode) IO ()
 setupLocalStateQueryExpr waitDone mPointVar' resultVar' ntcVersion f =
   LocalStateQueryClient . pure . Net.Query.SendMsgAcquire mPointVar' $
     Net.Query.ClientStAcquiring
@@ -88,11 +88,11 @@ setupLocalStateQueryExpr waitDone mPointVar' resultVar' ntcVersion f =
     }
 
 -- | Get the node server's Node-to-Client version.
-getNtcVersion :: LocalStateQueryExpr block point (QueryInMode mode) r IO NodeToClientVersion
+getNtcVersion :: LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO NodeToClientVersion
 getNtcVersion = LocalStateQueryExpr ask
 
 -- | Use 'queryExpr' in a do block to construct monadic local state queries.
-queryExpr :: QueryInMode mode a -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError a)
+queryExpr :: QueryInMode CardanoMode a -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError a)
 queryExpr q = do
   let minNtcVersion = nodeToClientVersionOf q
   ntcVersion <- getNtcVersion

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -59,8 +59,8 @@ data TxInMode where
   -- | Everything we consider a normal transaction.
   --
   TxInMode
-    :: Tx era
-    -> EraInMode era CardanoMode
+    :: CardanoEra era
+    -> Tx era
     -> TxInMode
 
   -- | Byron has various things we can post to the chain which are not
@@ -84,34 +84,35 @@ fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (
 
 fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (Z tx')))) =
   let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode (ShelleyTx ShelleyBasedEraShelley shelleyEraTx) ShelleyEraInCardanoMode
+  in TxInMode ShelleyEra (ShelleyTx ShelleyBasedEraShelley shelleyEraTx)
 
 fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (Z tx'))))) =
   let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode (ShelleyTx ShelleyBasedEraAllegra shelleyEraTx) AllegraEraInCardanoMode
+  in TxInMode AllegraEra (ShelleyTx ShelleyBasedEraAllegra shelleyEraTx)
 
 fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (Z tx')))))) =
   let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode (ShelleyTx ShelleyBasedEraMary shelleyEraTx) MaryEraInCardanoMode
+  in TxInMode MaryEra (ShelleyTx ShelleyBasedEraMary shelleyEraTx)
 
 fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (Z tx'))))))) =
   let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode (ShelleyTx ShelleyBasedEraAlonzo shelleyEraTx) AlonzoEraInCardanoMode
+  in TxInMode AlonzoEra (ShelleyTx ShelleyBasedEraAlonzo shelleyEraTx)
 
 fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (S (Z tx')))))))) =
   let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode (ShelleyTx ShelleyBasedEraBabbage shelleyEraTx) BabbageEraInCardanoMode
+  in TxInMode BabbageEra (ShelleyTx ShelleyBasedEraBabbage shelleyEraTx)
 
 fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (S (S (Z tx'))))))))) =
   let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode (ShelleyTx ShelleyBasedEraConway shelleyEraTx) ConwayEraInCardanoMode
+  in TxInMode ConwayEra (ShelleyTx ShelleyBasedEraConway shelleyEraTx)
 
 toConsensusGenTx :: ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block
   => TxInMode
   -> Consensus.GenTx block
-toConsensusGenTx (TxInMode (ByronTx ByronEraOnlyByron tx) ByronEraInCardanoMode) =
-    Consensus.HardForkGenTx (Consensus.OneEraGenTx (Z tx'))
+toConsensusGenTx (TxInMode w (ByronTx ByronEraOnlyByron tx)) =
+  case w of
+    ByronEra -> Consensus.HardForkGenTx (Consensus.OneEraGenTx (Z tx'))
   where
     tx' = Consensus.ByronTx (Consensus.byronIdTx tx) tx
     --TODO: add the above as mkByronTx to the consensus code,
@@ -120,37 +121,37 @@ toConsensusGenTx (TxInMode (ByronTx ByronEraOnlyByron tx) ByronEraInCardanoMode)
 toConsensusGenTx (TxInByronSpecial gtx ByronEraInCardanoMode) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (Z gtx))
 
-toConsensusGenTx (TxInMode (ShelleyTx _ tx) ShelleyEraInCardanoMode) =
+toConsensusGenTx (TxInMode ShelleyEra (ShelleyTx _ tx)) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (Z tx')))
   where
     tx' = Consensus.mkShelleyTx tx
 
-toConsensusGenTx (TxInMode (ShelleyTx _ tx) AllegraEraInCardanoMode) =
+toConsensusGenTx (TxInMode AllegraEra (ShelleyTx _ tx)) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (Z tx'))))
   where
     tx' = Consensus.mkShelleyTx tx
 
-toConsensusGenTx (TxInMode (ShelleyTx _ tx) MaryEraInCardanoMode) =
+toConsensusGenTx (TxInMode MaryEra (ShelleyTx _ tx)) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (Z tx')))))
   where
     tx' = Consensus.mkShelleyTx tx
 
-toConsensusGenTx (TxInMode (ShelleyTx _ tx) AlonzoEraInCardanoMode) =
+toConsensusGenTx (TxInMode AlonzoEra (ShelleyTx _ tx)) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (Z tx'))))))
   where
     tx' = Consensus.mkShelleyTx tx
 
-toConsensusGenTx (TxInMode (ShelleyTx _ tx) BabbageEraInCardanoMode) =
+toConsensusGenTx (TxInMode BabbageEra (ShelleyTx _ tx)) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (S (Z tx')))))))
   where
     tx' = Consensus.mkShelleyTx tx
 
-toConsensusGenTx (TxInMode (ShelleyTx _ tx) ConwayEraInCardanoMode) =
+toConsensusGenTx (TxInMode ConwayEra (ShelleyTx _ tx)) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (S (S (Z tx'))))))))
   where
     tx' = Consensus.mkShelleyTx tx
 
-toConsensusGenTx (TxInMode (ShelleyTx _ _) ByronEraInCardanoMode) =
+toConsensusGenTx (TxInMode ByronEra (ShelleyTx _ _)) =
   error "Cardano.Api.InMode.toConsensusGenTx: ShelleyTx In Byron era"
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -21,7 +21,7 @@ module Cardano.Api.InMode (
 
     -- * Transaction validation errors
     TxValidationError(..),
-    TxValidationErrorInMode(..),
+    TxValidationErrorInCardanoMode(..),
     fromConsensusApplyTxErr,
   ) where
 
@@ -271,53 +271,56 @@ instance Show (TxValidationError era) where
 --
 -- This is used in the LocalStateQuery protocol.
 --
-data TxValidationErrorInMode mode where
-     TxValidationErrorInMode :: TxValidationError era
-                             -> EraInMode era mode
-                             -> TxValidationErrorInMode mode
+data TxValidationErrorInCardanoMode where
+  TxValidationErrorInCardanoMode :: ()
+    => TxValidationError era
+    -> EraInMode era CardanoMode
+    -> TxValidationErrorInCardanoMode
 
-     TxValidationEraMismatch :: EraMismatch
-                             -> TxValidationErrorInMode mode
+  TxValidationEraMismatch :: ()
+    => EraMismatch
+    -> TxValidationErrorInCardanoMode
 
-deriving instance Show (TxValidationErrorInMode mode)
+deriving instance Show TxValidationErrorInCardanoMode
 
 
-fromConsensusApplyTxErr :: ConsensusBlockForMode mode ~ block
-                        => ConsensusMode mode
-                        -> Consensus.ApplyTxErr block
-                        -> TxValidationErrorInMode mode
+fromConsensusApplyTxErr :: ()
+  => ConsensusBlockForMode CardanoMode ~ block
+  => ConsensusMode CardanoMode
+  -> Consensus.ApplyTxErr block
+  -> TxValidationErrorInCardanoMode
 fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrByron err) =
-    TxValidationErrorInMode
+    TxValidationErrorInCardanoMode
       (ByronTxValidationError err)
       ByronEraInCardanoMode
 
 fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrShelley err) =
-    TxValidationErrorInMode
+    TxValidationErrorInCardanoMode
       (ShelleyTxValidationError ShelleyBasedEraShelley err)
       ShelleyEraInCardanoMode
 
 fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrAllegra err) =
-    TxValidationErrorInMode
+    TxValidationErrorInCardanoMode
       (ShelleyTxValidationError ShelleyBasedEraAllegra err)
       AllegraEraInCardanoMode
 
 fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrMary err) =
-    TxValidationErrorInMode
+    TxValidationErrorInCardanoMode
       (ShelleyTxValidationError ShelleyBasedEraMary err)
       MaryEraInCardanoMode
 
 fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrAlonzo err) =
-    TxValidationErrorInMode
+    TxValidationErrorInCardanoMode
       (ShelleyTxValidationError ShelleyBasedEraAlonzo err)
       AlonzoEraInCardanoMode
 
 fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrBabbage err) =
-    TxValidationErrorInMode
+    TxValidationErrorInCardanoMode
       (ShelleyTxValidationError ShelleyBasedEraBabbage err)
       BabbageEraInCardanoMode
 
 fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrConway err) =
-    TxValidationErrorInMode
+    TxValidationErrorInCardanoMode
       (ShelleyTxValidationError ShelleyBasedEraConway err)
       ConwayEraInCardanoMode
 

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -162,50 +162,54 @@ toConsensusGenTx (TxInMode (ShelleyTx _ _) ByronEraInCardanoMode) =
 -- different transaction types for all the eras. It is used in the
 -- LocalTxMonitoring protocol.
 --
-
-data TxIdInMode mode where
-  TxIdInMode :: TxId -> EraInMode era mode -> TxIdInMode mode
+-- TODO Rename to TxIdInEra
+data TxIdInMode where
+  TxIdInMode
+    :: CardanoEra era
+    -> TxId
+    -> TxIdInMode
 
 toConsensusTxId :: ()
   => ConsensusBlockForMode CardanoMode ~ block
-  => TxIdInMode CardanoMode -> Consensus.TxId  (Consensus.GenTx block)
-toConsensusTxId (TxIdInMode txid ByronEraInCardanoMode) =
+  => TxIdInMode
+  -> Consensus.TxId  (Consensus.GenTx block)
+toConsensusTxId (TxIdInMode ByronEra txid) =
   Consensus.HardForkGenTxId . Consensus.OneEraGenTxId . Z $ Consensus.WrapGenTxId txid'
  where
   txid' :: Consensus.TxId (Consensus.GenTx Consensus.ByronBlock)
   txid' = Consensus.ByronTxId $ toByronTxId txid
 
-toConsensusTxId (TxIdInMode txid ShelleyEraInCardanoMode) =
+toConsensusTxId (TxIdInMode ShelleyEra txid) =
   Consensus.HardForkGenTxId (Consensus.OneEraGenTxId (S (Z (Consensus.WrapGenTxId txid'))))
  where
   txid' :: Consensus.TxId (Consensus.GenTx Consensus.StandardShelleyBlock)
   txid' = Consensus.ShelleyTxId $ toShelleyTxId txid
 
-toConsensusTxId (TxIdInMode txid AllegraEraInCardanoMode) =
+toConsensusTxId (TxIdInMode AllegraEra txid) =
   Consensus.HardForkGenTxId (Consensus.OneEraGenTxId (S (S (Z (Consensus.WrapGenTxId txid')))))
  where
   txid' :: Consensus.TxId (Consensus.GenTx Consensus.StandardAllegraBlock)
   txid' = Consensus.ShelleyTxId $ toShelleyTxId txid
 
-toConsensusTxId (TxIdInMode txid MaryEraInCardanoMode) =
+toConsensusTxId (TxIdInMode MaryEra txid) =
   Consensus.HardForkGenTxId (Consensus.OneEraGenTxId (S (S (S (Z (Consensus.WrapGenTxId txid'))))))
  where
   txid' :: Consensus.TxId (Consensus.GenTx Consensus.StandardMaryBlock)
   txid' = Consensus.ShelleyTxId $ toShelleyTxId txid
 
-toConsensusTxId (TxIdInMode txid AlonzoEraInCardanoMode) =
+toConsensusTxId (TxIdInMode AlonzoEra txid) =
   Consensus.HardForkGenTxId (Consensus.OneEraGenTxId (S (S (S (S (Z (Consensus.WrapGenTxId txid')))))))
  where
   txid' :: Consensus.TxId (Consensus.GenTx Consensus.StandardAlonzoBlock)
   txid' = Consensus.ShelleyTxId $ toShelleyTxId txid
 
-toConsensusTxId (TxIdInMode txid BabbageEraInCardanoMode) =
+toConsensusTxId (TxIdInMode BabbageEra txid) =
   Consensus.HardForkGenTxId (Consensus.OneEraGenTxId (S (S (S (S (S (Z (Consensus.WrapGenTxId txid'))))))))
  where
   txid' :: Consensus.TxId (Consensus.GenTx Consensus.StandardBabbageBlock)
   txid' = Consensus.ShelleyTxId $ toShelleyTxId txid
 
-toConsensusTxId (TxIdInMode txid ConwayEraInCardanoMode) =
+toConsensusTxId (TxIdInMode ConwayEra txid) =
   Consensus.HardForkGenTxId (Consensus.OneEraGenTxId (S (S (S (S (S (S (Z (Consensus.WrapGenTxId txid')))))))))
  where
   txid' :: Consensus.TxId (Consensus.GenTx Consensus.StandardConwayBlock)

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
@@ -287,7 +288,6 @@ instance Show (TxValidationError era) where
 data TxValidationErrorInCardanoMode where
   TxValidationErrorInCardanoMode :: ()
     => TxValidationError era
-    -> EraInMode era CardanoMode
     -> TxValidationErrorInCardanoMode
 
   TxValidationEraMismatch :: ()
@@ -299,43 +299,22 @@ deriving instance Show TxValidationErrorInCardanoMode
 
 fromConsensusApplyTxErr :: ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block
-  => ConsensusMode CardanoMode
-  -> Consensus.ApplyTxErr block
+  => Consensus.ApplyTxErr block
   -> TxValidationErrorInCardanoMode
-fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrByron err) =
-    TxValidationErrorInCardanoMode
-      (ByronTxValidationError err)
-      ByronEraInCardanoMode
-
-fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrShelley err) =
-    TxValidationErrorInCardanoMode
-      (ShelleyTxValidationError ShelleyBasedEraShelley err)
-      ShelleyEraInCardanoMode
-
-fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrAllegra err) =
-    TxValidationErrorInCardanoMode
-      (ShelleyTxValidationError ShelleyBasedEraAllegra err)
-      AllegraEraInCardanoMode
-
-fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrMary err) =
-    TxValidationErrorInCardanoMode
-      (ShelleyTxValidationError ShelleyBasedEraMary err)
-      MaryEraInCardanoMode
-
-fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrAlonzo err) =
-    TxValidationErrorInCardanoMode
-      (ShelleyTxValidationError ShelleyBasedEraAlonzo err)
-      AlonzoEraInCardanoMode
-
-fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrBabbage err) =
-    TxValidationErrorInCardanoMode
-      (ShelleyTxValidationError ShelleyBasedEraBabbage err)
-      BabbageEraInCardanoMode
-
-fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrConway err) =
-    TxValidationErrorInCardanoMode
-      (ShelleyTxValidationError ShelleyBasedEraConway err)
-      ConwayEraInCardanoMode
-
-fromConsensusApplyTxErr CardanoMode (Consensus.ApplyTxErrWrongEra err) =
+fromConsensusApplyTxErr = \case
+  Consensus.ApplyTxErrByron err ->
+    TxValidationErrorInCardanoMode $ ByronTxValidationError err
+  Consensus.ApplyTxErrShelley err ->
+    TxValidationErrorInCardanoMode $ ShelleyTxValidationError ShelleyBasedEraShelley err
+  Consensus.ApplyTxErrAllegra err ->
+    TxValidationErrorInCardanoMode $ ShelleyTxValidationError ShelleyBasedEraAllegra err
+  Consensus.ApplyTxErrMary err ->
+    TxValidationErrorInCardanoMode $ ShelleyTxValidationError ShelleyBasedEraMary err
+  Consensus.ApplyTxErrAlonzo err ->
+    TxValidationErrorInCardanoMode $ ShelleyTxValidationError ShelleyBasedEraAlonzo err
+  Consensus.ApplyTxErrBabbage err ->
+    TxValidationErrorInCardanoMode $ ShelleyTxValidationError ShelleyBasedEraBabbage err
+  Consensus.ApplyTxErrConway err ->
+    TxValidationErrorInCardanoMode $ ShelleyTxValidationError ShelleyBasedEraConway err
+  Consensus.ApplyTxErrWrongEra err ->
     TxValidationEraMismatch err

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -32,6 +32,7 @@ import           Cardano.Api.Modes
 import           Cardano.Api.Tx
 import           Cardano.Api.TxBody
 
+import qualified Cardano.Ledger.Api as L
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
 import qualified Ouroboros.Consensus.Cardano.Block as Consensus
 import qualified Ouroboros.Consensus.HardFork.Combinator as Consensus
@@ -74,7 +75,7 @@ data TxInMode where
 deriving instance Show TxInMode
 
 fromConsensusGenTx :: ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => ConsensusMode CardanoMode
   -> Consensus.GenTx block
   -> TxInMode
@@ -106,7 +107,7 @@ fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (
   in TxInMode (ShelleyTx ShelleyBasedEraConway shelleyEraTx) ConwayEraInCardanoMode
 
 toConsensusGenTx :: ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => TxInMode
   -> Consensus.GenTx block
 toConsensusGenTx (TxInMode (ByronTx ByronEraOnlyByron tx) ByronEraInCardanoMode) =
@@ -170,7 +171,7 @@ data TxIdInMode where
     -> TxIdInMode
 
 toConsensusTxId :: ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => TxIdInMode
   -> Consensus.TxId  (Consensus.GenTx block)
 toConsensusTxId (TxIdInMode ByronEra txid) =
@@ -296,7 +297,7 @@ deriving instance Show TxValidationErrorInCardanoMode
 
 
 fromConsensusApplyTxErr :: ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => ConsensusMode CardanoMode
   -> Consensus.ApplyTxErr block
   -> TxValidationErrorInCardanoMode

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -159,9 +159,9 @@ toConsensusGenTx (TxInMode (ShelleyTx _ _) ByronEraInCardanoMode) =
 data TxIdInMode mode where
   TxIdInMode :: TxId -> EraInMode era mode -> TxIdInMode mode
 
-toConsensusTxId
-  :: ConsensusBlockForMode mode ~ block
-  => TxIdInMode mode -> Consensus.TxId  (Consensus.GenTx block)
+toConsensusTxId :: ()
+  => ConsensusBlockForMode CardanoMode ~ block
+  => TxIdInMode CardanoMode -> Consensus.TxId  (Consensus.GenTx block)
 toConsensusTxId (TxIdInMode txid ByronEraInCardanoMode) =
   Consensus.HardForkGenTxId . Consensus.OneEraGenTxId . Z $ Consensus.WrapGenTxId txid'
  where

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -69,43 +69,37 @@ data TxInMode where
   -- delegation certs.
   --
   TxInByronSpecial
-    :: Consensus.GenTx Consensus.ByronBlock
-    -> EraInMode ByronEra CardanoMode
+    :: ByronEraOnly era
+    -> Consensus.GenTx Consensus.ByronBlock
     -> TxInMode
 
 deriving instance Show TxInMode
 
 fromConsensusGenTx :: ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block
-  => ConsensusMode CardanoMode
-  -> Consensus.GenTx block
+  => Consensus.GenTx block
   -> TxInMode
-fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (Z tx'))) =
-  TxInByronSpecial tx' ByronEraInCardanoMode
-
-fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (Z tx')))) =
-  let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode ShelleyEra (ShelleyTx ShelleyBasedEraShelley shelleyEraTx)
-
-fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (Z tx'))))) =
-  let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode AllegraEra (ShelleyTx ShelleyBasedEraAllegra shelleyEraTx)
-
-fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (Z tx')))))) =
-  let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode MaryEra (ShelleyTx ShelleyBasedEraMary shelleyEraTx)
-
-fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (Z tx'))))))) =
-  let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode AlonzoEra (ShelleyTx ShelleyBasedEraAlonzo shelleyEraTx)
-
-fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (S (Z tx')))))))) =
-  let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode BabbageEra (ShelleyTx ShelleyBasedEraBabbage shelleyEraTx)
-
-fromConsensusGenTx CardanoMode (Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (S (S (Z tx'))))))))) =
-  let Consensus.ShelleyTx _txid shelleyEraTx = tx'
-  in TxInMode ConwayEra (ShelleyTx ShelleyBasedEraConway shelleyEraTx)
+fromConsensusGenTx = \case
+  Consensus.HardForkGenTx (Consensus.OneEraGenTx (Z tx')) ->
+    TxInByronSpecial ByronEraOnlyByron tx'
+  Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (Z tx'))) ->
+    let Consensus.ShelleyTx _txid shelleyEraTx = tx'
+    in TxInMode ShelleyEra (ShelleyTx ShelleyBasedEraShelley shelleyEraTx)
+  Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (Z tx')))) ->
+    let Consensus.ShelleyTx _txid shelleyEraTx = tx'
+    in TxInMode AllegraEra (ShelleyTx ShelleyBasedEraAllegra shelleyEraTx)
+  Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (Z tx'))))) ->
+    let Consensus.ShelleyTx _txid shelleyEraTx = tx'
+    in TxInMode MaryEra (ShelleyTx ShelleyBasedEraMary shelleyEraTx)
+  Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (Z tx')))))) ->
+    let Consensus.ShelleyTx _txid shelleyEraTx = tx'
+    in TxInMode AlonzoEra (ShelleyTx ShelleyBasedEraAlonzo shelleyEraTx)
+  Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (S (Z tx'))))))) ->
+    let Consensus.ShelleyTx _txid shelleyEraTx = tx'
+    in TxInMode BabbageEra (ShelleyTx ShelleyBasedEraBabbage shelleyEraTx)
+  Consensus.HardForkGenTx (Consensus.OneEraGenTx (S (S (S (S (S (S (Z tx')))))))) ->
+    let Consensus.ShelleyTx _txid shelleyEraTx = tx'
+    in TxInMode ConwayEra (ShelleyTx ShelleyBasedEraConway shelleyEraTx)
 
 toConsensusGenTx :: ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block
@@ -119,7 +113,7 @@ toConsensusGenTx (TxInMode w (ByronTx ByronEraOnlyByron tx)) =
     --TODO: add the above as mkByronTx to the consensus code,
     -- matching mkShelleyTx below
 
-toConsensusGenTx (TxInByronSpecial gtx ByronEraInCardanoMode) =
+toConsensusGenTx (TxInByronSpecial ByronEraOnlyByron gtx) =
     Consensus.HardForkGenTx (Consensus.OneEraGenTx (Z gtx))
 
 toConsensusGenTx (TxInMode ShelleyEra (ShelleyTx _ tx)) =

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -94,7 +94,7 @@ import           Cardano.Api.IPC (ConsensusModeParams (..),
                    LocalNodeConnectInfo (..), connectToLocalNode)
 import           Cardano.Api.Keys.Praos
 import           Cardano.Api.LedgerEvent (LedgerEvent, toLedgerEvent)
-import           Cardano.Api.Modes (CardanoMode, EpochSlots (..))
+import           Cardano.Api.Modes (EpochSlots (..))
 import qualified Cardano.Api.Modes as Api
 import           Cardano.Api.NetworkId (NetworkId (..), NetworkMagic (NetworkMagic))
 import           Cardano.Api.Query (CurrentEpochState (..), PoolDistribution (unPoolDistr),
@@ -355,7 +355,7 @@ foldBlocks
   -> ValidationMode
   -> a
   -- ^ The initial accumulator state.
-  -> (Env -> LedgerState -> [LedgerEvent] -> BlockInMode CardanoMode -> a -> IO a)
+  -> (Env -> LedgerState -> [LedgerEvent] -> BlockInMode -> a -> IO a)
   -- ^ Accumulator function Takes:
   --
   --  * Environment (this is a constant over the whole fold).
@@ -449,7 +449,7 @@ foldBlocks nodeConfigFilePath socketPath validationMode state0 accumulate = do
                     -> Env
                     -> LedgerState
                     -> CSP.ChainSyncClientPipelined
-                        (BlockInMode CardanoMode)
+                        BlockInMode
                         ChainPoint
                         ChainTip
                         IO ()
@@ -464,7 +464,7 @@ foldBlocks nodeConfigFilePath socketPath validationMode state0 accumulate = do
             -> WithOrigin BlockNo
             -> Nat n -- Number of requests inflight.
             -> LedgerStateHistory
-            -> CSP.ClientPipelinedStIdle n (BlockInMode CardanoMode) ChainPoint ChainTip IO ()
+            -> CSP.ClientPipelinedStIdle n BlockInMode ChainPoint ChainTip IO ()
           clientIdle_RequestMoreN clientTip serverTip n knownLedgerStates
             = case pipelineDecisionMax pipelineSize n clientTip serverTip  of
                 Collect -> case n of
@@ -474,10 +474,10 @@ foldBlocks nodeConfigFilePath socketPath validationMode state0 accumulate = do
           clientNextN
             :: Nat n -- Number of requests inflight.
             -> LedgerStateHistory
-            -> CSP.ClientStNext n (BlockInMode CardanoMode) ChainPoint ChainTip IO ()
+            -> CSP.ClientStNext n BlockInMode ChainPoint ChainTip IO ()
           clientNextN n knownLedgerStates =
             CSP.ClientStNext {
-                CSP.recvMsgRollForward = \blockInMode@(BlockInMode _ block@(Block (BlockHeader slotNo _ currBlockNo) _) _era) serverChainTip -> do
+                CSP.recvMsgRollForward = \blockInMode@(BlockInMode _ block@(Block (BlockHeader slotNo _ currBlockNo) _)) serverChainTip -> do
                   let newLedgerStateE = applyBlock
                         env
                         (maybe
@@ -518,7 +518,7 @@ foldBlocks nodeConfigFilePath socketPath validationMode state0 accumulate = do
           clientIdle_DoneN
             :: Nat n -- Number of requests inflight.
             -> Maybe LedgerStateError -- Return value (maybe an error)
-            -> IO (CSP.ClientPipelinedStIdle n (BlockInMode CardanoMode) ChainPoint ChainTip IO ())
+            -> IO (CSP.ClientPipelinedStIdle n BlockInMode ChainPoint ChainTip IO ())
           clientIdle_DoneN n errorMay = case n of
             Succ predN -> return (CSP.CollectResponse Nothing (clientNext_DoneN predN errorMay)) -- Ignore remaining message responses
             Zero -> do
@@ -528,7 +528,7 @@ foldBlocks nodeConfigFilePath socketPath validationMode state0 accumulate = do
           clientNext_DoneN
             :: Nat n -- Number of requests inflight.
             -> Maybe LedgerStateError -- Return value (maybe an error)
-            -> CSP.ClientStNext n (BlockInMode CardanoMode) ChainPoint ChainTip IO ()
+            -> CSP.ClientStNext n BlockInMode ChainPoint ChainTip IO ()
           clientNext_DoneN n errorMay =
             CSP.ClientStNext {
                 CSP.recvMsgRollForward = \_ _ -> clientIdle_DoneN n errorMay
@@ -548,7 +548,7 @@ chainSyncClientWithLedgerState
   -> LedgerState
   -- ^ Initial ledger state
   -> ValidationMode
-  -> CS.ChainSyncClient (BlockInMode CardanoMode, Either LedgerStateError (LedgerState, [LedgerEvent]))
+  -> CS.ChainSyncClient (BlockInMode, Either LedgerStateError (LedgerState, [LedgerEvent]))
                         ChainPoint
                         ChainTip
                         m
@@ -559,7 +559,7 @@ chainSyncClientWithLedgerState
   -- trust the node, then we generally expect blocks to validate. Also note that
   -- after a block fails to validate we may still roll back to a validated
   -- block, in which case the valid 'LedgerState' will be passed here again.
-  -> CS.ChainSyncClient (BlockInMode CardanoMode)
+  -> CS.ChainSyncClient BlockInMode
                         ChainPoint
                         ChainTip
                         m
@@ -571,8 +571,8 @@ chainSyncClientWithLedgerState env ledgerState0 validationMode (CS.ChainSyncClie
   where
     goClientStIdle
       :: Either LedgerStateError (History (Either LedgerStateError LedgerStateEvents))
-      -> CS.ClientStIdle (BlockInMode CardanoMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
-      -> CS.ClientStIdle (BlockInMode CardanoMode                                                      ) ChainPoint ChainTip m a
+      -> CS.ClientStIdle (BlockInMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
+      -> CS.ClientStIdle  BlockInMode                                                        ChainPoint ChainTip m a
     goClientStIdle history client = case client of
       CS.SendMsgRequestNext a b -> CS.SendMsgRequestNext (goClientStNext history a) (goClientStNext history <$> b)
       CS.SendMsgFindIntersect ps a -> CS.SendMsgFindIntersect ps (goClientStIntersect history a)
@@ -582,8 +582,8 @@ chainSyncClientWithLedgerState env ledgerState0 validationMode (CS.ChainSyncClie
     -- and use it to maintain the correct ledger state.
     goClientStNext
       :: Either LedgerStateError (History (Either LedgerStateError LedgerStateEvents))
-      -> CS.ClientStNext (BlockInMode CardanoMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
-      -> CS.ClientStNext (BlockInMode CardanoMode                                                      ) ChainPoint ChainTip m a
+      -> CS.ClientStNext (BlockInMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
+      -> CS.ClientStNext  BlockInMode                                                        ChainPoint ChainTip m a
     goClientStNext (Left err) (CS.ClientStNext recvMsgRollForward recvMsgRollBackward) = CS.ClientStNext
       (\blkInMode tip -> CS.ChainSyncClient $
             goClientStIdle (Left err) <$> CS.runChainSyncClient
@@ -593,7 +593,7 @@ chainSyncClientWithLedgerState env ledgerState0 validationMode (CS.ChainSyncClie
             goClientStIdle (Left err) <$> CS.runChainSyncClient (recvMsgRollBackward point tip)
       )
     goClientStNext (Right history) (CS.ClientStNext recvMsgRollForward recvMsgRollBackward) = CS.ClientStNext
-      (\blkInMode@(BlockInMode _ blk@(Block (BlockHeader slotNo _ _) _) _) tip -> CS.ChainSyncClient $ let
+      (\blkInMode@(BlockInMode _ blk@(Block (BlockHeader slotNo _ _) _)) tip -> CS.ChainSyncClient $ let
           newLedgerStateE = case Seq.lookup 0 history of
             Nothing -> error "Impossible! History should always be non-empty"
             Just (_, Left err, _) -> Left err
@@ -621,8 +621,8 @@ chainSyncClientWithLedgerState env ledgerState0 validationMode (CS.ChainSyncClie
 
     goClientStIntersect
       :: Either LedgerStateError (History (Either LedgerStateError LedgerStateEvents))
-      -> CS.ClientStIntersect (BlockInMode CardanoMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
-      -> CS.ClientStIntersect (BlockInMode CardanoMode                                                      ) ChainPoint ChainTip m a
+      -> CS.ClientStIntersect (BlockInMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
+      -> CS.ClientStIntersect  BlockInMode                                                        ChainPoint ChainTip m a
     goClientStIntersect history (CS.ClientStIntersect recvMsgIntersectFound recvMsgIntersectNotFound) = CS.ClientStIntersect
       (\point tip -> CS.ChainSyncClient (goClientStIdle history <$> CS.runChainSyncClient (recvMsgIntersectFound point tip)))
       (\tip -> CS.ChainSyncClient (goClientStIdle history <$> CS.runChainSyncClient (recvMsgIntersectNotFound tip)))
@@ -638,13 +638,13 @@ chainSyncClientPipelinedWithLedgerState
   -> LedgerState
   -> ValidationMode
   -> CSP.ChainSyncClientPipelined
-                        (BlockInMode CardanoMode, Either LedgerStateError (LedgerState, [LedgerEvent]))
+                        (BlockInMode, Either LedgerStateError (LedgerState, [LedgerEvent]))
                         ChainPoint
                         ChainTip
                         m
                         a
   -> CSP.ChainSyncClientPipelined
-                        (BlockInMode CardanoMode)
+                        BlockInMode
                         ChainPoint
                         ChainTip
                         m
@@ -655,8 +655,8 @@ chainSyncClientPipelinedWithLedgerState env ledgerState0 validationMode (CSP.Cha
     goClientPipelinedStIdle
       :: Either LedgerStateError (History (Either LedgerStateError LedgerStateEvents))
       -> Nat n
-      -> CSP.ClientPipelinedStIdle n (BlockInMode CardanoMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
-      -> CSP.ClientPipelinedStIdle n (BlockInMode CardanoMode                                                      ) ChainPoint ChainTip m a
+      -> CSP.ClientPipelinedStIdle n (BlockInMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
+      -> CSP.ClientPipelinedStIdle n  BlockInMode                                                        ChainPoint ChainTip m a
     goClientPipelinedStIdle history n client = case client of
       CSP.SendMsgRequestNext a b -> CSP.SendMsgRequestNext (goClientStNext history n a) (goClientStNext history n <$> b)
       CSP.SendMsgRequestNextPipelined a ->  CSP.SendMsgRequestNextPipelined (goClientPipelinedStIdle history (Succ n) a)
@@ -670,8 +670,8 @@ chainSyncClientPipelinedWithLedgerState env ledgerState0 validationMode (CSP.Cha
     goClientStNext
       :: Either LedgerStateError (History (Either LedgerStateError LedgerStateEvents))
       -> Nat n
-      -> CSP.ClientStNext n (BlockInMode CardanoMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
-      -> CSP.ClientStNext n (BlockInMode CardanoMode                                                      ) ChainPoint ChainTip m a
+      -> CSP.ClientStNext n (BlockInMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
+      -> CSP.ClientStNext n  BlockInMode                                                        ChainPoint ChainTip m a
     goClientStNext (Left err) n (CSP.ClientStNext recvMsgRollForward recvMsgRollBackward) = CSP.ClientStNext
       (\blkInMode tip ->
           goClientPipelinedStIdle (Left err) n <$> recvMsgRollForward
@@ -681,7 +681,7 @@ chainSyncClientPipelinedWithLedgerState env ledgerState0 validationMode (CSP.Cha
           goClientPipelinedStIdle (Left err) n <$> recvMsgRollBackward point tip
       )
     goClientStNext (Right history) n (CSP.ClientStNext recvMsgRollForward recvMsgRollBackward) = CSP.ClientStNext
-      (\blkInMode@(BlockInMode _ blk@(Block (BlockHeader slotNo _ _) _) _) tip -> let
+      (\blkInMode@(BlockInMode _ blk@(Block (BlockHeader slotNo _ _) _)) tip -> let
           newLedgerStateE = case Seq.lookup 0 history of
             Nothing -> error "Impossible! History should always be non-empty"
             Just (_, Left err, _) -> Left err
@@ -710,8 +710,8 @@ chainSyncClientPipelinedWithLedgerState env ledgerState0 validationMode (CSP.Cha
     goClientPipelinedStIntersect
       :: Either LedgerStateError (History (Either LedgerStateError LedgerStateEvents))
       -> Nat n
-      -> CSP.ClientPipelinedStIntersect (BlockInMode CardanoMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
-      -> CSP.ClientPipelinedStIntersect (BlockInMode CardanoMode                                                      ) ChainPoint ChainTip m a
+      -> CSP.ClientPipelinedStIntersect (BlockInMode, Either LedgerStateError (LedgerState, [LedgerEvent])) ChainPoint ChainTip m a
+      -> CSP.ClientPipelinedStIntersect  BlockInMode                                                        ChainPoint ChainTip m a
     goClientPipelinedStIntersect history _ (CSP.ClientPipelinedStIntersect recvMsgIntersectFound recvMsgIntersectNotFound) = CSP.ClientPipelinedStIntersect
       (\point tip -> goClientPipelinedStIdle history Zero <$> recvMsgIntersectFound point tip)
       (\tip -> goClientPipelinedStIdle history Zero <$> recvMsgIntersectNotFound tip)
@@ -729,7 +729,7 @@ chainSyncClientPipelinedWithLedgerState env ledgerState0 validationMode (CSP.Cha
 -- * The new block
 --
 type LedgerStateHistory = History LedgerStateEvents
-type History a = Seq (SlotNo, a, WithOrigin (BlockInMode CardanoMode))
+type History a = Seq (SlotNo, a, WithOrigin BlockInMode)
 
 -- | Add a new ledger state to the history
 pushLedgerState
@@ -737,7 +737,7 @@ pushLedgerState
   -> History a          -- ^ History of k items.
   -> SlotNo             -- ^ Slot number of the new item.
   -> a                  -- ^ New item to add to the history
-  -> BlockInMode CardanoMode
+  -> BlockInMode
                         -- ^ The block that (when applied to the previous
                         -- item) resulted in the new item.
   -> (History a, History a)

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -426,7 +426,12 @@ foldBlocks nodeConfigFilePath socketPath validationMode state0 accumulate = do
     Nothing -> lift $ readIORef stateIORef
   where
 
-    protocols :: IORef a -> IORef (Maybe LedgerStateError) -> Env -> LedgerState -> LocalNodeClientProtocolsInMode CardanoMode
+    protocols :: ()
+      => IORef a
+      -> IORef (Maybe LedgerStateError)
+      -> Env
+      -> LedgerState
+      -> LocalNodeClientProtocolsInMode
     protocols stateIORef errorIORef env ledgerState =
         LocalNodeClientProtocols {
           localChainSyncClient    = LocalChainSyncClientPipelined (chainSyncClient 50 stateIORef errorIORef env ledgerState),

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -409,13 +409,11 @@ foldBlocks nodeConfigFilePath socketPath validationMode state0 accumulate = do
       cardanoModeParams = CardanoModeParams . EpochSlots $ 10 * envSecurityParam env
 
   -- Connect to the node.
-  let connectInfo :: LocalNodeConnectInfo CardanoMode
-      connectInfo =
-          LocalNodeConnectInfo {
-            localConsensusModeParams = cardanoModeParams,
-            localNodeNetworkId       = networkId',
-            localNodeSocketPath      = socketPath
-          }
+  let connectInfo = LocalNodeConnectInfo
+        { localConsensusModeParams  = cardanoModeParams
+        , localNodeNetworkId        = networkId'
+        , localNodeSocketPath       = socketPath
+        }
 
   lift $ connectToLocalNode
     connectInfo

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -19,11 +19,6 @@ module Cardano.Api.Modes (
     AnyConsensusMode(..),
     renderMode,
 
-    -- * The eras supported by each mode
-    EraInMode(..),
-    eraInModeToEra,
-    toEraInMode,
-
     -- * The protocols supported in each era
     ConsensusProtocol,
     ChainDepStateProtocol,
@@ -55,8 +50,6 @@ import qualified Ouroboros.Consensus.Protocol.TPraos as Consensus
 import qualified Ouroboros.Consensus.Shelley.HFEras as Consensus
 import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus
 
-import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value)
-import           Data.Aeson.Types (Parser, prependFailure, typeMismatch)
 import           Data.SOP (K (K))
 import           Data.SOP.Strict (NS (S, Z))
 import           Data.Text (Text)
@@ -95,103 +88,6 @@ deriving instance Show AnyConsensusMode
 
 renderMode :: AnyConsensusMode -> Text
 renderMode (AnyConsensusMode CardanoMode) = "CardanoMode"
-
-toEraInMode :: CardanoEra era -> ConsensusMode CardanoMode -> Maybe (EraInMode era CardanoMode)
-toEraInMode ByronEra   CardanoMode = Just ByronEraInCardanoMode
-toEraInMode ShelleyEra CardanoMode = Just ShelleyEraInCardanoMode
-toEraInMode AllegraEra CardanoMode = Just AllegraEraInCardanoMode
-toEraInMode MaryEra    CardanoMode = Just MaryEraInCardanoMode
-toEraInMode AlonzoEra  CardanoMode = Just AlonzoEraInCardanoMode
-toEraInMode BabbageEra CardanoMode = Just BabbageEraInCardanoMode
-toEraInMode ConwayEra  CardanoMode = Just ConwayEraInCardanoMode
-
--- | A representation of which 'CardanoEra's are included in each
--- 'ConsensusMode'.
---
-data EraInMode era mode where
-     ByronEraInCardanoMode   :: EraInMode ByronEra   CardanoMode
-     ShelleyEraInCardanoMode :: EraInMode ShelleyEra CardanoMode
-     AllegraEraInCardanoMode :: EraInMode AllegraEra CardanoMode
-     MaryEraInCardanoMode    :: EraInMode MaryEra    CardanoMode
-     AlonzoEraInCardanoMode  :: EraInMode AlonzoEra  CardanoMode
-     BabbageEraInCardanoMode :: EraInMode BabbageEra CardanoMode
-     ConwayEraInCardanoMode  :: EraInMode ConwayEra  CardanoMode
-
-deriving instance Show (EraInMode era mode)
-
-deriving instance Eq (EraInMode era mode)
-
-instance FromJSON (EraInMode ByronEra CardanoMode) where
-  parseJSON "ByronEraInCardanoMode" = pure ByronEraInCardanoMode
-  parseJSON invalid =
-      invalidJSONFailure "ByronEraInCardanoMode"
-                         "parsing 'EraInMode ByronEra CardanoMode' failed, "
-                         invalid
-
-instance FromJSON (EraInMode ShelleyEra CardanoMode) where
-  parseJSON "ShelleyEraInCardanoMode" = pure ShelleyEraInCardanoMode
-  parseJSON invalid =
-      invalidJSONFailure "ShelleyEraInCardanoMode"
-                         "parsing 'EraInMode ShelleyEra CardanoMode' failed, "
-                         invalid
-
-instance FromJSON (EraInMode AllegraEra CardanoMode) where
-  parseJSON "AllegraEraInCardanoMode" = pure AllegraEraInCardanoMode
-  parseJSON invalid =
-      invalidJSONFailure "AllegraEraInCardanoMode"
-                         "parsing 'EraInMode AllegraEra CardanoMode' failed, "
-                         invalid
-
-instance FromJSON (EraInMode MaryEra CardanoMode) where
-  parseJSON "MaryEraInCardanoMode" = pure MaryEraInCardanoMode
-  parseJSON invalid =
-      invalidJSONFailure "MaryEraInCardanoMode"
-                         "parsing 'EraInMode MaryEra CardanoMode' failed, "
-                         invalid
-
-instance FromJSON (EraInMode AlonzoEra CardanoMode) where
-  parseJSON "AlonzoEraInCardanoMode" = pure AlonzoEraInCardanoMode
-  parseJSON invalid =
-      invalidJSONFailure "AlonzoEraInCardanoMode"
-                         "parsing 'EraInMode AlonzoEra CardanoMode' failed, "
-                         invalid
-
-instance FromJSON (EraInMode BabbageEra CardanoMode) where
-  parseJSON "BabbageEraInCardanoMode" = pure BabbageEraInCardanoMode
-  parseJSON invalid =
-      invalidJSONFailure "BabbageEraInCardanoMode"
-                         "parsing 'EraInMode Babbage CardanoMode' failed, "
-                         invalid
-
-instance FromJSON (EraInMode ConwayEra CardanoMode) where
-  parseJSON "ConwayEraInCardanoMode" = pure ConwayEraInCardanoMode
-  parseJSON invalid =
-      invalidJSONFailure "ConwayEraInCardanoMode"
-                         "parsing 'EraInMode Conway CardanoMode' failed, "
-                         invalid
-
-invalidJSONFailure :: String -> String -> Value -> Parser a
-invalidJSONFailure expectedType errorMsg invalidValue =
-    prependFailure errorMsg
-                   (typeMismatch expectedType invalidValue)
-
-instance ToJSON (EraInMode era mode) where
-  toJSON ByronEraInCardanoMode  = "ByronEraInCardanoMode"
-  toJSON ShelleyEraInCardanoMode = "ShelleyEraInCardanoMode"
-  toJSON AllegraEraInCardanoMode = "AllegraEraInCardanoMode"
-  toJSON MaryEraInCardanoMode = "MaryEraInCardanoMode"
-  toJSON AlonzoEraInCardanoMode = "AlonzoEraInCardanoMode"
-  toJSON BabbageEraInCardanoMode = "BabbageEraInCardanoMode"
-  toJSON ConwayEraInCardanoMode = "ConwayEraInCardanoMode"
-
-eraInModeToEra :: EraInMode era mode -> CardanoEra era
-eraInModeToEra ByronEraInCardanoMode   = ByronEra
-eraInModeToEra ShelleyEraInCardanoMode = ShelleyEra
-eraInModeToEra AllegraEraInCardanoMode = AllegraEra
-eraInModeToEra MaryEraInCardanoMode    = MaryEra
-eraInModeToEra AlonzoEraInCardanoMode  = AlonzoEra
-eraInModeToEra BabbageEraInCardanoMode = BabbageEra
-eraInModeToEra ConwayEraInCardanoMode  = ConwayEra
 
 -- | The consensus-mode-specific parameters needed to connect to a local node
 -- that is using each consensus mode.

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -25,7 +25,6 @@ module Cardano.Api.Modes (
 
     -- * Connection parameters for each mode
     ConsensusModeParams(..),
-    AnyConsensusModeParams(..),
     Byron.EpochSlots(..),
 
     -- * Conversions to and from types in the consensus library
@@ -66,11 +65,6 @@ import           Data.Text (Text)
 --
 data CardanoMode
 
-data AnyConsensusModeParams where
-  AnyConsensusModeParams :: ConsensusModeParams mode -> AnyConsensusModeParams
-
-deriving instance Show AnyConsensusModeParams
-
 -- | This GADT provides a value-level representation of all the consensus modes.
 -- This enables pattern matching on the era to allow them to be treated in a
 -- non-uniform way.
@@ -101,13 +95,12 @@ renderMode (AnyConsensusMode CardanoMode) = "CardanoMode"
 -- It is possible in future that we may be able to eliminate this parameter by
 -- discovering it from the node during the initial handshake.
 --
-data ConsensusModeParams mode where
+data ConsensusModeParams where
+  CardanoModeParams
+    :: Byron.EpochSlots
+    -> ConsensusModeParams
 
-     CardanoModeParams
-       :: Byron.EpochSlots
-       -> ConsensusModeParams CardanoMode
-
-deriving instance Show (ConsensusModeParams mode)
+deriving instance Show ConsensusModeParams
 
 -- ----------------------------------------------------------------------------
 -- Consensus conversion functions

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -174,12 +174,10 @@ toConsensusEraIndex = \case
   BabbageEra  -> eraIndex5
   ConwayEra   -> eraIndex6
 
-
 fromConsensusEraIndex :: ()
-  => ConsensusMode CardanoMode
-  -> Consensus.EraIndex (Consensus.CardanoEras StandardCrypto)
+  => Consensus.EraIndex (Consensus.CardanoEras StandardCrypto)
   -> AnyCardanoEra
-fromConsensusEraIndex CardanoMode = \case
+fromConsensusEraIndex = \case
   Consensus.EraIndex (Z (K ())) ->
     AnyCardanoEra ByronEra
   Consensus.EraIndex (S (Z (K ()))) ->

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -96,7 +96,7 @@ deriving instance Show AnyConsensusMode
 renderMode :: AnyConsensusMode -> Text
 renderMode (AnyConsensusMode CardanoMode) = "CardanoMode"
 
-toEraInMode :: CardanoEra era -> ConsensusMode mode -> Maybe (EraInMode era mode)
+toEraInMode :: CardanoEra era -> ConsensusMode CardanoMode -> Maybe (EraInMode era CardanoMode)
 toEraInMode ByronEra   CardanoMode = Just ByronEraInCardanoMode
 toEraInMode ShelleyEra CardanoMode = Just ShelleyEraInCardanoMode
 toEraInMode AllegraEra CardanoMode = Just AllegraEraInCardanoMode
@@ -289,7 +289,7 @@ toConsensusEraIndex = \case
 
 
 fromConsensusEraIndex :: ()
-  => ConsensusMode mode
+  => ConsensusMode CardanoMode
   -> Consensus.EraIndex (Consensus.CardanoEras StandardCrypto)
   -> AnyCardanoEra
 fromConsensusEraIndex CardanoMode = \case

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -16,8 +16,6 @@ module Cardano.Api.Modes (
     -- * Consensus modes
     CardanoMode,
     ConsensusMode(..),
-    AnyConsensusMode(..),
-    renderMode,
 
     -- * The protocols supported in each era
     ConsensusProtocol,
@@ -51,7 +49,6 @@ import qualified Ouroboros.Consensus.Shelley.ShelleyHFC as Consensus
 
 import           Data.SOP (K (K))
 import           Data.SOP.Strict (NS (S, Z))
-import           Data.Text (Text)
 
 -- ----------------------------------------------------------------------------
 -- Consensus modes
@@ -74,14 +71,6 @@ data ConsensusMode mode where
 
 
 deriving instance Show (ConsensusMode mode)
-
-data AnyConsensusMode where
-  AnyConsensusMode :: ConsensusMode mode -> AnyConsensusMode
-
-deriving instance Show AnyConsensusMode
-
-renderMode :: AnyConsensusMode -> Text
-renderMode (AnyConsensusMode CardanoMode) = "CardanoMode"
 
 -- | The consensus-mode-specific parameters needed to connect to a local node
 -- that is using each consensus mode.

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -35,7 +35,6 @@ module Cardano.Api.Modes (
 
     -- * Conversions to and from types in the consensus library
     ConsensusCryptoForBlock,
-    ConsensusBlockForMode,
     ConsensusBlockForEra,
     toConsensusEraIndex,
     fromConsensusEraIndex,
@@ -44,6 +43,7 @@ module Cardano.Api.Modes (
 import           Cardano.Api.Eras.Core
 
 import qualified Cardano.Chain.Slotting as Byron (EpochSlots (..))
+import qualified Cardano.Ledger.Api as L
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
 import qualified Ouroboros.Consensus.Cardano.Block as Consensus
@@ -220,8 +220,6 @@ deriving instance Show (ConsensusModeParams mode)
 -- | A closed type family that maps between the consensus mode (from this API)
 -- and the block type used by the consensus libraries.
 --
-type family ConsensusBlockForMode mode where
-  ConsensusBlockForMode CardanoMode = Consensus.CardanoBlock StandardCrypto
 
 type family ConsensusBlockForEra era where
   ConsensusBlockForEra ByronEra   = Consensus.ByronBlock
@@ -275,7 +273,7 @@ eraIndex6 :: Consensus.EraIndex (x6 : x5 : x4 : x3 : x2 : x1 : x0 : xs)
 eraIndex6 = eraIndexSucc eraIndex5
 
 toConsensusEraIndex :: ()
-  => ConsensusBlockForMode CardanoMode ~ Consensus.HardForkBlock xs
+  => Consensus.CardanoBlock L.StandardCrypto ~ Consensus.HardForkBlock xs
   => CardanoEra era
   -> Consensus.EraIndex xs
 toConsensusEraIndex = \case

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -18,7 +18,6 @@ module Cardano.Api.Modes (
     ConsensusMode(..),
     AnyConsensusMode(..),
     renderMode,
-    ConsensusModeIsMultiEra(..),
 
     -- * The eras supported by each mode
     EraInMode(..),
@@ -96,15 +95,6 @@ deriving instance Show AnyConsensusMode
 
 renderMode :: AnyConsensusMode -> Text
 renderMode (AnyConsensusMode CardanoMode) = "CardanoMode"
-
--- | The subset of consensus modes that consist of multiple eras. Some features
--- are not supported in single-era modes (for exact compatibility without
--- using the hard fork combination at all).
---
-data ConsensusModeIsMultiEra mode where
-     CardanoModeIsMultiEra :: ConsensusModeIsMultiEra CardanoMode
-
-deriving instance Show (ConsensusModeIsMultiEra mode)
 
 toEraInMode :: CardanoEra era -> ConsensusMode mode -> Maybe (EraInMode era mode)
 toEraInMode ByronEra   CardanoMode = Just ByronEraInCardanoMode

--- a/cardano-api/internal/Cardano/Api/Modes.hs
+++ b/cardano-api/internal/Cardano/Api/Modes.hs
@@ -12,11 +12,6 @@
 -- combinations of consensus protocols and ledger eras.
 --
 module Cardano.Api.Modes (
-
-    -- * Consensus modes
-    CardanoMode,
-    ConsensusMode(..),
-
     -- * The protocols supported in each era
     ConsensusProtocol,
     ChainDepStateProtocol,
@@ -53,24 +48,6 @@ import           Data.SOP.Strict (NS (S, Z))
 -- ----------------------------------------------------------------------------
 -- Consensus modes
 --
-
--- | The Cardano consensus mode consists of all the eras currently in use on
--- the Cardano mainnet. This is currently: the 'ByronEra'; 'ShelleyEra',
--- 'AllegraEra' and 'MaryEra', in that order.
---
--- This mode will be extended with new eras as the Cardano mainnet develops.
---
-data CardanoMode
-
--- | This GADT provides a value-level representation of all the consensus modes.
--- This enables pattern matching on the era to allow them to be treated in a
--- non-uniform way.
---
-data ConsensusMode mode where
-     CardanoMode :: ConsensusMode CardanoMode
-
-
-deriving instance Show (ConsensusMode mode)
 
 -- | The consensus-mode-specific parameters needed to connect to a local node
 -- that is using each consensus mode.

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -115,7 +115,6 @@ import qualified Ouroboros.Consensus.Cardano.Block as Consensus
 import qualified Ouroboros.Consensus.HardFork.Combinator as Consensus
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
 import qualified Ouroboros.Consensus.HardFork.Combinator.AcrossEras as Consensus
-import qualified Ouroboros.Consensus.HardFork.Combinator.Degenerate as Consensus
 import qualified Ouroboros.Consensus.HardFork.History as Consensus
 import qualified Ouroboros.Consensus.HardFork.History as History
 import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
@@ -556,11 +555,6 @@ toConsensusQuery (QueryCurrentEra CardanoModeIsMultiEra) =
       Consensus.QueryHardFork
         Consensus.GetCurrentEra
 
-toConsensusQuery (QueryInEra ByronEraInByronMode QueryByronUpdateState) =
-    Some $ Consensus.BlockQuery $
-      Consensus.DegenQuery
-        Consensus.GetUpdateInterfaceState
-
 toConsensusQuery (QueryEraHistory CardanoModeIsMultiEra) =
     Some $ Consensus.BlockQuery $
       Consensus.QueryHardFork
@@ -579,7 +573,6 @@ toConsensusQuery (QueryInEra ByronEraInCardanoMode QueryByronUpdateState) =
 
 toConsensusQuery (QueryInEra erainmode (QueryInShelleyBasedEra sbe q)) =
     case erainmode of
-      ByronEraInByronMode     -> case sbe of {}
       ByronEraInCardanoMode   -> case sbe of {}
       ShelleyEraInCardanoMode -> toConsensusQueryShelleyBased erainmode q
       AllegraEraInCardanoMode -> toConsensusQueryShelleyBased erainmode q
@@ -698,7 +691,6 @@ consensusQueryInEraInMode
 consensusQueryInEraInMode erainmode =
     Consensus.BlockQuery
   . case erainmode of
-      ByronEraInByronMode     -> Consensus.DegenQuery
       ByronEraInCardanoMode   -> Consensus.QueryIfCurrentByron
       ShelleyEraInCardanoMode -> Consensus.QueryIfCurrentShelley
       AllegraEraInCardanoMode -> Consensus.QueryIfCurrentAllegra
@@ -748,14 +740,6 @@ fromConsensusQueryResult (QueryCurrentEra CardanoModeIsMultiEra) q' r' =
         -> anyEraInModeToAnyEra (fromConsensusEraIndex CardanoMode r')
       _ -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResult (QueryInEra ByronEraInByronMode
-                                     QueryByronUpdateState) q' r' =
-    case (q', r') of
-      (Consensus.BlockQuery (Consensus.DegenQuery Consensus.GetUpdateInterfaceState),
-       Consensus.DegenQueryResult r'')
-        -> Right (ByronUpdateState r'')
-      _ -> fromConsensusQueryResultMismatch
-
 fromConsensusQueryResult (QueryInEra ByronEraInCardanoMode
                                      QueryByronUpdateState) q' r' =
     case q' of
@@ -763,10 +747,6 @@ fromConsensusQueryResult (QueryInEra ByronEraInCardanoMode
         (Consensus.QueryIfCurrentByron Consensus.GetUpdateInterfaceState)
         -> bimap fromConsensusEraMismatch ByronUpdateState r'
       _ -> fromConsensusQueryResultMismatch
-
-fromConsensusQueryResult (QueryInEra ByronEraInByronMode
-                                     (QueryInShelleyBasedEra sbe _)) _ _ =
-    case sbe of {}
 
 fromConsensusQueryResult (QueryInEra ByronEraInCardanoMode
                                      (QueryInShelleyBasedEra sbe _)) _ _ =

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -737,7 +737,7 @@ fromConsensusQueryResult (QueryChainPoint mode) q' r' =
 fromConsensusQueryResult (QueryCurrentEra CardanoModeIsMultiEra) q' r' =
     case q' of
       Consensus.BlockQuery (Consensus.QueryHardFork Consensus.GetCurrentEra)
-        -> anyEraInModeToAnyEra (fromConsensusEraIndex CardanoMode r')
+        -> fromConsensusEraIndex CardanoMode r'
       _ -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResult (QueryInEra ByronEraInCardanoMode

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -183,7 +183,7 @@ instance NodeToClientVersionOf (QueryInMode mode result) where
 
 data EraHistory where
   EraHistory
-    :: ConsensusBlockForMode CardanoMode ~ Consensus.HardForkBlock xs
+    :: Consensus.CardanoBlock L.StandardCrypto ~ Consensus.HardForkBlock xs
     => ConsensusMode CardanoMode
     -> History.Interpreter xs
     -> EraHistory
@@ -552,7 +552,7 @@ fromShelleyRewardAccounts =
 --
 
 toConsensusQuery :: forall block result. ()
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => QueryInMode CardanoMode result
   -> Some (Consensus.Query block)
 toConsensusQuery QueryCurrentEra =
@@ -582,7 +582,7 @@ toConsensusQuery (QueryInEra (QueryInShelleyBasedEra sbe q)) =
 toConsensusQueryShelleyBased :: forall era protocol block result. ()
   => ConsensusBlockForEra era ~ Consensus.ShelleyBlock protocol (ShelleyLedgerEra era)
   => Core.EraCrypto (ShelleyLedgerEra era) ~ Consensus.StandardCrypto
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => ShelleyBasedEra era
   -> QueryInShelleyBasedEra era result
   -> Some (Consensus.Query block)
@@ -680,7 +680,7 @@ toConsensusQueryShelleyBased sbe = \case
 consensusQueryInEraInMode
   :: forall era erablock modeblock result result' xs.
      ConsensusBlockForEra era   ~ erablock
-  => ConsensusBlockForMode CardanoMode ~ modeblock
+  => Consensus.CardanoBlock L.StandardCrypto ~ modeblock
   => modeblock ~ Consensus.HardForkBlock xs
   => Consensus.HardForkQueryResult xs result ~ result'
   => CardanoEra era
@@ -703,7 +703,7 @@ consensusQueryInEraInMode era =
 
 fromConsensusQueryResult :: forall block result result'. ()
   => HasCallStack
-  => ConsensusBlockForMode CardanoMode ~ block
+  => Consensus.CardanoBlock L.StandardCrypto ~ block
   => QueryInMode CardanoMode result
   -> Consensus.Query block result'
   -> result'

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -580,7 +580,6 @@ toConsensusQuery (QueryInEra ByronEraInCardanoMode QueryByronUpdateState) =
 toConsensusQuery (QueryInEra erainmode (QueryInShelleyBasedEra sbe q)) =
     case erainmode of
       ByronEraInByronMode     -> case sbe of {}
-      ShelleyEraInShelleyMode -> toConsensusQueryShelleyBased erainmode q
       ByronEraInCardanoMode   -> case sbe of {}
       ShelleyEraInCardanoMode -> toConsensusQueryShelleyBased erainmode q
       AllegraEraInCardanoMode -> toConsensusQueryShelleyBased erainmode q
@@ -700,7 +699,6 @@ consensusQueryInEraInMode erainmode =
     Consensus.BlockQuery
   . case erainmode of
       ByronEraInByronMode     -> Consensus.DegenQuery
-      ShelleyEraInShelleyMode -> Consensus.DegenQuery
       ByronEraInCardanoMode   -> Consensus.QueryIfCurrentByron
       ShelleyEraInCardanoMode -> Consensus.QueryIfCurrentShelley
       AllegraEraInCardanoMode -> Consensus.QueryIfCurrentAllegra
@@ -769,15 +767,6 @@ fromConsensusQueryResult (QueryInEra ByronEraInCardanoMode
 fromConsensusQueryResult (QueryInEra ByronEraInByronMode
                                      (QueryInShelleyBasedEra sbe _)) _ _ =
     case sbe of {}
-
-fromConsensusQueryResult (QueryInEra ShelleyEraInShelleyMode
-                                     (QueryInShelleyBasedEra _sbe q)) q' r' =
-    case (q', r') of
-      (Consensus.BlockQuery (Consensus.DegenQuery q''),
-       Consensus.DegenQueryResult r'')
-        -> Right (fromConsensusQueryResultShelleyBased
-                    ShelleyBasedEraShelley q q'' r'')
-      _ -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResult (QueryInEra ByronEraInCardanoMode
                                      (QueryInShelleyBasedEra sbe _)) _ _ =

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -726,10 +726,10 @@ fromConsensusQueryResult QueryChainBlockNo q' r' =
         -> r'
       _ -> fromConsensusQueryResultMismatch
 
-fromConsensusQueryResult (QueryChainPoint mode) q' r' =
+fromConsensusQueryResult (QueryChainPoint _) q' r' =
     case q' of
       Consensus.GetChainPoint
-        -> fromConsensusPointInMode mode r'
+        -> fromConsensusPointHF r'
       _ -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResult QueryCurrentEra q' r' =

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -733,7 +733,7 @@ fromConsensusQueryResult QueryChainPoint q' r' =
 fromConsensusQueryResult QueryCurrentEra q' r' =
     case q' of
       Consensus.BlockQuery (Consensus.QueryHardFork Consensus.GetCurrentEra)
-        -> fromConsensusEraIndex CardanoMode r'
+        -> fromConsensusEraIndex r'
       _ -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResult (QueryInEra QueryByronUpdateState) q' r' =

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -66,7 +66,7 @@ import           Data.Set (Set)
 import qualified Data.Set as S
 
 queryChainBlockNo :: ()
-  => LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (WithOrigin BlockNo))
+  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (WithOrigin BlockNo))
 queryChainBlockNo =
   queryExpr QueryChainBlockNo
 
@@ -81,23 +81,23 @@ queryCurrentEra =
   queryExpr QueryCurrentEra
 
 queryCurrentEpochState :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedCurrentEpochState era)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedCurrentEpochState era)))
 queryCurrentEpochState eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryCurrentEpochState
 
 queryEpoch :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch EpochNo))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch EpochNo))
 queryEpoch eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryEpoch
 
 queryDebugLedgerState :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedDebugLedgerState era)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedDebugLedgerState era)))
 queryDebugLedgerState eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryDebugLedgerState
 
@@ -107,165 +107,165 @@ queryEraHistory =
   queryExpr QueryEraHistory
 
 queryGenesisParameters :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (GenesisParameters ShelleyEra)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (GenesisParameters ShelleyEra)))
 queryGenesisParameters eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryGenesisParameters
 
 queryPoolDistribution :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> Maybe (Set PoolId)
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolDistribution era)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolDistribution era)))
 queryPoolDistribution eraInMode sbe mPoolIds =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryPoolDistribution mPoolIds
 
 queryPoolState :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> Maybe (Set PoolId)
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolState era)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolState era)))
 queryPoolState eraInMode sbe mPoolIds =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryPoolState mPoolIds
 
 queryProtocolParameters :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Ledger.PParams (ShelleyLedgerEra era))))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Ledger.PParams (ShelleyLedgerEra era))))
 queryProtocolParameters eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 
 queryConstitutionHash :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (SafeHash (EraCrypto (ShelleyLedgerEra era)) L.AnchorData))))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (SafeHash (EraCrypto (ShelleyLedgerEra era)) L.AnchorData))))
 queryConstitutionHash eraInMode sbe =
   (fmap . fmap . fmap . fmap) (L.anchorDataHash .  L.constitutionAnchor)
     $ queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryConstitution
 
 queryProtocolParametersUpdate :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash GenesisKey) ProtocolParametersUpdate)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash GenesisKey) ProtocolParametersUpdate)))
 queryProtocolParametersUpdate eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolParametersUpdate
 
 queryProtocolState :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (ProtocolState era)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (ProtocolState era)))
 queryProtocolState eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolState
 
 queryStakeAddresses :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> Set StakeCredential
   -> NetworkId
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map StakeAddress Lovelace, Map StakeAddress PoolId)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map StakeAddress Lovelace, Map StakeAddress PoolId)))
 queryStakeAddresses eraInMode sbe stakeCredentials networkId =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakeAddresses stakeCredentials networkId
 
 queryStakeDelegDeposits :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> Set StakeCredential
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential Lovelace)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential Lovelace)))
 queryStakeDelegDeposits eraInMode sbe stakeCreds
   | S.null stakeCreds = pure . pure $ pure mempty
   | otherwise         = queryExpr $ QueryInEra eraInMode . QueryInShelleyBasedEra sbe $ QueryStakeDelegDeposits stakeCreds
 
 queryStakeDistribution :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash StakePoolKey) Rational)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash StakePoolKey) Rational)))
 queryStakeDistribution eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryStakeDistribution
 
 queryStakePoolParameters :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> Set PoolId
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map PoolId StakePoolParameters)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map PoolId StakePoolParameters)))
 queryStakePoolParameters eraInMode sbe poolIds
   | S.null poolIds  = pure . pure $ pure mempty
   | otherwise       = queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakePoolParameters poolIds
 
 queryStakePools :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Set PoolId)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Set PoolId)))
 queryStakePools eraInMode sbe =
   queryExpr $ QueryInEra eraInMode . QueryInShelleyBasedEra sbe $ QueryStakePools
 
 queryStakeSnapshot :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> Maybe (Set PoolId)
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedStakeSnapshots era)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedStakeSnapshots era)))
 queryStakeSnapshot eraInMode sbe mPoolIds =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakeSnapshot mPoolIds
 
 querySystemStart :: ()
-  => LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError SystemStart)
+  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError SystemStart)
 querySystemStart =
   queryExpr QuerySystemStart
 
 queryUtxo :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> QueryUTxOFilter
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (UTxO era)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (UTxO era)))
 queryUtxo eraInMode sbe utxoFilter =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryUTxO utxoFilter
 
 -- | A monad expression that determines what era the node is in.
 determineEraExpr :: ()
-  => ConsensusModeParams mode
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
+  => ConsensusModeParams CardanoMode
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
 determineEraExpr cModeParams = runExceptT $
   case consensusModeOnly cModeParams of
     CardanoMode -> ExceptT queryCurrentEra
 
 queryConstitution :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.Constitution (ShelleyLedgerEra era)))))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.Constitution (ShelleyLedgerEra era)))))
 queryConstitution eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryConstitution
 
 queryGovState :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (L.GovState (ShelleyLedgerEra era))))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (L.GovState (ShelleyLedgerEra era))))
 queryGovState eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryGovState
 
 queryDRepState :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> Set (L.Credential L.DRepRole L.StandardCrypto)
   -- ^ An empty credentials set means that states for all DReps will be returned
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.Credential L.DRepRole L.StandardCrypto) (L.DRepState L.StandardCrypto))))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.Credential L.DRepRole L.StandardCrypto) (L.DRepState L.StandardCrypto))))
 queryDRepState eraInMode sbe drepCreds = queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryDRepState drepCreds
 
 queryDRepStakeDistribution :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> Set (L.DRep L.StandardCrypto)
   -- ^ An empty DRep set means that distributions for all DReps will be returned
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.DRep L.StandardCrypto) Lovelace)))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.DRep L.StandardCrypto) Lovelace)))
 queryDRepStakeDistribution eraInMode sbe dreps = queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryDRepStakeDistr dreps
 
 -- | Returns info about committee members filtered by: cold credentials, hot credentials and statuses.
 -- If empty sets are passed as filters, then no filtering is done.
 queryCommitteeMembersState :: ()
-  => EraInMode era mode
+  => EraInMode era CardanoMode
   -> ShelleyBasedEra era
   -> Set (L.Credential L.ColdCommitteeRole L.StandardCrypto)
   -> Set (L.Credential L.HotCommitteeRole L.StandardCrypto)
   -> Set L.MemberStatus
-  -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.CommitteeMembersState L.StandardCrypto))))
+  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.CommitteeMembersState L.StandardCrypto))))
 queryCommitteeMembersState eraInMode sbe coldCreds hotCreds statuses =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe (QueryCommitteeMembersState coldCreds hotCreds statuses)

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -25,7 +25,6 @@ module Cardano.Api.Query.Expr
   , queryStakeSnapshot
   , querySystemStart
   , queryUtxo
-  , determineEraExpr
   , L.MemberStatus (..)
   , L.CommitteeMembersState (..)
   , queryCommitteeMembersState
@@ -59,7 +58,6 @@ import           Cardano.Ledger.SafeHash
 import           Cardano.Slotting.Slot
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as Consensus
 
-import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import           Data.Map (Map)
 import           Data.Set (Set)
 import qualified Data.Set as S
@@ -201,14 +199,6 @@ queryUtxo :: ()
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (UTxO era)))
 queryUtxo sbe utxoFilter =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryUTxO utxoFilter
-
--- | A monad expression that determines what era the node is in.
-determineEraExpr :: ()
-  => ConsensusModeParams CardanoMode
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
-determineEraExpr cModeParams = runExceptT $
-  case consensusModeOnly cModeParams of
-    CardanoMode -> ExceptT queryCurrentEra
 
 queryConstitution :: ()
   => ShelleyBasedEra era

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -63,85 +63,85 @@ import           Data.Set (Set)
 import qualified Data.Set as S
 
 queryChainBlockNo :: ()
-  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (WithOrigin BlockNo))
+  => LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (WithOrigin BlockNo))
 queryChainBlockNo =
   queryExpr QueryChainBlockNo
 
 queryChainPoint :: ()
-  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError ChainPoint)
+  => LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError ChainPoint)
 queryChainPoint =
-  queryExpr $ QueryChainPoint CardanoMode
+  queryExpr QueryChainPoint
 
 queryCurrentEra :: ()
-  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
+  => LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
 queryCurrentEra =
   queryExpr QueryCurrentEra
 
 queryCurrentEpochState :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedCurrentEpochState era)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedCurrentEpochState era)))
 queryCurrentEpochState sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryCurrentEpochState
 
 queryEpoch :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch EpochNo))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch EpochNo))
 queryEpoch sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryEpoch
 
 queryDebugLedgerState :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedDebugLedgerState era)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedDebugLedgerState era)))
 queryDebugLedgerState sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryDebugLedgerState
 
 queryEraHistory :: ()
-  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError  EraHistory)
+  => LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError  EraHistory)
 queryEraHistory =
   queryExpr QueryEraHistory
 
 queryGenesisParameters :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (GenesisParameters ShelleyEra)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (GenesisParameters ShelleyEra)))
 queryGenesisParameters sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryGenesisParameters
 
 queryPoolDistribution :: ()
   => ShelleyBasedEra era
   -> Maybe (Set PoolId)
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolDistribution era)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolDistribution era)))
 queryPoolDistribution sbe mPoolIds =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryPoolDistribution mPoolIds
 
 queryPoolState :: ()
   => ShelleyBasedEra era
   -> Maybe (Set PoolId)
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolState era)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolState era)))
 queryPoolState sbe mPoolIds =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryPoolState mPoolIds
 
 queryProtocolParameters :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Ledger.PParams (ShelleyLedgerEra era))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Ledger.PParams (ShelleyLedgerEra era))))
 queryProtocolParameters sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 
 queryConstitutionHash :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (SafeHash (EraCrypto (ShelleyLedgerEra era)) L.AnchorData))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (SafeHash (EraCrypto (ShelleyLedgerEra era)) L.AnchorData))))
 queryConstitutionHash sbe =
   (fmap . fmap . fmap . fmap) (L.anchorDataHash .  L.constitutionAnchor)
     $ queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryConstitution
 
 queryProtocolParametersUpdate :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash GenesisKey) ProtocolParametersUpdate)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash GenesisKey) ProtocolParametersUpdate)))
 queryProtocolParametersUpdate sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryProtocolParametersUpdate
 
 queryProtocolState :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (ProtocolState era)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (ProtocolState era)))
 queryProtocolState sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryProtocolState
 
@@ -149,66 +149,66 @@ queryStakeAddresses :: ()
   => ShelleyBasedEra era
   -> Set StakeCredential
   -> NetworkId
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map StakeAddress Lovelace, Map StakeAddress PoolId)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map StakeAddress Lovelace, Map StakeAddress PoolId)))
 queryStakeAddresses sbe stakeCredentials networkId =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeAddresses stakeCredentials networkId
 
 queryStakeDelegDeposits :: ()
   => ShelleyBasedEra era
   -> Set StakeCredential
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential Lovelace)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential Lovelace)))
 queryStakeDelegDeposits sbe stakeCreds
   | S.null stakeCreds = pure . pure $ pure mempty
   | otherwise         = queryExpr $ QueryInEra . QueryInShelleyBasedEra sbe $ QueryStakeDelegDeposits stakeCreds
 
 queryStakeDistribution :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash StakePoolKey) Rational)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash StakePoolKey) Rational)))
 queryStakeDistribution sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryStakeDistribution
 
 queryStakePoolParameters :: ()
   => ShelleyBasedEra era
   -> Set PoolId
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map PoolId StakePoolParameters)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map PoolId StakePoolParameters)))
 queryStakePoolParameters sbe poolIds
   | S.null poolIds  = pure . pure $ pure mempty
   | otherwise       = queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakePoolParameters poolIds
 
 queryStakePools :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Set PoolId)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Set PoolId)))
 queryStakePools sbe =
   queryExpr $ QueryInEra . QueryInShelleyBasedEra sbe $ QueryStakePools
 
 queryStakeSnapshot :: ()
   => ShelleyBasedEra era
   -> Maybe (Set PoolId)
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedStakeSnapshots era)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedStakeSnapshots era)))
 queryStakeSnapshot sbe mPoolIds =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeSnapshot mPoolIds
 
 querySystemStart :: ()
-  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError SystemStart)
+  => LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError SystemStart)
 querySystemStart =
   queryExpr QuerySystemStart
 
 queryUtxo :: ()
   => ShelleyBasedEra era
   -> QueryUTxOFilter
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (UTxO era)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (UTxO era)))
 queryUtxo sbe utxoFilter =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryUTxO utxoFilter
 
 queryConstitution :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.Constitution (ShelleyLedgerEra era)))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.Constitution (ShelleyLedgerEra era)))))
 queryConstitution sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryConstitution
 
 queryGovState :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (L.GovState (ShelleyLedgerEra era))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (L.GovState (ShelleyLedgerEra era))))
 queryGovState sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryGovState
 
@@ -216,14 +216,14 @@ queryDRepState :: ()
   => ShelleyBasedEra era
   -> Set (L.Credential L.DRepRole L.StandardCrypto)
   -- ^ An empty credentials set means that states for all DReps will be returned
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.Credential L.DRepRole L.StandardCrypto) (L.DRepState L.StandardCrypto))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.Credential L.DRepRole L.StandardCrypto) (L.DRepState L.StandardCrypto))))
 queryDRepState sbe drepCreds = queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryDRepState drepCreds
 
 queryDRepStakeDistribution :: ()
   => ShelleyBasedEra era
   -> Set (L.DRep L.StandardCrypto)
   -- ^ An empty DRep set means that distributions for all DReps will be returned
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.DRep L.StandardCrypto) Lovelace)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.DRep L.StandardCrypto) Lovelace)))
 queryDRepStakeDistribution sbe dreps = queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryDRepStakeDistr dreps
 
 -- | Returns info about committee members filtered by: cold credentials, hot credentials and statuses.
@@ -233,6 +233,6 @@ queryCommitteeMembersState :: ()
   -> Set (L.Credential L.ColdCommitteeRole L.StandardCrypto)
   -> Set (L.Credential L.HotCommitteeRole L.StandardCrypto)
   -> Set L.MemberStatus
-  -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.CommitteeMembersState L.StandardCrypto))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.CommitteeMembersState L.StandardCrypto))))
 queryCommitteeMembersState sbe coldCreds hotCreds statuses =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe (QueryCommitteeMembersState coldCreds hotCreds statuses)

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -43,7 +43,6 @@ import           Cardano.Api.GenesisParameters
 import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Monad
 import           Cardano.Api.Keys.Shelley
-import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query
@@ -81,25 +80,22 @@ queryCurrentEra =
   queryExpr QueryCurrentEra
 
 queryCurrentEpochState :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedCurrentEpochState era)))
-queryCurrentEpochState eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryCurrentEpochState
+queryCurrentEpochState sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryCurrentEpochState
 
 queryEpoch :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch EpochNo))
-queryEpoch eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryEpoch
+queryEpoch sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryEpoch
 
 queryDebugLedgerState :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedDebugLedgerState era)))
-queryDebugLedgerState eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryDebugLedgerState
+queryDebugLedgerState sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryDebugLedgerState
 
 queryEraHistory :: ()
   => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError  EraHistory)
@@ -107,105 +103,92 @@ queryEraHistory =
   queryExpr QueryEraHistory
 
 queryGenesisParameters :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (GenesisParameters ShelleyEra)))
-queryGenesisParameters eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryGenesisParameters
+queryGenesisParameters sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryGenesisParameters
 
 queryPoolDistribution :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> Maybe (Set PoolId)
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolDistribution era)))
-queryPoolDistribution eraInMode sbe mPoolIds =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryPoolDistribution mPoolIds
+queryPoolDistribution sbe mPoolIds =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryPoolDistribution mPoolIds
 
 queryPoolState :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> Maybe (Set PoolId)
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolState era)))
-queryPoolState eraInMode sbe mPoolIds =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryPoolState mPoolIds
+queryPoolState sbe mPoolIds =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryPoolState mPoolIds
 
 queryProtocolParameters :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Ledger.PParams (ShelleyLedgerEra era))))
-queryProtocolParameters eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters
+queryProtocolParameters sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 
 queryConstitutionHash :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (SafeHash (EraCrypto (ShelleyLedgerEra era)) L.AnchorData))))
-queryConstitutionHash eraInMode sbe =
+queryConstitutionHash sbe =
   (fmap . fmap . fmap . fmap) (L.anchorDataHash .  L.constitutionAnchor)
-    $ queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryConstitution
+    $ queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryConstitution
 
 queryProtocolParametersUpdate :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash GenesisKey) ProtocolParametersUpdate)))
-queryProtocolParametersUpdate eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolParametersUpdate
+queryProtocolParametersUpdate sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryProtocolParametersUpdate
 
 queryProtocolState :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (ProtocolState era)))
-queryProtocolState eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryProtocolState
+queryProtocolState sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryProtocolState
 
 queryStakeAddresses :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> Set StakeCredential
   -> NetworkId
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map StakeAddress Lovelace, Map StakeAddress PoolId)))
-queryStakeAddresses eraInMode sbe stakeCredentials networkId =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakeAddresses stakeCredentials networkId
+queryStakeAddresses sbe stakeCredentials networkId =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeAddresses stakeCredentials networkId
 
 queryStakeDelegDeposits :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> Set StakeCredential
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential Lovelace)))
-queryStakeDelegDeposits eraInMode sbe stakeCreds
+queryStakeDelegDeposits sbe stakeCreds
   | S.null stakeCreds = pure . pure $ pure mempty
-  | otherwise         = queryExpr $ QueryInEra eraInMode . QueryInShelleyBasedEra sbe $ QueryStakeDelegDeposits stakeCreds
+  | otherwise         = queryExpr $ QueryInEra . QueryInShelleyBasedEra sbe $ QueryStakeDelegDeposits stakeCreds
 
 queryStakeDistribution :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (Hash StakePoolKey) Rational)))
-queryStakeDistribution eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryStakeDistribution
+queryStakeDistribution sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryStakeDistribution
 
 queryStakePoolParameters :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> Set PoolId
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map PoolId StakePoolParameters)))
-queryStakePoolParameters eraInMode sbe poolIds
+queryStakePoolParameters sbe poolIds
   | S.null poolIds  = pure . pure $ pure mempty
-  | otherwise       = queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakePoolParameters poolIds
+  | otherwise       = queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakePoolParameters poolIds
 
 queryStakePools :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Set PoolId)))
-queryStakePools eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode . QueryInShelleyBasedEra sbe $ QueryStakePools
+queryStakePools sbe =
+  queryExpr $ QueryInEra . QueryInShelleyBasedEra sbe $ QueryStakePools
 
 queryStakeSnapshot :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> Maybe (Set PoolId)
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedStakeSnapshots era)))
-queryStakeSnapshot eraInMode sbe mPoolIds =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryStakeSnapshot mPoolIds
+queryStakeSnapshot sbe mPoolIds =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeSnapshot mPoolIds
 
 querySystemStart :: ()
   => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError SystemStart)
@@ -213,12 +196,11 @@ querySystemStart =
   queryExpr QuerySystemStart
 
 queryUtxo :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> QueryUTxOFilter
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (UTxO era)))
-queryUtxo eraInMode sbe utxoFilter =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryUTxO utxoFilter
+queryUtxo sbe utxoFilter =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryUTxO utxoFilter
 
 -- | A monad expression that determines what era the node is in.
 determineEraExpr :: ()
@@ -229,43 +211,38 @@ determineEraExpr cModeParams = runExceptT $
     CardanoMode -> ExceptT queryCurrentEra
 
 queryConstitution :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.Constitution (ShelleyLedgerEra era)))))
-queryConstitution eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryConstitution
+queryConstitution sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryConstitution
 
 queryGovState :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (L.GovState (ShelleyLedgerEra era))))
-queryGovState eraInMode sbe =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryGovState
+queryGovState sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryGovState
 
 queryDRepState :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> Set (L.Credential L.DRepRole L.StandardCrypto)
   -- ^ An empty credentials set means that states for all DReps will be returned
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.Credential L.DRepRole L.StandardCrypto) (L.DRepState L.StandardCrypto))))
-queryDRepState eraInMode sbe drepCreds = queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryDRepState drepCreds
+queryDRepState sbe drepCreds = queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryDRepState drepCreds
 
 queryDRepStakeDistribution :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> Set (L.DRep L.StandardCrypto)
   -- ^ An empty DRep set means that distributions for all DReps will be returned
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.DRep L.StandardCrypto) Lovelace)))
-queryDRepStakeDistribution eraInMode sbe dreps = queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe $ QueryDRepStakeDistr dreps
+queryDRepStakeDistribution sbe dreps = queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryDRepStakeDistr dreps
 
 -- | Returns info about committee members filtered by: cold credentials, hot credentials and statuses.
 -- If empty sets are passed as filters, then no filtering is done.
 queryCommitteeMembersState :: ()
-  => EraInMode era CardanoMode
-  -> ShelleyBasedEra era
+  => ShelleyBasedEra era
   -> Set (L.Credential L.ColdCommitteeRole L.StandardCrypto)
   -> Set (L.Credential L.HotCommitteeRole L.StandardCrypto)
   -> Set L.MemberStatus
   -> LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.CommitteeMembersState L.StandardCrypto))))
-queryCommitteeMembersState eraInMode sbe coldCreds hotCreds statuses =
-  queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe (QueryCommitteeMembersState coldCreds hotCreds statuses)
+queryCommitteeMembersState sbe coldCreds hotCreds statuses =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe (QueryCommitteeMembersState coldCreds hotCreds statuses)

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -227,7 +227,6 @@ determineEraExpr :: ()
 determineEraExpr cModeParams = runExceptT $
   case consensusModeOnly cModeParams of
     ByronMode -> pure $ AnyCardanoEra ByronEra
-    ShelleyMode -> pure $ AnyCardanoEra ShelleyEra
     CardanoMode -> ExceptT queryCurrentEra
 
 queryConstitution :: ()

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -102,7 +102,7 @@ queryDebugLedgerState eraInMode sbe =
   queryExpr $ QueryInEra eraInMode $ QueryInShelleyBasedEra sbe QueryDebugLedgerState
 
 queryEraHistory :: ()
-  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (EraHistory CardanoMode))
+  => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError  EraHistory)
 queryEraHistory =
   queryExpr QueryEraHistory
 

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -78,7 +78,7 @@ queryChainPoint =
 queryCurrentEra :: ()
   => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
 queryCurrentEra =
-  queryExpr $ QueryCurrentEra CardanoModeIsMultiEra
+  queryExpr QueryCurrentEra
 
 queryCurrentEpochState :: ()
   => EraInMode era mode
@@ -104,7 +104,7 @@ queryDebugLedgerState eraInMode sbe =
 queryEraHistory :: ()
   => LocalStateQueryExpr block point (QueryInMode CardanoMode) r IO (Either UnsupportedNtcVersionError (EraHistory CardanoMode))
 queryEraHistory =
-  queryExpr $ QueryEraHistory CardanoModeIsMultiEra
+  queryExpr QueryEraHistory
 
 queryGenesisParameters :: ()
   => EraInMode era mode

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -226,7 +226,6 @@ determineEraExpr :: ()
   -> LocalStateQueryExpr block point (QueryInMode mode) r IO (Either UnsupportedNtcVersionError AnyCardanoEra)
 determineEraExpr cModeParams = runExceptT $
   case consensusModeOnly cModeParams of
-    ByronMode -> pure $ AnyCardanoEra ByronEra
     CardanoMode -> ExceptT queryCurrentEra
 
 queryConstitution :: ()

--- a/cardano-api/internal/Cardano/Api/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Tx.hs
@@ -36,6 +36,7 @@ module Cardano.Api.Tx (
 
     -- ** Incremental signing and separate witnesses
     makeSignedTransaction,
+    makeSignedTransaction',
     KeyWitness(..),
     makeByronKeyWitness,
     ShelleyWitnessSigningKey(..),
@@ -492,6 +493,13 @@ getTxWitnesses (ShelleyTx sbe tx') =
                          => L.Tx ledgerera
                          -> [KeyWitness era]
     getAlonzoTxWitnesses = getShelleyTxWitnesses
+
+makeSignedTransaction' :: ()
+  => CardanoEra era
+  -> [KeyWitness era]
+  -> TxBody era
+  -> Tx era
+makeSignedTransaction' _ = makeSignedTransaction
 
 makeSignedTransaction :: forall era.
      [KeyWitness era]

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -790,7 +790,6 @@ module Cardano.Api (
     renderMode,
     ConsensusMode(CardanoMode),
     consensusModeOnly,
-    ConsensusModeIsMultiEra(..),
     AnyConsensusModeParams(..),
     ConsensusModeParams(..),
     ConsensusProtocol,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -824,7 +824,7 @@ module Cardano.Api (
     -- *** Local tx submission
     LocalTxSubmissionClient(..),
     TxInMode(..),
-    TxValidationErrorInMode(..),
+    TxValidationErrorInCardanoMode(..),
     SubmitResult(..),
     submitTxToNodeLocal,
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -790,7 +790,6 @@ module Cardano.Api (
     renderMode,
     ConsensusMode(CardanoMode),
     consensusModeOnly,
-    AnyConsensusModeParams(..),
     ConsensusModeParams(..),
     ConsensusProtocol,
     ChainDepStateProtocol,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -794,7 +794,6 @@ module Cardano.Api (
     ConsensusModeParams(..),
     ConsensusProtocol,
     ChainDepStateProtocol,
-    ConsensusBlockForMode,
     ConsensusBlockForEra,
     EraInMode(..),
     toEraInMode,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -789,7 +789,6 @@ module Cardano.Api (
     AnyConsensusMode(..),
     renderMode,
     ConsensusMode(CardanoMode),
-    consensusModeOnly,
     ConsensusModeParams(..),
     ConsensusProtocol,
     ChainDepStateProtocol,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -983,7 +983,6 @@ module Cardano.Api (
     queryStakeSnapshot,
     querySystemStart,
     queryUtxo,
-    determineEraExpr,
     queryConstitution,
     queryGovState,
     queryDRepState,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -795,8 +795,6 @@ module Cardano.Api (
     ConsensusProtocol,
     ChainDepStateProtocol,
     ConsensusBlockForEra,
-    EraInMode(..),
-    toEraInMode,
     LocalNodeClientProtocols(..),
     LocalNodeClientParams(..),
     mkLocalNodeClientParams,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -786,8 +786,6 @@ module Cardano.Api (
     connectToLocalNode,
     connectToLocalNodeWithVersion,
     LocalNodeConnectInfo(..),
-    AnyConsensusMode(..),
-    renderMode,
     ConsensusMode(CardanoMode),
     ConsensusModeParams(..),
     ConsensusProtocol,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -786,7 +786,6 @@ module Cardano.Api (
     connectToLocalNode,
     connectToLocalNodeWithVersion,
     LocalNodeConnectInfo(..),
-    ConsensusMode(CardanoMode),
     ConsensusModeParams(..),
     ConsensusProtocol,
     ChainDepStateProtocol,
@@ -795,7 +794,6 @@ module Cardano.Api (
     LocalNodeClientParams(..),
     mkLocalNodeClientParams,
     LocalChainSyncClient(..),
-    CardanoMode,
     --  connectToRemoteNode,
 
     -- ** Protocol related types

--- a/cardano-api/src/Cardano/Api/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Byron.hs
@@ -47,10 +47,6 @@ module Cardano.Api.Byron
 
     -- ** Low level protocol interaction with a Cardano node
     LocalNodeConnectInfo(LocalNodeConnectInfo),
-    ByronMode,
-    ConsensusMode
-      ( ByronMode
-      ),
     LocalNodeClientProtocols(LocalNodeClientProtocols),
 
     -- *** Chain sync protocol
@@ -92,7 +88,6 @@ module Cardano.Api.Byron
 
 import           Cardano.Api
 import           Cardano.Api.Address
-import           Cardano.Api.IPC
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.NetworkId
 import           Cardano.Api.SpecialByron

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -97,7 +97,6 @@ module Cardano.Api.Shelley
     fromConsensusBlock,
     toConsensusBlock,
     fromConsensusTip,
-    fromConsensusPointInMode,
     fromConsensusPointHF,
     toConsensusPointInMode,
     toConsensusPointHF,

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -214,10 +214,8 @@ module Cardano.Api.Shelley
 
     -- ** Low level protocol interaction with a Cardano node
     LocalNodeConnectInfo(LocalNodeConnectInfo),
-    ShelleyMode,
     ConsensusMode
       ( ByronMode
-      , ShelleyMode
       ),
     LocalNodeClientProtocols(LocalNodeClientProtocols),
 

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -214,9 +214,6 @@ module Cardano.Api.Shelley
 
     -- ** Low level protocol interaction with a Cardano node
     LocalNodeConnectInfo(LocalNodeConnectInfo),
-    ConsensusMode
-      ( ByronMode
-      ),
     LocalNodeClientProtocols(LocalNodeClientProtocols),
 
     -- ** Shelley based eras

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -98,7 +98,6 @@ module Cardano.Api.Shelley
     toConsensusBlock,
     fromConsensusTip,
     fromConsensusPointHF,
-    toConsensusPointInMode,
     toConsensusPointHF,
 
     -- * Transaction metadata

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 
 module Test.Cardano.Api.Json
   ( tests
@@ -9,8 +8,7 @@ module Test.Cardano.Api.Json
 import           Cardano.Api.Orphans ()
 import           Cardano.Api.Shelley
 
-import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), eitherDecode, encode)
-import           Data.Aeson.Types (Parser, parseEither)
+import           Data.Aeson (eitherDecode, encode)
 
 import           Test.Gen.Cardano.Api (genAlonzoGenesis)
 import           Test.Gen.Cardano.Api.Typed
@@ -52,30 +50,6 @@ prop_json_roundtrip_txout_utxo_context = H.property $ do
   txOut <- forAll $ genTxOutUTxOContext BabbageEra
   tripping txOut encode eitherDecode
 
-prop_json_roundtrip_eraInMode :: Property
-prop_json_roundtrip_eraInMode = H.property $ do
-  H.assert $ parseEither rountripEraInModeParser ByronEraInCardanoMode == Right ByronEraInCardanoMode
-  H.assert $ parseEither rountripEraInModeParser ShelleyEraInCardanoMode == Right ShelleyEraInCardanoMode
-  H.assert $ parseEither rountripEraInModeParser AllegraEraInCardanoMode == Right AllegraEraInCardanoMode
-  H.assert $ parseEither rountripEraInModeParser MaryEraInCardanoMode == Right MaryEraInCardanoMode
-  H.assert $ parseEither rountripEraInModeParser AlonzoEraInCardanoMode == Right AlonzoEraInCardanoMode
-  H.assert $ parseEither rountripEraInModeParser BabbageEraInCardanoMode == Right BabbageEraInCardanoMode
-  H.assert $ parseEither rountripEraInModeParser ConwayEraInCardanoMode == Right ConwayEraInCardanoMode
-
-  where
-    -- Defined this way instead of using 'tripping' in order to warn the
-    -- developer if there's ever a new constructor in 'EraInMode' and we would
-    -- need to add a new 'FromJSON' instance.
-    rountripEraInModeParser :: EraInMode era CardanoMode -> Parser (EraInMode era CardanoMode)
-    rountripEraInModeParser = \case
-      ByronEraInCardanoMode -> parseJSON $ toJSON ByronEraInCardanoMode
-      ShelleyEraInCardanoMode -> parseJSON $ toJSON ShelleyEraInCardanoMode
-      AllegraEraInCardanoMode -> parseJSON $ toJSON AllegraEraInCardanoMode
-      MaryEraInCardanoMode -> parseJSON $ toJSON MaryEraInCardanoMode
-      AlonzoEraInCardanoMode -> parseJSON $ toJSON AlonzoEraInCardanoMode
-      BabbageEraInCardanoMode -> parseJSON $ toJSON BabbageEraInCardanoMode
-      ConwayEraInCardanoMode -> parseJSON $ toJSON ConwayEraInCardanoMode
-
 prop_json_roundtrip_scriptdata_detailed_json :: Property
 prop_json_roundtrip_scriptdata_detailed_json = H.property $ do
   sData <- forAll genHashableScriptData
@@ -89,6 +63,5 @@ tests = testGroup "Test.Cardano.Api.Json"
   , testProperty "json roundtrip txoutvalue"               prop_json_roundtrip_txoutvalue
   , testProperty "json roundtrip txout tx context"         prop_json_roundtrip_txout_tx_context
   , testProperty "json roundtrip txout utxo context"       prop_json_roundtrip_txout_utxo_context
-  , testProperty "json roundtrip eraInMode"                prop_json_roundtrip_eraInMode
   , testProperty "json roundtrip scriptdata detailed json" prop_json_roundtrip_scriptdata_detailed_json
   ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -55,7 +55,6 @@ prop_json_roundtrip_txout_utxo_context = H.property $ do
 prop_json_roundtrip_eraInMode :: Property
 prop_json_roundtrip_eraInMode = H.property $ do
   H.assert $ parseEither rountripEraInModeParser ByronEraInByronMode == Right ByronEraInByronMode
-  H.assert $ parseEither rountripEraInModeParser ShelleyEraInShelleyMode == Right ShelleyEraInShelleyMode
   H.assert $ parseEither rountripEraInModeParser ByronEraInCardanoMode == Right ByronEraInCardanoMode
   H.assert $ parseEither rountripEraInModeParser ShelleyEraInCardanoMode == Right ShelleyEraInCardanoMode
   H.assert $ parseEither rountripEraInModeParser AllegraEraInCardanoMode == Right AllegraEraInCardanoMode
@@ -71,7 +70,6 @@ prop_json_roundtrip_eraInMode = H.property $ do
     rountripEraInModeParser :: EraInMode era mode -> Parser (EraInMode era mode)
     rountripEraInModeParser = \case
       ByronEraInByronMode -> parseJSON $ toJSON ByronEraInByronMode
-      ShelleyEraInShelleyMode -> parseJSON $ toJSON ShelleyEraInShelleyMode
       ByronEraInCardanoMode -> parseJSON $ toJSON ByronEraInCardanoMode
       ShelleyEraInCardanoMode -> parseJSON $ toJSON ShelleyEraInCardanoMode
       AllegraEraInCardanoMode -> parseJSON $ toJSON AllegraEraInCardanoMode

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -54,7 +54,6 @@ prop_json_roundtrip_txout_utxo_context = H.property $ do
 
 prop_json_roundtrip_eraInMode :: Property
 prop_json_roundtrip_eraInMode = H.property $ do
-  H.assert $ parseEither rountripEraInModeParser ByronEraInByronMode == Right ByronEraInByronMode
   H.assert $ parseEither rountripEraInModeParser ByronEraInCardanoMode == Right ByronEraInCardanoMode
   H.assert $ parseEither rountripEraInModeParser ShelleyEraInCardanoMode == Right ShelleyEraInCardanoMode
   H.assert $ parseEither rountripEraInModeParser AllegraEraInCardanoMode == Right AllegraEraInCardanoMode
@@ -69,7 +68,6 @@ prop_json_roundtrip_eraInMode = H.property $ do
     -- need to add a new 'FromJSON' instance.
     rountripEraInModeParser :: EraInMode era mode -> Parser (EraInMode era mode)
     rountripEraInModeParser = \case
-      ByronEraInByronMode -> parseJSON $ toJSON ByronEraInByronMode
       ByronEraInCardanoMode -> parseJSON $ toJSON ByronEraInCardanoMode
       ShelleyEraInCardanoMode -> parseJSON $ toJSON ShelleyEraInCardanoMode
       AllegraEraInCardanoMode -> parseJSON $ toJSON AllegraEraInCardanoMode

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -66,7 +66,7 @@ prop_json_roundtrip_eraInMode = H.property $ do
     -- Defined this way instead of using 'tripping' in order to warn the
     -- developer if there's ever a new constructor in 'EraInMode' and we would
     -- need to add a new 'FromJSON' instance.
-    rountripEraInModeParser :: EraInMode era mode -> Parser (EraInMode era mode)
+    rountripEraInModeParser :: EraInMode era CardanoMode -> Parser (EraInMode era CardanoMode)
     rountripEraInModeParser = \case
       ByronEraInCardanoMode -> parseJSON $ toJSON ByronEraInCardanoMode
       ShelleyEraInCardanoMode -> parseJSON $ toJSON ShelleyEraInCardanoMode


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Delete `ByronMode` and `ShelleyMode`
    Delete `anyEraInModeToAnyEra`
    Delete `AnyEraInMode`
    Modify to use `CardanoMode` only:
      - `executeQueryAnyMode`
      - `connectToLocalNode`
      - `connectToLocalNodeWithVersion
      - `mkLocalNodeClientParams`
      - `queryNodeLocalState`
      - `submitTxToNodeLocal`
      - `queryTxMonitoringLocal`
      - `getLocalChainTip`
      - `executeLocalStateQueryExpr`
    Deparameterise `LocalNodeClientProtocolsInMode`
    Modify `LocalNodeClientProtocols` to only work in `CardanoMode`.
    Rename `LocalNodeClientProtocolsInMode` to `LocalNodeClientProtocolsInIO`
    Rename `TxValidationErrorInMode` to `TxValidationErrorInCardanoMode`
    Deparameterise `TxValidationErrorInMode`
    Modify to use `CardanoMode` only
    - `determineEra`
    Deparameterise `LocalNodeConnectInfo`
    Deparameterise `LocalTxMonitoringResult`
    Deparameterise `LocalTxMonitoringQuery`
    Deparameterise `TxInMode`
    Modify to use `CardanoMode` only
    - `fromConsensusBlock`
    - `toConsensusBlock`
    - `queryExpr`
    - `getProgress`
    - `getSlotForRelativeTime`
    - `toLedgerEpochInfo`
    - `slotToEpoch`
    - `queryCurrentEpochState`
    - `queryEpoch`
    - `queryDebugLedgerState`
    - `queryGenesisParameters`
    - `queryPoolDistribution`
    - `queryPoolState`
    - `queryProtocolParameters`
    - `queryConstitutionHash`
    - `queryProtocolParametersUpdate`
    - `queryProtocolState`
    - `queryStakeAddresses`
    - `queryStakeDelegDeposits`
    - `queryStakeDistribution`
    - `queryStakePoolParameters`
    - `queryStakePools`
    - `queryStakeSnapshot`
    - `queryUtxo`
    - `queryConstitution`
    - `queryGovState`
    - `queryDRepState`
    - `queryDRepStakeDistribution`
    - `queryCommitteeMembersState`
    Deparameterise `BlockInMode`
    Deparameterise `TxIdInMode`
    Remove `EraInMode` argument in `QueryInEra` constructor
    Delete `ConsensusBlockForMode`
    Modify `TxInMode` to carry `CardanoEra` instead of `EraInMode`
    Deparameterise `BlockInMode`
    Deparameterise `TxIdInMode`
    Deparameterise `EraHistory`
    Modify to not take `EraInMode` argument
    - `queryCurrentEpochState`
    - `queryEpoch`
    - `queryDebugLedgerState`
    - `queryGenesisParameters`
    - `queryPoolDistribution`
    - `queryPoolState`
    - `queryProtocolParameters`
    - `queryConstitutionHash`
    - `queryProtocolParametersUpdate`
    - `queryProtocolState`
    - `queryStakeAddresses`
    - `queryStakeDelegDeposits`
    - `queryStakeDistribution`
    - `queryStakePoolParameters`
    - `queryStakePools`
    - `queryStakeSnapshot`
    - `queryUtxo`
    - `queryConstitution`
    - `queryGovState`
    - `queryDRepState`
    - `queryDRepStakeDistribution`
    - `queryCommitteeMembersState`
    Modify `TxInMode` constructors to remove `EraInMode` arguments from constructors
    Remove `EraInMode` from `TxValidationErrorInCardanoMode` constructors
    Delete `EraInMode`, `eraInModeToEra` and `toEraInMode`
    Remove `ConsensusMode` argument from:
    - `fromConsensusBlock`
    - `fromConsensusTip`
    - `determineEra`
    Delete `determineEraExpr`.  Use `queryCurrentEra` instead.
    Deparameterise `QueryInMode`
    Delete `AnyConsensusModeParams`
    Deparametrise `ConsensusModeParams`
    Remove `ConsensusMode` argument from `EraHistory` constructor
    Delete `EraConsensusModeMismatch` constructor
    Delete `localConsensusMode`, `AnyConsensusMode` and `renderMode`
    Delete `EraConsensusModeMismatch`
    Delete `CardanoMode` and `ConsensusMode`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We neither use not need `ConsensusMode` anymore.

This PR makes all the necessary changes to remove `ConsensusMode`.

Type names and function names retain the word `Mode` in them because that can be postponed to a future PR.

Refactoring to simplify code enabled by the removal can also be postponed to a future PR.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
