### PR TITLE
Replace `IsCardanoEra` and `IsShelleyBasedEra` contraints in GADT constructors with `Typeable`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -15,7 +15,6 @@ module Cardano.Api.Eon.ShelleyBasedEra
     ShelleyBasedEra(..)
   , IsShelleyBasedEra(..)
   , AnyShelleyBasedEra(..)
-  , anyShelleyBasedEra
   , InAnyShelleyBasedEra(..)
   , inAnyShelleyBasedEra
   , shelleyBasedToCardanoEra
@@ -228,7 +227,8 @@ shelleyBasedEraConstraints = \case
 
 data AnyShelleyBasedEra where
   AnyShelleyBasedEra
-    :: ShelleyBasedEra era
+    :: Typeable era
+    => ShelleyBasedEra era
     -> AnyShelleyBasedEra
 
 deriving instance Show AnyShelleyBasedEra
@@ -280,19 +280,13 @@ instance FromJSON AnyShelleyBasedEra where
         "Conway" -> pure $ AnyShelleyBasedEra ShelleyBasedEraConway
         wrong -> fail $ "Failed to parse unknown shelley-based era: " <> Text.unpack wrong
 
-anyShelleyBasedEra :: ()
-  => ShelleyBasedEra era
-  -> AnyShelleyBasedEra
-anyShelleyBasedEra sbe =
-  AnyShelleyBasedEra sbe
-
 -- | This pairs up some era-dependent type with a 'ShelleyBasedEra' value that
 -- tells us what era it is, but hides the era type. This is useful when the era
 -- is not statically known, for example when deserialising from a file.
 --
 data InAnyShelleyBasedEra thing where
   InAnyShelleyBasedEra
-    :: IsShelleyBasedEra era
+    :: Typeable era
     => ShelleyBasedEra era
     -> thing era
     -> InAnyShelleyBasedEra thing

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -313,7 +313,7 @@ cardanoEraConstraints = \case
 
 data AnyCardanoEra where
   AnyCardanoEra
-    :: IsCardanoEra era
+    :: Typeable era
     => CardanoEra era
     -> AnyCardanoEra
 
@@ -390,7 +390,7 @@ anyCardanoEra = \case
 --
 data InAnyCardanoEra thing where
   InAnyCardanoEra
-    :: IsCardanoEra era
+    :: Typeable era
     => CardanoEra era
     -> thing era
     -> InAnyCardanoEra thing

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -105,7 +105,6 @@ module Cardano.Api (
     ShelleyBasedEra(..),
     IsShelleyBasedEra(..),
     AnyShelleyBasedEra(..),
-    anyShelleyBasedEra,
     InAnyShelleyBasedEra(..),
     inAnyShelleyBasedEra,
     shelleyBasedToCardanoEra,

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
@@ -44,7 +44,7 @@ prop_toJSON_CardanoMatchesShelley :: Property
 prop_toJSON_CardanoMatchesShelley = property $ do
   AnyShelleyBasedEra sbe <- forAll $ Gen.element [minBound..maxBound]
 
-  toJSON (anyShelleyBasedEra sbe) === toJSON (anyCardanoEra (shelleyBasedToCardanoEra sbe))
+  toJSON (AnyShelleyBasedEra sbe) === toJSON (anyCardanoEra (shelleyBasedToCardanoEra sbe))
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Json"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace `IsCardanoEra` and `IsShelleyBasedEra` contraints in GADT constructors with `Typeable`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

There are very few places where we need `IsCardanoEra` and `IsShelleyBasedEra` in these GADTs.

In these few remaining places, `cardanoEraConstraints` and `shelleyBaseConstraints` can be used to get the constraints instead.

Removing these constraints is helpful because whilst it makes it more convenient when unpacking the GADT, when constructing the GADT it is more inconvenient because the declared constraints need to be available on construction.

Moreover, the removal of these constraints makes the modified GADTs more compatible with `EraInEon`.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
