### PR TITLE
Protocol version change is not common to all versions anymore

### DIFF
--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -112,6 +112,7 @@ module Cardano.Api.Shelley
     EraBasedProtocolParametersUpdate(..),
     CommonProtocolParametersUpdate(..),
     AlonzoOnwardsPParams(..),
+    DeprecatedAfterBabbagePParams(..),
     DeprecatedAfterMaryPParams(..),
     ShelleyToAlonzoPParams(..),
     IntroducedInBabbagePParams(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    --protocol-(minor|major)-version cannot be changed via create-protocol-parameters-update command in conway
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`cardano-api` part of fixing https://github.com/input-output-hk/cardano-cli/issues/388

# How to trust this PR

1. Observe that the `cppProtocolVersion` field is removed from the arguments common to all versions
2. See it is moved to the new type `DeprecatedAfterBabbagePParams`
3. Observe that the rest derives from there
4. See PR on `cardano-cli` that uses this change: https://github.com/input-output-hk/cardano-cli/pull/437

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff