### PR TITLE
Merge `ShelleyLedgerEra` and `CardanoLedgerEra` to a single type family `LedgerEra`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Era.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Era.hs
@@ -24,9 +24,9 @@ import           Test.QuickCheck (Arbitrary (..))
 
 shelleyBasedEraTestConstraints :: ()
   => ShelleyBasedEra era
-  ->  ( ( Ledger.Era (ShelleyLedgerEra era)
-        , Arbitrary (Ledger.PParamsHKD Ledger.StrictMaybe (ShelleyLedgerEra era))
-        , Arbitrary (Ledger.PParamsHKD Ledger.Identity (ShelleyLedgerEra era))
+  ->  ( ( Ledger.Era (LedgerEra era)
+        , Arbitrary (Ledger.PParamsHKD Ledger.StrictMaybe (LedgerEra era))
+        , Arbitrary (Ledger.PParamsHKD Ledger.Identity (LedgerEra era))
         )
       => a
       )
@@ -41,9 +41,9 @@ shelleyBasedEraTestConstraints = \case
 
 shelleyToBabbageEraTestConstraints :: ()
   => ShelleyToBabbageEra era
-  ->  ( ( Ledger.Era (ShelleyLedgerEra era)
-        , Arbitrary (Ledger.PParamsHKD Ledger.StrictMaybe (ShelleyLedgerEra era))
-        , Arbitrary (Ledger.PParamsHKD Ledger.Identity (ShelleyLedgerEra era))
+  ->  ( ( Ledger.Era (LedgerEra era)
+        , Arbitrary (Ledger.PParamsHKD Ledger.StrictMaybe (LedgerEra era))
+        , Arbitrary (Ledger.PParamsHKD Ledger.Identity (LedgerEra era))
         )
       => a
       )
@@ -57,9 +57,9 @@ shelleyToBabbageEraTestConstraints = \case
 
 conwayEraOnwardsTestConstraints :: ()
   => ConwayEraOnwards era
-  ->  ( ( Ledger.Era (ShelleyLedgerEra era)
-        , Arbitrary (Ledger.PParamsHKD Ledger.StrictMaybe (ShelleyLedgerEra era))
-        , Arbitrary (Ledger.PParamsHKD Ledger.Identity (ShelleyLedgerEra era))
+  ->  ( ( Ledger.Era (LedgerEra era)
+        , Arbitrary (Ledger.PParamsHKD Ledger.StrictMaybe (LedgerEra era))
+        , Arbitrary (Ledger.PParamsHKD Ledger.Identity (LedgerEra era))
         )
       => a
       )

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -368,14 +368,14 @@ genUnsignedQuantity = genQuantity (Range.constant 0 2)
 genPositiveQuantity :: Gen Quantity
 genPositiveQuantity = genQuantity (Range.constant 1 2)
 
-genValue :: MaryEraOnwards era -> Gen AssetId -> Gen Quantity -> Gen (L.Value (ShelleyLedgerEra era))
+genValue :: MaryEraOnwards era -> Gen AssetId -> Gen Quantity -> Gen (L.Value (LedgerEra era))
 genValue w genAId genQuant =
   toLedgerValue w . valueFromList <$>
     Gen.list (Range.constant 0 10)
              ((,) <$> genAId <*> genQuant)
 
 -- | Generate a 'Value' with any asset ID and a positive or negative quantity.
-genValueDefault :: MaryEraOnwards era -> Gen (L.Value (ShelleyLedgerEra era))
+genValueDefault :: MaryEraOnwards era -> Gen (L.Value (LedgerEra era))
 genValueDefault w = genValue w genAssetId genSignedNonZeroQuantity
 
 -- | Generate a 'Value' suitable for minting, i.e. non-ADA asset ID and a
@@ -390,7 +390,7 @@ genValueForMinting w =
 
 -- | Generate a 'Value' suitable for usage in a transaction output, i.e. any
 -- asset ID and a positive quantity.
-genValueForTxOut :: ShelleyBasedEra era -> Gen (L.Value (ShelleyLedgerEra era))
+genValueForTxOut :: ShelleyBasedEra era -> Gen (L.Value (LedgerEra era))
 genValueForTxOut sbe = do
   -- Generate at least one positive ADA, without it Value in TxOut makes no sense
   -- and will fail deserialization starting with ConwayEra

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -100,7 +100,7 @@ data Block era where
                 -> Block ByronEra
 
      ShelleyBlock :: ShelleyBasedEra era
-                  -> Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era)
+                  -> Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era)
                   -> Block era
 
 -- | A block consists of a header and a body containing transactions.
@@ -174,7 +174,7 @@ getBlockTxs = \case
 
 
 getShelleyBlockTxs :: forall era ledgerera blockheader.
-                      ShelleyLedgerEra era ~ ledgerera
+                      LedgerEra era ~ ledgerera
                    => Consensus.ShelleyCompatible (ConsensusProtocol era) ledgerera
                    => Consensus.ShelleyProtocolHeader (ConsensusProtocol era) ~ blockheader
                    => ShelleyBasedEra era

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -116,14 +116,14 @@ data Certificate era where
      --   7. MIR certificates
      ShelleyRelatedCertificate
        :: ShelleyToBabbageEra era
-       -> Ledger.ShelleyTxCert (ShelleyLedgerEra era)
+       -> Ledger.ShelleyTxCert (LedgerEra era)
        -> Certificate era
 
      -- Conway onwards
      -- TODO: Add comments about the new types of certificates
      ConwayCertificate
        :: ConwayEraOnwards era
-       -> Ledger.ConwayTxCert (ShelleyLedgerEra era)
+       -> Ledger.ConwayTxCert (LedgerEra era)
        -> Certificate era
 
   deriving anyclass SerialiseAsCBOR
@@ -141,14 +141,14 @@ instance
   ) => ToCBOR (Certificate era) where
     toCBOR =
       shelleyBasedEraConstraints (shelleyBasedEra @era)
-        $ Ledger.toEraCBOR @(ShelleyLedgerEra era) . toShelleyCertificate
+        $ Ledger.toEraCBOR @(LedgerEra era) . toShelleyCertificate
 
 instance
   ( IsShelleyBasedEra era
   ) => FromCBOR (Certificate era) where
     fromCBOR =
       shelleyBasedEraConstraints (shelleyBasedEra @era)
-        $ fromShelleyCertificate shelleyBasedEra <$> Ledger.fromEraCBOR @(ShelleyLedgerEra era)
+        $ fromShelleyCertificate shelleyBasedEra <$> Ledger.fromEraCBOR @(LedgerEra era)
 
 
 instance
@@ -278,7 +278,7 @@ data StakeDelegationRequirements era where
   StakeDelegationRequirementsConwayOnwards
     :: ConwayEraOnwards era
     -> StakeCredential
-    -> Ledger.Delegatee (EraCrypto (ShelleyLedgerEra era))
+    -> Ledger.Delegatee (EraCrypto (LedgerEra era))
     -> StakeDelegationRequirements era
 
   StakeDelegationRequirementsPreConway
@@ -302,12 +302,12 @@ makeStakeAddressDelegationCertificate = \case
 data StakePoolRegistrationRequirements era where
   StakePoolRegistrationRequirementsConwayOnwards
     :: ConwayEraOnwards era
-    -> Ledger.PoolParams (EraCrypto (ShelleyLedgerEra era))
+    -> Ledger.PoolParams (EraCrypto (LedgerEra era))
     -> StakePoolRegistrationRequirements era
 
   StakePoolRegistrationRequirementsPreConway
     :: ShelleyToBabbageEra era
-    -> Ledger.PoolParams (EraCrypto (ShelleyLedgerEra era))
+    -> Ledger.PoolParams (EraCrypto (LedgerEra era))
     -> StakePoolRegistrationRequirements era
 
 makeStakePoolRegistrationCertificate :: ()
@@ -369,7 +369,7 @@ data MirCertificateRequirements era where
   MirCertificateRequirements
     :: ShelleyToBabbageEra era
     -> Ledger.MIRPot
-    -> Ledger.MIRTarget (EraCrypto (ShelleyLedgerEra era))
+    -> Ledger.MIRTarget (EraCrypto (LedgerEra era))
     -> MirCertificateRequirements era
 
 makeMIRCertificate :: ()
@@ -382,14 +382,14 @@ makeMIRCertificate (MirCertificateRequirements atMostEra mirPot mirTarget) =
 data DRepRegistrationRequirements era where
   DRepRegistrationRequirements
     :: ConwayEraOnwards era
-    -> (Ledger.Credential Ledger.DRepRole (EraCrypto (ShelleyLedgerEra era)))
+    -> (Ledger.Credential Ledger.DRepRole (EraCrypto (LedgerEra era)))
     -> Lovelace
     -> DRepRegistrationRequirements era
 
 
 makeDrepRegistrationCertificate :: ()
   => DRepRegistrationRequirements era
-  -> Maybe (Ledger.Anchor (EraCrypto (ShelleyLedgerEra era)))
+  -> Maybe (Ledger.Anchor (EraCrypto (LedgerEra era)))
   -> Certificate era
 makeDrepRegistrationCertificate (DRepRegistrationRequirements conwayOnwards vcred deposit) anchor =
   ConwayCertificate conwayOnwards
@@ -402,8 +402,8 @@ makeDrepRegistrationCertificate (DRepRegistrationRequirements conwayOnwards vcre
 data CommitteeHotKeyAuthorizationRequirements era where
   CommitteeHotKeyAuthorizationRequirements
     :: ConwayEraOnwards era
-    -> Ledger.KeyHash Ledger.ColdCommitteeRole (EraCrypto (ShelleyLedgerEra era))
-    -> Ledger.KeyHash Ledger.HotCommitteeRole (EraCrypto (ShelleyLedgerEra era))
+    -> Ledger.KeyHash Ledger.ColdCommitteeRole (EraCrypto (LedgerEra era))
+    -> Ledger.KeyHash Ledger.HotCommitteeRole (EraCrypto (LedgerEra era))
     -> CommitteeHotKeyAuthorizationRequirements era
 
 makeCommitteeHotKeyAuthorizationCertificate :: ()
@@ -419,8 +419,8 @@ makeCommitteeHotKeyAuthorizationCertificate (CommitteeHotKeyAuthorizationRequire
 data CommitteeColdkeyResignationRequirements era where
   CommitteeColdkeyResignationRequirements
     :: ConwayEraOnwards era
-    -> Ledger.KeyHash Ledger.ColdCommitteeRole (EraCrypto (ShelleyLedgerEra era))
-    -> Maybe (Ledger.Anchor (EraCrypto (ShelleyLedgerEra era)))
+    -> Ledger.KeyHash Ledger.ColdCommitteeRole (EraCrypto (LedgerEra era))
+    -> Maybe (Ledger.Anchor (EraCrypto (LedgerEra era)))
     -> CommitteeColdkeyResignationRequirements era
 
 makeCommitteeColdkeyResignationCertificate :: ()
@@ -436,7 +436,7 @@ makeCommitteeColdkeyResignationCertificate (CommitteeColdkeyResignationRequireme
 data DRepUnregistrationRequirements era where
   DRepUnregistrationRequirements
     :: ConwayEraOnwards era
-    -> (Ledger.Credential Ledger.DRepRole (EraCrypto (ShelleyLedgerEra era)))
+    -> (Ledger.Credential Ledger.DRepRole (EraCrypto (LedgerEra era)))
     -> Lovelace
     -> DRepUnregistrationRequirements era
 
@@ -452,7 +452,7 @@ makeDrepUnregistrationCertificate (DRepUnregistrationRequirements conwayOnwards 
 makeStakeAddressAndDRepDelegationCertificate :: ()
   => ConwayEraOnwards era
   -> StakeCredential
-  -> Ledger.Delegatee (EraCrypto (ShelleyLedgerEra era))
+  -> Ledger.Delegatee (EraCrypto (LedgerEra era))
   -> Lovelace
   -> Certificate era
 makeStakeAddressAndDRepDelegationCertificate w cred delegatee deposit =
@@ -555,7 +555,7 @@ filterUnRegDRepCreds = \case
 
 toShelleyCertificate :: ()
   => Certificate era
-  -> Ledger.TxCert (ShelleyLedgerEra era)
+  -> Ledger.TxCert (LedgerEra era)
 toShelleyCertificate = \case
   ShelleyRelatedCertificate w c ->
     shelleyToBabbageEraConstraints w c
@@ -564,7 +564,7 @@ toShelleyCertificate = \case
 
 fromShelleyCertificate :: ()
   => ShelleyBasedEra era
-  -> Ledger.TxCert (ShelleyLedgerEra era)
+  -> Ledger.TxCert (LedgerEra era)
   -> Certificate era
 fromShelleyCertificate =
   caseShelleyToBabbageOrConwayEraOnwards ShelleyRelatedCertificate ConwayCertificate

--- a/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
@@ -66,23 +66,23 @@ instance ToCardanoEra AllegraEraOnwards where
     AllegraEraOnwardsConway  -> ConwayEra
 
 type AllegraEraOnwardsConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.AllegraEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.AllegraEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
@@ -70,34 +70,33 @@ instance ToCardanoEra AlonzoEraOnwards where
     AlonzoEraOnwardsConway  -> ConwayEra
 
 type AlonzoEraOnwardsConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.AlonzoEraPParams (ShelleyLedgerEra era)
-  , L.AlonzoEraTx (ShelleyLedgerEra era)
-  , L.AlonzoEraTxBody (ShelleyLedgerEra era)
-  , L.AlonzoEraTxOut (ShelleyLedgerEra era)
-  , L.AlonzoEraTxWits (ShelleyLedgerEra era)
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPlutusContext 'L.PlutusV1 (ShelleyLedgerEra era)
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.EraUTxO (ShelleyLedgerEra era)
-  , L.ExtendedUTxO (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.MaryEraTxBody (ShelleyLedgerEra era)
-  , L.Script (ShelleyLedgerEra era) ~ L.AlonzoScript (ShelleyLedgerEra era)
-  , L.ScriptsNeeded (ShelleyLedgerEra era) ~ L.AlonzoScriptsNeeded (ShelleyLedgerEra era)
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
+  , L.AlonzoEraPParams (LedgerEra era)
+  , L.AlonzoEraTx (LedgerEra era)
+  , L.AlonzoEraTxBody (LedgerEra era)
+  , L.AlonzoEraTxOut (LedgerEra era)
+  , L.AlonzoEraTxWits (LedgerEra era)
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPlutusContext 'L.PlutusV1 (LedgerEra era)
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraUTxO (LedgerEra era)
+  , L.ExtendedUTxO (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.MaryEraTxBody (LedgerEra era)
+  , L.Script (LedgerEra era) ~ L.AlonzoScript (LedgerEra era)
+  , L.ScriptsNeeded (LedgerEra era) ~ L.AlonzoScriptsNeeded (LedgerEra era)
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+  , L.Value (LedgerEra era) ~ L.MaryValue L.StandardCrypto
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
@@ -67,34 +67,34 @@ instance ToCardanoEra BabbageEraOnwards where
     BabbageEraOnwardsConway  -> ConwayEra
 
 type BabbageEraOnwardsConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.AlonzoEraTxOut (ShelleyLedgerEra era)
-  , L.BabbageEraPParams (ShelleyLedgerEra era)
-  , L.BabbageEraTxBody (ShelleyLedgerEra era)
-  , L.BabbageEraTxOut (ShelleyLedgerEra era)
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPlutusContext 'L.PlutusV1 (ShelleyLedgerEra era)
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.EraUTxO (ShelleyLedgerEra era)
-  , L.ExtendedUTxO (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.MaryEraTxBody (ShelleyLedgerEra era)
-  , L.Script (ShelleyLedgerEra era) ~ L.AlonzoScript (ShelleyLedgerEra era)
-  , L.ScriptsNeeded (ShelleyLedgerEra era) ~ L.AlonzoScriptsNeeded (ShelleyLedgerEra era)
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.TxOut (ShelleyLedgerEra era) ~ L.BabbageTxOut (ShelleyLedgerEra era)
-  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
+  , L.AlonzoEraTxOut (LedgerEra era)
+  , L.BabbageEraPParams (LedgerEra era)
+  , L.BabbageEraTxBody (LedgerEra era)
+  , L.BabbageEraTxOut (LedgerEra era)
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPlutusContext 'L.PlutusV1 (LedgerEra era)
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.EraUTxO (LedgerEra era)
+  , L.ExtendedUTxO (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.MaryEraTxBody (LedgerEra era)
+  , L.Script (LedgerEra era) ~ L.AlonzoScript (LedgerEra era)
+  , L.ScriptsNeeded (LedgerEra era) ~ L.AlonzoScriptsNeeded (LedgerEra era)
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+  , L.TxOut (LedgerEra era) ~ L.BabbageTxOut (LedgerEra era)
+  , L.Value (LedgerEra era) ~ L.MaryValue L.StandardCrypto
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -67,37 +67,37 @@ instance ToCardanoEra ConwayEraOnwards where
     ConwayEraOnwardsConway -> ConwayEra
 
 type ConwayEraOnwardsConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.AlonzoEraTxOut (ShelleyLedgerEra era)
-  , L.BabbageEraTxBody (ShelleyLedgerEra era)
-  , L.ConwayEraGov (ShelleyLedgerEra era)
-  , L.ConwayEraPParams (ShelleyLedgerEra era)
-  , L.ConwayEraTxBody (ShelleyLedgerEra era)
-  , L.ConwayEraTxCert (ShelleyLedgerEra era)
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraGov (ShelleyLedgerEra era)
-  , L.EraPlutusContext 'L.PlutusV1 (ShelleyLedgerEra era)
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.EraUTxO (ShelleyLedgerEra era)
-  , L.ExtendedUTxO (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.MaryEraTxBody (ShelleyLedgerEra era)
-  , L.Script (ShelleyLedgerEra era) ~ L.AlonzoScript (ShelleyLedgerEra era)
-  , L.ScriptsNeeded (ShelleyLedgerEra era) ~ L.AlonzoScriptsNeeded (ShelleyLedgerEra era)
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.TxCert (ShelleyLedgerEra era) ~ L.ConwayTxCert (ShelleyLedgerEra era)
-  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
+  , L.AlonzoEraTxOut (LedgerEra era)
+  , L.BabbageEraTxBody (LedgerEra era)
+  , L.ConwayEraGov (LedgerEra era)
+  , L.ConwayEraPParams (LedgerEra era)
+  , L.ConwayEraTxBody (LedgerEra era)
+  , L.ConwayEraTxCert (LedgerEra era)
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraGov (LedgerEra era)
+  , L.EraPlutusContext 'L.PlutusV1 (LedgerEra era)
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.EraUTxO (LedgerEra era)
+  , L.ExtendedUTxO (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.MaryEraTxBody (LedgerEra era)
+  , L.Script (LedgerEra era) ~ L.AlonzoScript (LedgerEra era)
+  , L.ScriptsNeeded (LedgerEra era) ~ L.AlonzoScriptsNeeded (LedgerEra era)
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+  , L.TxCert (LedgerEra era) ~ L.ConwayTxCert (LedgerEra era)
+  , L.Value (LedgerEra era) ~ L.MaryValue L.StandardCrypto
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
@@ -66,25 +66,25 @@ instance ToCardanoEra MaryEraOnwards where
     MaryEraOnwardsConway  -> ConwayEra
 
 type MaryEraOnwardsConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.EraUTxO (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.MaryEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.EraUTxO (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.MaryEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+  , L.Value (LedgerEra era) ~ L.MaryValue L.StandardCrypto
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -28,7 +28,7 @@ module Cardano.Api.Eon.ShelleyBasedEra
   , requireShelleyBasedEra
 
     -- ** Mapping to era types from the Shelley ledger library
-  , ShelleyLedgerEra
+  , LedgerEra
   , eraProtVerLow
 
   , ShelleyBasedEraConstraints
@@ -50,8 +50,6 @@ import qualified Cardano.Ledger.SafeHash as L
 import qualified Cardano.Ledger.UTxO as L
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
-import           Ouroboros.Consensus.Shelley.Eras as Consensus (StandardAllegra, StandardAlonzo,
-                   StandardBabbage, StandardConway, StandardMary, StandardShelley)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
 
 import           Control.DeepSeq
@@ -192,23 +190,24 @@ instance IsShelleyBasedEra ConwayEra where
    shelleyBasedEra = ShelleyBasedEraConway
 
 type ShelleyBasedEraConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.EraUTxO (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.EraUTxO (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , IsCardanoEra era
   , IsShelleyBasedEra era
@@ -309,25 +308,6 @@ shelleyBasedToCardanoEra ShelleyBasedEraMary    = MaryEra
 shelleyBasedToCardanoEra ShelleyBasedEraAlonzo  = AlonzoEra
 shelleyBasedToCardanoEra ShelleyBasedEraBabbage = BabbageEra
 shelleyBasedToCardanoEra ShelleyBasedEraConway  = ConwayEra
-
--- ----------------------------------------------------------------------------
--- Conversion to Shelley ledger library types
---
-
--- | A type family that connects our era type tags to equivalent type tags used
--- in the Shelley ledger library.
---
--- This type mapping  connect types from this API with types in the Shelley
--- ledger library which allows writing conversion functions in a more generic
--- way.
---
-type family ShelleyLedgerEra era = ledgerera | ledgerera -> era where
-  ShelleyLedgerEra ShelleyEra = Consensus.StandardShelley
-  ShelleyLedgerEra AllegraEra = Consensus.StandardAllegra
-  ShelleyLedgerEra MaryEra    = Consensus.StandardMary
-  ShelleyLedgerEra AlonzoEra  = Consensus.StandardAlonzo
-  ShelleyLedgerEra BabbageEra = Consensus.StandardBabbage
-  ShelleyLedgerEra ConwayEra  = Consensus.StandardConway
 
 -- | Lookup the lower major protocol version for the shelley based era. In other words
 -- this is the major protocol version that the era has started in.

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
@@ -60,29 +60,29 @@ instance ToCardanoEra ShelleyEraOnly where
     ShelleyEraOnlyShelley  -> ShelleyEra
 
 type ShelleyEraOnlyConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.ExactEra L.ShelleyEra (ShelleyLedgerEra era)
-  , L.ExactEra L.ShelleyEra (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 2
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 6
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 8
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
-  , L.Value (ShelleyLedgerEra era) ~ L.Coin
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.ExactEra L.ShelleyEra (LedgerEra era)
+  , L.ExactEra L.ShelleyEra (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (LedgerEra era) 2
+  , L.ProtVerAtMost (LedgerEra era) 6
+  , L.ProtVerAtMost (LedgerEra era) 8
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+  , L.TxCert (LedgerEra era) ~ L.ShelleyTxCert (LedgerEra era)
+  , L.Value (LedgerEra era) ~ L.Coin
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
@@ -63,28 +63,28 @@ instance ToCardanoEra ShelleyToAllegraEra where
     ShelleyToAllegraEraAllegra  -> AllegraEra
 
 type ShelleyToAllegraEraConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.EraUTxO (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 4
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 6
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 8
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
-  , L.Value (ShelleyLedgerEra era) ~ L.Coin
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.EraUTxO (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (LedgerEra era) 4
+  , L.ProtVerAtMost (LedgerEra era) 6
+  , L.ProtVerAtMost (LedgerEra era) 8
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+  , L.TxCert (LedgerEra era) ~ L.ShelleyTxCert (LedgerEra era)
+  , L.Value (LedgerEra era) ~ L.Coin
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
@@ -65,25 +65,25 @@ instance ToCardanoEra ShelleyToAlonzoEra where
     ShelleyToAlonzoEraAlonzo   -> AlonzoEra
 
 type ShelleyToAlonzoEraConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 6
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 8
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (LedgerEra era) 6
+  , L.ProtVerAtMost (LedgerEra era) 8
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+  , L.TxCert (LedgerEra era) ~ L.ShelleyTxCert (LedgerEra era)
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
@@ -67,24 +67,24 @@ instance ToCardanoEra ShelleyToBabbageEra where
     ShelleyToBabbageEraBabbage  -> BabbageEra
 
 type ShelleyToBabbageEraConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 8
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (LedgerEra era) 8
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+  , L.TxCert (LedgerEra era) ~ L.ShelleyTxCert (LedgerEra era)
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
@@ -63,26 +63,26 @@ instance ToCardanoEra ShelleyToMaryEra where
     ShelleyToMaryEraMary     -> MaryEra
 
 type ShelleyToMaryEraConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (LedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (LedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era) ~ ConsensusBlockForEra era
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (LedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 4
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 6
-  , L.ProtVerAtMost (ShelleyLedgerEra era) 8
-  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (LedgerEra era))
+  , L.Era (LedgerEra era)
+  , L.EraCrypto (LedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (LedgerEra era)
+  , L.EraTx (LedgerEra era)
+  , L.EraTxBody (LedgerEra era)
+  , L.EraTxOut (LedgerEra era)
+  , L.HashAnnotated (L.TxBody (LedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (LedgerEra era) 4
+  , L.ProtVerAtMost (LedgerEra era) 6
+  , L.ProtVerAtMost (LedgerEra era) 8
+  , L.ShelleyEraTxBody (LedgerEra era)
+  , L.ShelleyEraTxCert (LedgerEra era)
+  , L.TxCert (LedgerEra era) ~ L.ShelleyTxCert (LedgerEra era)
 
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -18,7 +18,6 @@ module Cardano.Api.Eras
   , InAnyCardanoEra(..)
   , inAnyCardanoEra
   , cardanoEraConstraints
-  , CardanoLedgerEra
   , ToCardanoEra(..)
 
     -- * IsEon

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -27,7 +27,7 @@ module Cardano.Api.Eras.Core
   , anyCardanoEra
   , InAnyCardanoEra(..)
   , inAnyCardanoEra
-  , CardanoLedgerEra
+  , LedgerEra
   , ToCardanoEra(..)
 
     -- * IsEon
@@ -409,15 +409,15 @@ inAnyCardanoEra era a =
 -- | A type family that connects our era type tags to equivalent type tags used
 -- in the ledger library.
 --
--- This type mapping  connect types from this API with types in the
+-- This type mapping connects types from this API with types in the
 -- ledger library which allows writing conversion functions in a more generic
 -- way.
 
-type family CardanoLedgerEra era = ledgerera | ledgerera -> era where
-  CardanoLedgerEra ByronEra   = L.ByronEra   L.StandardCrypto
-  CardanoLedgerEra ShelleyEra = L.ShelleyEra L.StandardCrypto
-  CardanoLedgerEra AllegraEra = L.AllegraEra L.StandardCrypto
-  CardanoLedgerEra MaryEra    = L.MaryEra    L.StandardCrypto
-  CardanoLedgerEra AlonzoEra  = L.AlonzoEra  L.StandardCrypto
-  CardanoLedgerEra BabbageEra = L.BabbageEra L.StandardCrypto
-  CardanoLedgerEra ConwayEra  = L.ConwayEra  L.StandardCrypto
+type family LedgerEra era = ledgerera | ledgerera -> era where
+  LedgerEra ByronEra   = L.ByronEra   L.StandardCrypto
+  LedgerEra ShelleyEra = L.ShelleyEra L.StandardCrypto
+  LedgerEra AllegraEra = L.AllegraEra L.StandardCrypto
+  LedgerEra MaryEra    = L.MaryEra    L.StandardCrypto
+  LedgerEra AlonzoEra  = L.AlonzoEra  L.StandardCrypto
+  LedgerEra BabbageEra = L.BabbageEra L.StandardCrypto
+  LedgerEra ConwayEra  = L.ConwayEra  L.StandardCrypto

--- a/cardano-api/internal/Cardano/Api/GenesisParameters.hs
+++ b/cardano-api/internal/Cardano/Api/GenesisParameters.hs
@@ -91,7 +91,7 @@ data GenesisParameters era =
 
        -- | The initial values of the updateable 'ProtocolParameters'.
        --
-       protocolInitialUpdateableProtocolParameters :: Ledger.PParams (ShelleyLedgerEra era)
+       protocolInitialUpdateableProtocolParameters :: Ledger.PParams (LedgerEra era)
      }
 
 

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -63,12 +63,12 @@ data GovernanceAction era
       ProtVer
   | UpdatePParams
       (StrictMaybe (Ledger.PrevGovActionId Ledger.PParamUpdatePurpose StandardCrypto))
-      (Ledger.PParamsUpdate (ShelleyLedgerEra era))
+      (Ledger.PParamsUpdate (LedgerEra era))
 
 toGovernanceAction :: ()
   => ShelleyBasedEra era
   -> GovernanceAction era
-  -> Gov.GovAction (ShelleyLedgerEra era)
+  -> Gov.GovAction (LedgerEra era)
 toGovernanceAction sbe =
   shelleyBasedEraConstraints sbe $ \case
     MotionOfNoConfidence prevGovId ->
@@ -99,8 +99,8 @@ toGovernanceAction sbe =
       Gov.ParameterChange preGovId ppup
 
 fromGovernanceAction
-  :: EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
-  => Gov.GovAction (ShelleyLedgerEra era)
+  :: EraCrypto (LedgerEra era) ~ StandardCrypto
+  => Gov.GovAction (LedgerEra era)
   -> GovernanceAction era
 fromGovernanceAction = \case
   Gov.NoConfidence prevGovId ->
@@ -125,7 +125,7 @@ fromGovernanceAction = \case
   Gov.InfoAction ->
     InfoAct
 
-newtype Proposal era = Proposal { unProposal :: Gov.ProposalProcedure (ShelleyLedgerEra era) }
+newtype Proposal era = Proposal { unProposal :: Gov.ProposalProcedure (LedgerEra era) }
 
 instance IsShelleyBasedEra era => Show (Proposal era) where
   show (Proposal pp) = do

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
@@ -36,29 +36,29 @@ import qualified Data.Text.Encoding as Text
 import           GHC.Generics
 
 newtype GovernanceActionId era = GovernanceActionId
-  { unGovernanceActionId :: Ledger.GovActionId (EraCrypto (ShelleyLedgerEra era))
+  { unGovernanceActionId :: Ledger.GovActionId (EraCrypto (LedgerEra era))
   }
   deriving (Show, Eq, Ord)
 
 instance IsShelleyBasedEra era => ToCBOR (GovernanceActionId era) where
   toCBOR = \case
     GovernanceActionId v ->
-      shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.toEraCBOR @(ShelleyLedgerEra era) v
+      shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.toEraCBOR @(LedgerEra era) v
 
 instance IsShelleyBasedEra era => FromCBOR (GovernanceActionId era) where
   fromCBOR = do
-    !v <- shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.fromEraCBOR @(ShelleyLedgerEra era)
+    !v <- shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.fromEraCBOR @(LedgerEra era)
     return $ GovernanceActionId v
 
-newtype Voter era = Voter (Ledger.Voter (L.EraCrypto (ShelleyLedgerEra era)))
+newtype Voter era = Voter (Ledger.Voter (L.EraCrypto (LedgerEra era)))
   deriving (Show, Eq, Ord)
 
 instance IsShelleyBasedEra era => ToCBOR (Voter era) where
-  toCBOR (Voter v) = shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.toEraCBOR @(ShelleyLedgerEra era) v
+  toCBOR (Voter v) = shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.toEraCBOR @(LedgerEra era) v
 
 instance IsShelleyBasedEra era => FromCBOR (Voter era) where
   fromCBOR = do
-    !v <- shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.fromEraCBOR @(ShelleyLedgerEra era)
+    !v <- shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.fromEraCBOR @(LedgerEra era)
     pure $ Voter v
 
 
@@ -88,15 +88,15 @@ createVotingProcedure eon vChoice mProposalAnchor =
           }
 
 newtype VotingProcedure era = VotingProcedure
-  { unVotingProcedure :: Ledger.VotingProcedure (ShelleyLedgerEra era)
+  { unVotingProcedure :: Ledger.VotingProcedure (LedgerEra era)
   } deriving (Show, Eq)
 
 instance IsShelleyBasedEra era => ToCBOR (VotingProcedure era) where
-  toCBOR (VotingProcedure vp) = shelleyBasedEraConstraints sbe $ L.toEraCBOR @(ShelleyLedgerEra era) vp
+  toCBOR (VotingProcedure vp) = shelleyBasedEraConstraints sbe $ L.toEraCBOR @(LedgerEra era) vp
     where sbe = shelleyBasedEra @era
 
 instance IsShelleyBasedEra era => FromCBOR (VotingProcedure era) where
-  fromCBOR = shelleyBasedEraConstraints (shelleyBasedEra @era) $ VotingProcedure <$> L.fromEraCBOR @(ShelleyLedgerEra era)
+  fromCBOR = shelleyBasedEraConstraints (shelleyBasedEra @era) $ VotingProcedure <$> L.fromEraCBOR @(LedgerEra era)
 
 instance IsShelleyBasedEra era => SerialiseAsCBOR (VotingProcedure era) where
   serialiseToCBOR = shelleyBasedEraConstraints (shelleyBasedEra @era) CBOR.serialize'
@@ -110,7 +110,7 @@ instance HasTypeProxy era => HasTypeProxy (VotingProcedure era) where
   proxyToAsType _ = AsVote
 
 newtype VotingProcedures era = VotingProcedures
-  { unVotingProcedures  :: L.VotingProcedures (ShelleyLedgerEra era)
+  { unVotingProcedures  :: L.VotingProcedures (LedgerEra era)
   }
 
 deriving instance Eq (VotingProcedures era)
@@ -121,12 +121,12 @@ instance IsShelleyBasedEra era => ToCBOR (VotingProcedures era) where
   toCBOR = \case
     VotingProcedures vp ->
       shelleyBasedEraConstraints (shelleyBasedEra @era)
-        $ L.toEraCBOR @(ShelleyLedgerEra era) vp
+        $ L.toEraCBOR @(LedgerEra era) vp
 
 instance IsShelleyBasedEra era => FromCBOR (VotingProcedures era) where
   fromCBOR =
     shelleyBasedEraConstraints (shelleyBasedEra @era)
-      $ VotingProcedures <$> L.fromEraCBOR @(ShelleyLedgerEra era)
+      $ VotingProcedures <$> L.fromEraCBOR @(LedgerEra era)
 
 instance IsShelleyBasedEra era => SerialiseAsCBOR (VotingProcedures era) where
   serialiseToCBOR = shelleyBasedEraConstraints (shelleyBasedEra @era) CBOR.serialize'
@@ -144,9 +144,9 @@ emptyVotingProcedures = VotingProcedures $ L.VotingProcedures Map.empty
 
 singletonVotingProcedures :: ()
   => ConwayEraOnwards era
-  -> L.Voter (L.EraCrypto (ShelleyLedgerEra era))
-  -> L.GovActionId (L.EraCrypto (ShelleyLedgerEra era))
-  -> L.VotingProcedure (ShelleyLedgerEra era)
+  -> L.Voter (L.EraCrypto (LedgerEra era))
+  -> L.GovActionId (L.EraCrypto (LedgerEra era))
+  -> L.VotingProcedure (LedgerEra era)
   -> VotingProcedures era
 singletonVotingProcedures _ voter govActionId votingProcedure =
   VotingProcedures

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -226,7 +226,7 @@ data TxValidationError era where
 
      ShelleyTxValidationError
        :: ShelleyBasedEra era
-       -> Consensus.ApplyTxErr (Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era))
+       -> Consensus.ApplyTxErr (Consensus.ShelleyBlock (ConsensusProtocol era) (LedgerEra era))
        -> TxValidationError era
 
 -- The GADT in the ShelleyTxValidationError case requires a custom instance

--- a/cardano-api/internal/Cardano/Api/Ledger/Lens.hs
+++ b/cardano-api/internal/Cardano/Api/Ledger/Lens.hs
@@ -66,7 +66,7 @@ import           Data.Set (Set)
 import           Lens.Micro
 
 newtype TxBody era = TxBody
-  { unTxBody :: L.TxBody (ShelleyLedgerEra era)
+  { unTxBody :: L.TxBody (LedgerEra era)
   }
 
 strictMaybeL :: Lens' (StrictMaybe a) (Maybe a)
@@ -79,7 +79,7 @@ strictMaybeL = lens g s
     s :: StrictMaybe a -> Maybe a -> StrictMaybe a
     s _ = maybe SNothing SJust
 
-txBodyL :: Lens' (TxBody era) (L.TxBody (ShelleyLedgerEra era))
+txBodyL :: Lens' (TxBody era) (L.TxBody (LedgerEra era))
 txBodyL = lens unTxBody (\_ x -> TxBody x)
 
 invalidBeforeTxBodyL :: AllegraEraOnwards era -> Lens' (TxBody era) (Maybe SlotNo)
@@ -144,7 +144,7 @@ invalidHereAfterStrictL = lens g s
     s :: L.ValidityInterval -> StrictMaybe SlotNo -> L.ValidityInterval
     s (L.ValidityInterval a _) b = L.ValidityInterval a b
 
-updateTxBodyL :: ShelleyToBabbageEra era -> Lens' (TxBody era) (StrictMaybe (L.Update (ShelleyLedgerEra era)))
+updateTxBodyL :: ShelleyToBabbageEra era -> Lens' (TxBody era) (StrictMaybe (L.Update (LedgerEra era)))
 updateTxBodyL w = shelleyToBabbageEraConstraints w $ txBodyL . L.updateTxBodyL
 
 mintTxBodyL :: MaryEraOnwards era -> Lens' (TxBody era) (L.MultiAsset L.StandardCrypto)
@@ -162,44 +162,44 @@ reqSignerHashesTxBodyL w = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSigner
 referenceInputsTxBodyL :: BabbageEraOnwards era -> Lens' (TxBody era) (Set (L.TxIn L.StandardCrypto))
 referenceInputsTxBodyL w = babbageEraOnwardsConstraints w $ txBodyL . L.referenceInputsTxBodyL
 
-collateralReturnTxBodyL :: BabbageEraOnwards era -> Lens' (TxBody era) (StrictMaybe (L.TxOut (ShelleyLedgerEra era)))
+collateralReturnTxBodyL :: BabbageEraOnwards era -> Lens' (TxBody era) (StrictMaybe (L.TxOut (LedgerEra era)))
 collateralReturnTxBodyL w = babbageEraOnwardsConstraints w $ txBodyL . L.collateralReturnTxBodyL
 
 totalCollateralTxBodyL :: BabbageEraOnwards era -> Lens' (TxBody era) (StrictMaybe L.Coin)
 totalCollateralTxBodyL w = babbageEraOnwardsConstraints w $ txBodyL . L.totalCollateralTxBodyL
 
-certsTxBodyL :: ShelleyBasedEra era -> Lens' (TxBody era) (L.StrictSeq (L.TxCert (ShelleyLedgerEra era)))
+certsTxBodyL :: ShelleyBasedEra era -> Lens' (TxBody era) (L.StrictSeq (L.TxCert (LedgerEra era)))
 certsTxBodyL w = shelleyBasedEraConstraints w $ txBodyL . L.certsTxBodyL
 
-votingProceduresTxBodyL :: ConwayEraOnwards era -> Lens' (TxBody era) (L.VotingProcedures (ShelleyLedgerEra era))
+votingProceduresTxBodyL :: ConwayEraOnwards era -> Lens' (TxBody era) (L.VotingProcedures (LedgerEra era))
 votingProceduresTxBodyL w = conwayEraOnwardsConstraints w $ txBodyL . L.votingProceduresTxBodyL
 
-proposalProceduresTxBodyL :: ConwayEraOnwards era -> Lens' (TxBody era) (L.OSet (L.ProposalProcedure (ShelleyLedgerEra era)))
+proposalProceduresTxBodyL :: ConwayEraOnwards era -> Lens' (TxBody era) (L.OSet (L.ProposalProcedure (LedgerEra era)))
 proposalProceduresTxBodyL w = conwayEraOnwardsConstraints w $ txBodyL . L.proposalProceduresTxBodyL
 
-mkAdaOnlyTxOut :: ShelleyBasedEra era -> L.Addr (L.EraCrypto (ShelleyLedgerEra era)) -> L.Coin -> L.TxOut (ShelleyLedgerEra era)
+mkAdaOnlyTxOut :: ShelleyBasedEra era -> L.Addr (L.EraCrypto (LedgerEra era)) -> L.Coin -> L.TxOut (LedgerEra era)
 mkAdaOnlyTxOut sbe addr coin =
   mkBasicTxOut sbe addr (mkAdaValue sbe coin)
 
-mkBasicTxOut :: ShelleyBasedEra era -> L.Addr (L.EraCrypto (ShelleyLedgerEra era)) -> L.Value (ShelleyLedgerEra era) -> L.TxOut (ShelleyLedgerEra era)
+mkBasicTxOut :: ShelleyBasedEra era -> L.Addr (L.EraCrypto (LedgerEra era)) -> L.Value (LedgerEra era) -> L.TxOut (LedgerEra era)
 mkBasicTxOut sbe addr value =
   shelleyBasedEraConstraints sbe $ L.mkBasicTxOut addr value
 
-mkAdaValue :: ShelleyBasedEra era -> L.Coin -> L.Value (ShelleyLedgerEra era)
+mkAdaValue :: ShelleyBasedEra era -> L.Coin -> L.Value (LedgerEra era)
 mkAdaValue sbe coin =
   caseShelleyToAllegraOrMaryEraOnwards
     (const coin)
     (const (L.MaryValue (L.unCoin coin) mempty))
     sbe
 
-adaAssetL :: ShelleyBasedEra era -> Lens' (L.Value (ShelleyLedgerEra era)) L.Coin
+adaAssetL :: ShelleyBasedEra era -> Lens' (L.Value (LedgerEra era)) L.Coin
 adaAssetL sbe =
   caseShelleyToAllegraOrMaryEraOnwards
     adaAssetShelleyToAllegraEraL
     adaAssetMaryEraOnwardsL
     sbe
 
-adaAssetShelleyToAllegraEraL :: ShelleyToAllegraEra era -> Lens' (L.Value (ShelleyLedgerEra era)) L.Coin
+adaAssetShelleyToAllegraEraL :: ShelleyToAllegraEra era -> Lens' (L.Value (LedgerEra era)) L.Coin
 adaAssetShelleyToAllegraEraL w =
   shelleyToAllegraEraConstraints w $ lens id const
 
@@ -215,8 +215,8 @@ multiAssetL w =
     (\(L.MaryValue _ ma) -> ma)
     (\(L.MaryValue c _) ma -> L.MaryValue c ma)
 
-valueTxOutL :: ShelleyBasedEra era -> Lens' (L.TxOut (ShelleyLedgerEra era)) (L.Value (ShelleyLedgerEra era))
+valueTxOutL :: ShelleyBasedEra era -> Lens' (L.TxOut (LedgerEra era)) (L.Value (LedgerEra era))
 valueTxOutL sbe = shelleyBasedEraConstraints sbe L.valueTxOutL
 
-valueTxOutAdaAssetL :: ShelleyBasedEra era -> Lens' (L.TxOut (ShelleyLedgerEra era)) L.Coin
+valueTxOutAdaAssetL :: ShelleyBasedEra era -> Lens' (L.TxOut (LedgerEra era)) L.Coin
 valueTxOutAdaAssetL sbe = valueTxOutL sbe . adaAssetL sbe

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -1517,7 +1517,7 @@ nextEpochEligibleLeadershipSlots :: forall era. ()
   -- ^ Potential slot leading stake pool
   -> SigningKey VrfKey
   -- ^ VRF signing key of the stake pool
-  -> Ledger.PParams (ShelleyLedgerEra era)
+  -> Ledger.PParams (LedgerEra era)
   -> EpochInfo (Either Text)
   -> (ChainTip, EpochNo)
   -> Either LeadershipError (Set SlotNo)
@@ -1653,7 +1653,7 @@ currentEpochEligibleLeadershipSlots :: forall era. ()
   => ShelleyBasedEra era
   -> ShelleyGenesis Shelley.StandardCrypto
   -> EpochInfo (Either Text)
-  -> Ledger.PParams (ShelleyLedgerEra era)
+  -> Ledger.PParams (LedgerEra era)
   -> ProtocolState era
   -> PoolId
   -> SigningKey VrfKey

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -246,7 +246,7 @@ data QueryInShelleyBasedEra era result where
     :: QueryInShelleyBasedEra era (GenesisParameters ShelleyEra)
 
   QueryProtocolParameters
-    :: QueryInShelleyBasedEra era (Ledger.PParams (ShelleyLedgerEra era))
+    :: QueryInShelleyBasedEra era (Ledger.PParams (LedgerEra era))
 
   QueryProtocolParametersUpdate
     :: QueryInShelleyBasedEra era
@@ -301,10 +301,10 @@ data QueryInShelleyBasedEra era result where
     -> QueryInShelleyBasedEra era (Map StakeCredential Lovelace)
 
   QueryConstitution
-    :: QueryInShelleyBasedEra era (Maybe (L.Constitution (ShelleyLedgerEra era)))
+    :: QueryInShelleyBasedEra era (Maybe (L.Constitution (LedgerEra era)))
 
   QueryGovState
-    :: QueryInShelleyBasedEra era (L.GovState (ShelleyLedgerEra era))
+    :: QueryInShelleyBasedEra era (L.GovState (LedgerEra era))
 
   QueryDRepState
     :: Set (Shelley.Credential Shelley.DRepRole StandardCrypto)
@@ -404,7 +404,7 @@ instance (IsShelleyBasedEra era, FromJSON (TxOut CtxUTxO era))
             <*> parseJSON txOutVal
 
 newtype SerialisedDebugLedgerState era
-  = SerialisedDebugLedgerState (Serialised (Shelley.NewEpochState (ShelleyLedgerEra era)))
+  = SerialisedDebugLedgerState (Serialised (Shelley.NewEpochState (LedgerEra era)))
 
 decodeDebugLedgerState :: forall era. ()
   => FromCBOR (DebugLedgerState era)
@@ -424,9 +424,9 @@ decodeProtocolState
 decodeProtocolState (ProtocolState (Serialised pbs)) = first (pbs,) $ Plain.decodeFull pbs
 
 newtype SerialisedCurrentEpochState era
-  = SerialisedCurrentEpochState (Serialised (Shelley.EpochState (ShelleyLedgerEra era)))
+  = SerialisedCurrentEpochState (Serialised (Shelley.EpochState (LedgerEra era)))
 
-newtype CurrentEpochState era = CurrentEpochState (Shelley.EpochState (ShelleyLedgerEra era))
+newtype CurrentEpochState era = CurrentEpochState (Shelley.EpochState (LedgerEra era))
 
 decodeCurrentEpochState
   :: ShelleyBasedEra era
@@ -436,28 +436,28 @@ decodeCurrentEpochState sbe (SerialisedCurrentEpochState (Serialised ls)) =
   shelleyBasedEraConstraints sbe $ CurrentEpochState <$> Plain.decodeFull ls
 
 newtype SerialisedPoolState era
-  = SerialisedPoolState (Serialised (Shelley.PState (ShelleyLedgerEra era)))
+  = SerialisedPoolState (Serialised (Shelley.PState (LedgerEra era)))
 
-newtype PoolState era = PoolState (Shelley.PState (ShelleyLedgerEra era))
+newtype PoolState era = PoolState (Shelley.PState (LedgerEra era))
 
 decodePoolState
   :: forall era. ()
-  => Core.Era (ShelleyLedgerEra era)
-  => DecCBOR (Shelley.PState (ShelleyLedgerEra era))
+  => Core.Era (LedgerEra era)
+  => DecCBOR (Shelley.PState (LedgerEra era))
   => SerialisedPoolState era
   -> Either DecoderError (PoolState era)
 decodePoolState (SerialisedPoolState (Serialised ls)) =
-  PoolState <$> decodeFull (Core.eraProtVerLow @(ShelleyLedgerEra era)) ls
+  PoolState <$> decodeFull (Core.eraProtVerLow @(LedgerEra era)) ls
 
 newtype SerialisedPoolDistribution era
-  = SerialisedPoolDistribution (Serialised (Shelley.PoolDistr (Core.EraCrypto (ShelleyLedgerEra era))))
+  = SerialisedPoolDistribution (Serialised (Shelley.PoolDistr (Core.EraCrypto (LedgerEra era))))
 
 newtype PoolDistribution era = PoolDistribution
-  { unPoolDistr :: Shelley.PoolDistr (Core.EraCrypto (ShelleyLedgerEra era))
+  { unPoolDistr :: Shelley.PoolDistr (Core.EraCrypto (LedgerEra era))
   }
 
 decodePoolDistribution
-  :: forall era. (Crypto (Core.EraCrypto (ShelleyLedgerEra era)))
+  :: forall era. (Crypto (Core.EraCrypto (LedgerEra era)))
   => ShelleyBasedEra era
   -> SerialisedPoolDistribution era
   -> Either DecoderError (PoolDistribution era)
@@ -465,13 +465,13 @@ decodePoolDistribution sbe (SerialisedPoolDistribution (Serialised ls)) =
   PoolDistribution <$> decodeFull (eraProtVerLow sbe) ls
 
 newtype SerialisedStakeSnapshots era
-  = SerialisedStakeSnapshots (Serialised (Consensus.StakeSnapshots (Core.EraCrypto (ShelleyLedgerEra era))))
+  = SerialisedStakeSnapshots (Serialised (Consensus.StakeSnapshots (Core.EraCrypto (LedgerEra era))))
 
-newtype StakeSnapshot era = StakeSnapshot (Consensus.StakeSnapshots (Core.EraCrypto (ShelleyLedgerEra era)))
+newtype StakeSnapshot era = StakeSnapshot (Consensus.StakeSnapshots (Core.EraCrypto (LedgerEra era)))
 
 decodeStakeSnapshot
   :: forall era. ()
-  => FromCBOR (Consensus.StakeSnapshots (Core.EraCrypto (ShelleyLedgerEra era)))
+  => FromCBOR (Consensus.StakeSnapshots (Core.EraCrypto (LedgerEra era)))
   => SerialisedStakeSnapshots era
   -> Either DecoderError (StakeSnapshot era)
 decodeStakeSnapshot (SerialisedStakeSnapshots (Serialised ls)) = StakeSnapshot <$> Plain.decodeFull ls
@@ -492,7 +492,7 @@ toShelleyAddrSet era =
 toLedgerUTxO :: ()
   => ShelleyBasedEra era
   -> UTxO era
-  -> Shelley.UTxO (ShelleyLedgerEra era)
+  -> Shelley.UTxO (LedgerEra era)
 toLedgerUTxO sbe (UTxO utxo) =
   shelleyBasedEraConstraints sbe
     $ Shelley.UTxO
@@ -503,7 +503,7 @@ toLedgerUTxO sbe (UTxO utxo) =
 
 fromLedgerUTxO :: ()
   => ShelleyBasedEra era
-  -> Shelley.UTxO (ShelleyLedgerEra era)
+  -> Shelley.UTxO (LedgerEra era)
   -> UTxO era
 fromLedgerUTxO sbe (Shelley.UTxO utxo) =
   shelleyBasedEraConstraints sbe
@@ -578,8 +578,8 @@ toConsensusQuery (QueryInEra (QueryInShelleyBasedEra sbe q)) =
   shelleyBasedEraConstraints sbe $ toConsensusQueryShelleyBased sbe q
 
 toConsensusQueryShelleyBased :: forall era protocol block result. ()
-  => ConsensusBlockForEra era ~ Consensus.ShelleyBlock protocol (ShelleyLedgerEra era)
-  => Core.EraCrypto (ShelleyLedgerEra era) ~ Consensus.StandardCrypto
+  => ConsensusBlockForEra era ~ Consensus.ShelleyBlock protocol (LedgerEra era)
+  => Core.EraCrypto (LedgerEra era) ~ Consensus.StandardCrypto
   => Consensus.CardanoBlock L.StandardCrypto ~ block
   => ShelleyBasedEra era
   -> QueryInShelleyBasedEra era result
@@ -800,7 +800,7 @@ fromConsensusQueryResult (QueryInEra (QueryInShelleyBasedEra ShelleyBasedEraConw
 fromConsensusQueryResultShelleyBased
   :: forall era ledgerera protocol result result'.
      HasCallStack
-  => ShelleyLedgerEra era ~ ledgerera
+  => LedgerEra era ~ ledgerera
   => Core.EraCrypto ledgerera ~ Consensus.StandardCrypto
   => ConsensusProtocol era ~ protocol
   => ShelleyBasedEra era

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -122,13 +122,13 @@ queryPoolState sbe mPoolIds =
 
 queryProtocolParameters :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Ledger.PParams (ShelleyLedgerEra era))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Ledger.PParams (LedgerEra era))))
 queryProtocolParameters sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 
 queryConstitutionHash :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (SafeHash (EraCrypto (ShelleyLedgerEra era)) L.AnchorData))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (SafeHash (EraCrypto (LedgerEra era)) L.AnchorData))))
 queryConstitutionHash sbe =
   (fmap . fmap . fmap . fmap) (L.anchorDataHash .  L.constitutionAnchor)
     $ queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryConstitution
@@ -202,13 +202,13 @@ queryUtxo sbe utxoFilter =
 
 queryConstitution :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.Constitution (ShelleyLedgerEra era)))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.Constitution (LedgerEra era)))))
 queryConstitution sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryConstitution
 
 queryGovState :: ()
   => ShelleyBasedEra era
-  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (L.GovState (ShelleyLedgerEra era))))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (L.GovState (LedgerEra era))))
 queryGovState sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryGovState
 

--- a/cardano-api/internal/Cardano/Api/Query/Types.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Types.hs
@@ -18,14 +18,14 @@ import           Data.Aeson (ToJSON (..), object, (.=))
 import qualified Data.Aeson as Aeson
 
 newtype DebugLedgerState era = DebugLedgerState
-  { unDebugLedgerState :: Shelley.NewEpochState (ShelleyLedgerEra era)
+  { unDebugLedgerState :: Shelley.NewEpochState (LedgerEra era)
   }
 
 instance IsShelleyBasedEra era => FromCBOR (DebugLedgerState era) where
   fromCBOR =
     shelleyBasedEraConstraints (shelleyBasedEra @era) $
       DebugLedgerState <$>
-        (fromCBOR :: Plain.Decoder s (Shelley.NewEpochState (ShelleyLedgerEra era)))
+        (fromCBOR :: Plain.Decoder s (Shelley.NewEpochState (LedgerEra era)))
 
 instance IsShelleyBasedEra era => ToJSON (DebugLedgerState era) where
   toJSON =

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -418,7 +418,7 @@ instance HasTypeProxy lang => HasTypeProxy (Script lang) where
 
 instance IsScriptLanguage lang => SerialiseAsCBOR (Script lang) where
     serialiseToCBOR (SimpleScript s) =
-      CBOR.serialize' (toAllegraTimelock s :: Timelock.Timelock (ShelleyLedgerEra AllegraEra))
+      CBOR.serialize' (toAllegraTimelock s :: Timelock.Timelock (LedgerEra AllegraEra))
 
     serialiseToCBOR (PlutusScript PlutusScriptV1 s) =
       CBOR.serialize' s
@@ -432,8 +432,8 @@ instance IsScriptLanguage lang => SerialiseAsCBOR (Script lang) where
     deserialiseFromCBOR _ bs =
       case scriptLanguage :: ScriptLanguage lang of
         SimpleScriptLanguage ->
-          let version = Ledger.eraProtVerLow @(ShelleyLedgerEra AllegraEra)
-          in  SimpleScript . fromAllegraTimelock @(ShelleyLedgerEra AllegraEra)
+          let version = Ledger.eraProtVerLow @(LedgerEra AllegraEra)
+          in  SimpleScript . fromAllegraTimelock @(LedgerEra AllegraEra)
           <$> Binary.decodeFullAnnotator version "Script" Binary.decCBOR (LBS.fromStrict bs)
 
         PlutusScriptLanguage PlutusScriptV1 ->
@@ -975,25 +975,25 @@ hashScript (SimpleScript s) =
     -- We convert to the Allegra-era version specifically and hash that.
     -- Later ledger eras have to be compatible anyway.
     ScriptHash
-  . Ledger.hashScript @(ShelleyLedgerEra AllegraEra)
-  . (toAllegraTimelock :: SimpleScript -> Timelock.Timelock (ShelleyLedgerEra AllegraEra))
+  . Ledger.hashScript @(LedgerEra AllegraEra)
+  . (toAllegraTimelock :: SimpleScript -> Timelock.Timelock (LedgerEra AllegraEra))
   $ s
 
 hashScript (PlutusScript PlutusScriptV1 (PlutusScriptSerialised script)) =
     -- For Plutus V1, we convert to the Alonzo-era version specifically and
     -- hash that. Later ledger eras have to be compatible anyway.
     ScriptHash
-  . Ledger.hashScript @(ShelleyLedgerEra AlonzoEra)
+  . Ledger.hashScript @(LedgerEra AlonzoEra)
   $ AlonzoPlutusScript Alonzo.PlutusV1 script
 
 hashScript (PlutusScript PlutusScriptV2 (PlutusScriptSerialised script)) =
     ScriptHash
-  . Ledger.hashScript @(ShelleyLedgerEra BabbageEra)
+  . Ledger.hashScript @(LedgerEra BabbageEra)
   $ AlonzoPlutusScript Alonzo.PlutusV2 script
 
 hashScript (PlutusScript PlutusScriptV3 (PlutusScriptSerialised script)) =
     ScriptHash
-  . Ledger.hashScript @(ShelleyLedgerEra ConwayEra)
+  . Ledger.hashScript @(LedgerEra ConwayEra)
   $ AlonzoPlutusScript Alonzo.PlutusV3 script
 
 toShelleyScriptHash :: ScriptHash -> Shelley.ScriptHash StandardCrypto
@@ -1100,7 +1100,7 @@ scriptArityForWitCtx WitCtxStake = 2
 -- Conversion functions
 --
 
-toShelleyScript :: ScriptInEra era -> Ledger.Script (ShelleyLedgerEra era)
+toShelleyScript :: ScriptInEra era -> Ledger.Script (LedgerEra era)
 toShelleyScript (ScriptInEra langInEra (SimpleScript script)) =
     case langInEra of
       SimpleScriptInShelley -> either (error . show) id (toShelleyMultiSig script)
@@ -1129,7 +1129,7 @@ toShelleyScript (ScriptInEra langInEra (PlutusScript PlutusScriptV3
       PlutusScriptV3InConway  -> AlonzoPlutusScript Alonzo.PlutusV3 script
 
 fromShelleyBasedScript  :: ShelleyBasedEra era
-                        -> Ledger.Script (ShelleyLedgerEra era)
+                        -> Ledger.Script (LedgerEra era)
                         -> ScriptInEra era
 fromShelleyBasedScript sbe script =
   case sbe of
@@ -1407,7 +1407,7 @@ instance IsCardanoEra era => FromJSON (ReferenceScript era) where
 refScriptToShelleyScript
   :: CardanoEra era
   -> ReferenceScript era
-  -> StrictMaybe (Ledger.Script (ShelleyLedgerEra era))
+  -> StrictMaybe (Ledger.Script (LedgerEra era))
 refScriptToShelleyScript era (ReferenceScript _ s) =
   case toScriptInEra era s of
     Just sInEra -> SJust $ toShelleyScript sInEra
@@ -1415,7 +1415,7 @@ refScriptToShelleyScript era (ReferenceScript _ s) =
 refScriptToShelleyScript _ ReferenceScriptNone = SNothing
 
 fromShelleyScriptToReferenceScript
-  :: ShelleyBasedEra era -> Ledger.Script (ShelleyLedgerEra era) -> ReferenceScript era
+  :: ShelleyBasedEra era -> Ledger.Script (LedgerEra era) -> ReferenceScript era
 fromShelleyScriptToReferenceScript sbe script =
    scriptInEraToRefScript $ fromShelleyBasedScript sbe script
 

--- a/cardano-api/internal/Cardano/Api/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Tx.hs
@@ -109,7 +109,7 @@ data Tx era where
 
      ShelleyTx
        :: ShelleyBasedEra era
-       -> L.Tx (ShelleyLedgerEra era)
+       -> L.Tx (LedgerEra era)
        -> Tx era
 
 
@@ -393,12 +393,12 @@ encodeShelleyBasedBootstrapWitness wit =
     CBOR.encodeListLen 2 <> CBOR.encodeWord 1 <> CBOR.encCBOR wit
 
 decodeShelleyBasedWitness :: forall era.
-                             L.Era (ShelleyLedgerEra era)
+                             L.Era (LedgerEra era)
                           => ShelleyBasedEra era
                           -> ByteString
                           -> Either CBOR.DecoderError (KeyWitness era)
 decodeShelleyBasedWitness sbe =
-    CBOR.decodeFullAnnotator (L.eraProtVerLow @(ShelleyLedgerEra era))
+    CBOR.decodeFullAnnotator (L.eraProtVerLow @(LedgerEra era))
       "Shelley Witness" decode
     . LBS.fromStrict
   where
@@ -528,7 +528,7 @@ makeSignedTransaction witnesses (ShelleyTxBody sbe txbody
   where
     txCommon
       :: forall ledgerera.
-         ShelleyLedgerEra era ~ ledgerera
+         LedgerEra era ~ ledgerera
       => L.EraCrypto ledgerera ~ StandardCrypto
       => L.EraTx ledgerera
       => L.Tx ledgerera
@@ -547,7 +547,7 @@ makeSignedTransaction witnesses (ShelleyTxBody sbe txbody
 
     shelleySignedTransaction
       :: forall ledgerera.
-         ShelleyLedgerEra era ~ ledgerera
+         LedgerEra era ~ ledgerera
       => Ledger.EraCrypto ledgerera ~ StandardCrypto
       => Ledger.EraTx ledgerera
       => Tx era
@@ -555,7 +555,7 @@ makeSignedTransaction witnesses (ShelleyTxBody sbe txbody
 
     alonzoSignedTransaction
       :: forall ledgerera.
-         ShelleyLedgerEra era ~ ledgerera
+         LedgerEra era ~ ledgerera
       => Ledger.EraCrypto ledgerera ~ StandardCrypto
       => L.AlonzoEraTx ledgerera
       => Tx era
@@ -633,7 +633,7 @@ makeShelleyBootstrapWitness sbe nwOrAddr txBody sk =
 makeShelleyBasedBootstrapWitness :: forall era. ()
   => ShelleyBasedEra era
   -> WitnessNetworkIdOrByronAddress
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> SigningKey ByronKey
   -> KeyWitness era
 makeShelleyBasedBootstrapWitness sbe nwOrAddr txbody (ByronSigningKey sk) =

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -693,7 +693,7 @@ toByronTxOut ByronEraOnlyByron = \case
 
 
 toShelleyTxOut :: forall era ledgerera.
-                  ShelleyLedgerEra era ~ ledgerera
+                  LedgerEra era ~ ledgerera
                => ShelleyBasedEra era
                -> TxOut CtxUTxO era
                -> Ledger.TxOut ledgerera
@@ -716,7 +716,7 @@ toShelleyTxOut sbe = \case -- jky simplify
 
 fromShelleyTxOut :: forall era ctx. ()
   => ShelleyBasedEra era
-  -> Core.TxOut (ShelleyLedgerEra era)
+  -> Core.TxOut (LedgerEra era)
   -> TxOut ctx era
 fromShelleyTxOut sbe ledgerTxOut = shelleyBasedEraConstraints sbe $ do
   let txOutValue = TxOutValueShelleyBased sbe $ ledgerTxOut ^. A.valueTxOutL sbe
@@ -766,8 +766,8 @@ fromShelleyTxOut sbe ledgerTxOut = shelleyBasedEraConstraints sbe $ do
         mRefScript = ledgerTxOut ^. L.referenceScriptTxOutL
 
 toBabbageTxOutDatum
-  :: (L.Era (ShelleyLedgerEra era), Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto)
-  => TxOutDatum CtxUTxO era -> Babbage.Datum (ShelleyLedgerEra era)
+  :: (L.Era (LedgerEra era), Ledger.EraCrypto (LedgerEra era) ~ StandardCrypto)
+  => TxOutDatum CtxUTxO era -> Babbage.Datum (LedgerEra era)
 toBabbageTxOutDatum  TxOutDatumNone = Babbage.NoDatum
 toBabbageTxOutDatum (TxOutDatumHash _ (ScriptDataHash dh)) = Babbage.DatumHash dh
 toBabbageTxOutDatum (TxOutDatumInline _ sd) = scriptDataToInlineDatum sd
@@ -844,11 +844,11 @@ data TxOutValue era where
     -> TxOutValue era
 
   TxOutValueShelleyBased
-    ::  ( Eq (Ledger.Value (ShelleyLedgerEra era))
-        , Show (Ledger.Value (ShelleyLedgerEra era))
+    ::  ( Eq (Ledger.Value (LedgerEra era))
+        , Show (Ledger.Value (LedgerEra era))
         )
     => ShelleyBasedEra era
-    -> L.Value (ShelleyLedgerEra era)
+    -> L.Value (LedgerEra era)
     -> TxOutValue era
 
 deriving instance Eq   (TxOutValue era)
@@ -1324,11 +1324,11 @@ data TxBody era where
 
      ShelleyTxBody
        :: ShelleyBasedEra era
-       -> Ledger.TxBody (ShelleyLedgerEra era)
+       -> Ledger.TxBody (LedgerEra era)
 
           -- We include the scripts along with the tx body, rather than the
           -- witnesses set, since they need to be known when building the body.
-       -> [Ledger.Script (ShelleyLedgerEra era)]
+       -> [Ledger.Script (LedgerEra era)]
 
           -- The info for each use of each script: the script input data, both
           -- the UTxO input data (called the "datum") and the supplied input
@@ -1343,13 +1343,13 @@ data TxBody era where
           -- extra script data has to be passed to scripts and hence is needed
           -- for validation. It is thus part of the witness data, not the
           -- auxiliary data.
-       -> Maybe (L.TxAuxData (ShelleyLedgerEra era))
+       -> Maybe (L.TxAuxData (LedgerEra era))
 
        -> TxScriptValidity era -- ^ Mark script as expected to pass or fail validation
 
        -> TxBody era
      -- The 'ShelleyBasedEra' GADT tells us what era we are in.
-     -- The 'ShelleyLedgerEra' type family maps that to the era type from the
+     -- The 'LedgerEra' type family maps that to the era type from the
      -- ledger lib. The 'Ledger.TxBody' type family maps that to a specific
      -- tx body type, which is different for each Shelley-based era.
 
@@ -1357,12 +1357,12 @@ data TxBody era where
 data TxBodyScriptData era where
      TxBodyNoScriptData :: TxBodyScriptData era
      TxBodyScriptData   :: AlonzoEraOnwards era
-                        -> Alonzo.TxDats (ShelleyLedgerEra era)
-                        -> Alonzo.Redeemers (ShelleyLedgerEra era)
+                        -> Alonzo.TxDats (LedgerEra era)
+                        -> Alonzo.Redeemers (LedgerEra era)
                         -> TxBodyScriptData era
 
 deriving instance Eq   (TxBodyScriptData era)
-deriving instance L.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto => Show (TxBodyScriptData era)
+deriving instance L.EraCrypto (LedgerEra era) ~ StandardCrypto => Show (TxBodyScriptData era)
 
 
 -- The GADT in the ShelleyTxBody case requires a custom instance
@@ -1547,23 +1547,23 @@ instance IsCardanoEra era => SerialiseAsCBOR (TxBody era) where
 -- same, but they can be handled generally with one overloaded implementation.
 serialiseShelleyBasedTxBody :: forall era. ()
   => ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
-  -> [Ledger.Script (ShelleyLedgerEra era)]
+  -> Ledger.TxBody (LedgerEra era)
+  -> [Ledger.Script (LedgerEra era)]
   -> TxBodyScriptData era
-  -> Maybe (L.TxAuxData (ShelleyLedgerEra era))
+  -> Maybe (L.TxAuxData (LedgerEra era))
   -> TxScriptValidity era -- ^ Mark script as expected to pass or fail validation
   -> ByteString
 serialiseShelleyBasedTxBody sbe txbody txscripts
                             TxBodyNoScriptData txmetadata scriptValidity =
   caseShelleyToMaryOrAlonzoEraOnwards
-    (const $ CBOR.serialize' (L.eraProtVerLow @(ShelleyLedgerEra era)) $ mconcat
+    (const $ CBOR.serialize' (L.eraProtVerLow @(LedgerEra era)) $ mconcat
       [ CBOR.encodeListLen 3
       , CBOR.encCBOR txbody
       , CBOR.encCBOR txscripts
       , CBOR.encodeNullMaybe CBOR.encCBOR txmetadata
       ]
     )
-    (const $ CBOR.serialize' (L.eraProtVerLow @(ShelleyLedgerEra era)) $ mconcat
+    (const $ CBOR.serialize' (L.eraProtVerLow @(LedgerEra era)) $ mconcat
       [ CBOR.encodeListLen 4
       , CBOR.encCBOR txbody
       , CBOR.encCBOR txscripts
@@ -1577,7 +1577,7 @@ serialiseShelleyBasedTxBody _ txbody txscripts
                             (TxBodyScriptData w datums redeemers)
                             txmetadata txBodyScriptValidity =
   alonzoEraOnwardsConstraints w $
-    CBOR.serialize' (L.eraProtVerLow @(ShelleyLedgerEra era)) $ mconcat
+    CBOR.serialize' (L.eraProtVerLow @(LedgerEra era)) $ mconcat
       [ CBOR.encodeListLen 6
       , CBOR.encCBOR txbody
       , CBOR.encCBOR txscripts
@@ -1594,7 +1594,7 @@ deserialiseShelleyBasedTxBody :: forall era. ()
 deserialiseShelleyBasedTxBody sbe bs =
   shelleyBasedEraConstraints sbe $
     CBOR.decodeFullAnnotator
-      (L.eraProtVerLow @(ShelleyLedgerEra era))
+      (L.eraProtVerLow @(LedgerEra era))
       "Shelley TxBody"
       decodeAnnotatedTuple
       (LBS.fromStrict bs)
@@ -1719,9 +1719,9 @@ getTxId (ShelleyTxBody sbe tx _ _ _ _) =
   shelleyBasedEraConstraints sbe $ getTxIdShelley sbe tx
 
 getTxIdShelley
-  :: Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
-  => Ledger.EraTxBody (ShelleyLedgerEra era)
-  => ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxId
+  :: Ledger.EraCrypto (LedgerEra era) ~ StandardCrypto
+  => Ledger.EraTxBody (LedgerEra era)
+  => ShelleyBasedEra era -> Ledger.TxBody (LedgerEra era) -> TxId
 getTxIdShelley _ tx =
     TxId
   . Crypto.castHash
@@ -1857,7 +1857,7 @@ getScriptIntegrityHash :: ()
   => BuildTxWith BuildTx (Maybe (LedgerProtocolParameters era))
   -> Set Alonzo.Language
   -> TxBodyScriptData era
-  -> StrictMaybe (L.ScriptIntegrityHash (Ledger.EraCrypto (ShelleyLedgerEra era)))
+  -> StrictMaybe (L.ScriptIntegrityHash (Ledger.EraCrypto (LedgerEra era)))
 getScriptIntegrityHash apiProtocolParameters languages = \case
   TxBodyNoScriptData -> SNothing
   TxBodyScriptData w datums redeemers ->
@@ -2029,9 +2029,9 @@ getTxBodyContent = \case
 fromLedgerTxBody
   :: ShelleyBasedEra era
   -> TxScriptValidity era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> TxBodyScriptData era
-  -> Maybe (L.TxAuxData (ShelleyLedgerEra era))
+  -> Maybe (L.TxAuxData (LedgerEra era))
   -> TxBodyContent ViewTx era
 fromLedgerTxBody sbe scriptValidity body scriptdata mAux =
     TxBodyContent
@@ -2061,7 +2061,7 @@ fromLedgerTxBody sbe scriptValidity body scriptdata mAux =
 
 fromLedgerProposalProcedures
   :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> Maybe (Featured ConwayEraOnwards era [Proposal era])
 fromLedgerProposalProcedures sbe body =
   forShelleyBasedEraInEonMaybe sbe $ \w ->
@@ -2073,7 +2073,7 @@ fromLedgerProposalProcedures sbe body =
 
 fromLedgerVotingProcedures :: ()
   => ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> Maybe (Featured ConwayEraOnwards era (VotingProcedures era))
 fromLedgerVotingProcedures sbe body =
   forShelleyBasedEraInEonMaybe sbe $ \w ->
@@ -2085,14 +2085,14 @@ fromLedgerVotingProcedures sbe body =
 fromLedgerTxIns
   :: forall era.
      ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> [(TxIn,BuildTxWith ViewTx (Witness WitCtxTxIn era))]
 fromLedgerTxIns sbe body =
     [ (fromShelleyTxIn input, ViewTx)
     | input <- Set.toList (inputs_ sbe body) ]
   where
     inputs_ :: ShelleyBasedEra era
-           -> Ledger.TxBody (ShelleyLedgerEra era)
+           -> Ledger.TxBody (LedgerEra era)
            -> Set (Ledger.TxIn StandardCrypto)
     inputs_ ShelleyBasedEraShelley = view L.inputsTxBodyL
     inputs_ ShelleyBasedEraAllegra = view L.inputsTxBodyL
@@ -2105,7 +2105,7 @@ fromLedgerTxIns sbe body =
 fromLedgerTxInsCollateral
   :: forall era.
      ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> TxInsCollateral era
 fromLedgerTxInsCollateral sbe body =
   caseShelleyToMaryOrAlonzoEraOnwards
@@ -2114,7 +2114,7 @@ fromLedgerTxInsCollateral sbe body =
     sbe
 
 fromLedgerTxInsReference
-  :: ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxInsReference ViewTx era
+  :: ShelleyBasedEra era -> Ledger.TxBody (LedgerEra era) -> TxInsReference ViewTx era
 fromLedgerTxInsReference sbe txBody =
   caseShelleyToAlonzoOrBabbageEraOnwards
     (const TxInsReferenceNone)
@@ -2124,7 +2124,7 @@ fromLedgerTxInsReference sbe txBody =
 fromLedgerTxOuts
   :: forall era.
      ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> TxBodyScriptData era
   -> [TxOut CtxTx era]
 fromLedgerTxOuts sbe body scriptdata =
@@ -2167,7 +2167,7 @@ fromLedgerTxOuts sbe body scriptdata =
 
 fromAlonzoTxOut :: ()
   => AlonzoEraOnwards era
-  -> L.TxOut (ShelleyLedgerEra era)
+  -> L.TxOut (LedgerEra era)
   -> TxOut CtxTx era
 fromAlonzoTxOut w txOut =
   alonzoEraOnwardsConstraints w $
@@ -2181,8 +2181,8 @@ fromAlonzoTxOut w txOut =
 
 fromBabbageTxOut :: forall era. ()
   => BabbageEraOnwards era
-  -> Map (L.DataHash StandardCrypto) (L.Data (ShelleyLedgerEra era))
-  -> L.TxOut (ShelleyLedgerEra era)
+  -> Map (L.DataHash StandardCrypto) (L.Data (LedgerEra era))
+  -> L.TxOut (LedgerEra era)
   -> TxOut CtxTx era
 fromBabbageTxOut w txdatums txout =
   babbageEraOnwardsConstraints w $
@@ -2216,7 +2216,7 @@ fromBabbageTxOut w txdatums txout =
 
 fromLedgerTxTotalCollateral
   :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> TxTotalCollateral era
 fromLedgerTxTotalCollateral sbe txbody =
   caseShelleyToAlonzoOrBabbageEraOnwards
@@ -2230,7 +2230,7 @@ fromLedgerTxTotalCollateral sbe txbody =
 
 fromLedgerTxReturnCollateral
   :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> TxReturnCollateral CtxTx era
 fromLedgerTxReturnCollateral sbe txbody =
   caseShelleyToAlonzoOrBabbageEraOnwards
@@ -2243,7 +2243,7 @@ fromLedgerTxReturnCollateral sbe txbody =
     sbe
 
 fromLedgerTxFee
-  :: ShelleyBasedEra era -> Ledger.TxBody (ShelleyLedgerEra era) -> TxFee era
+  :: ShelleyBasedEra era -> Ledger.TxBody (LedgerEra era) -> TxFee era
 fromLedgerTxFee sbe body =
   shelleyBasedEraConstraints sbe
     $ TxFeeExplicit sbe
@@ -2273,7 +2273,7 @@ fromLedgerTxValidityUpperBound sbe body =
 
 fromLedgerAuxiliaryData
   :: ShelleyBasedEra era
-  -> L.TxAuxData (ShelleyLedgerEra era)
+  -> L.TxAuxData (LedgerEra era)
   -> (Map Word64 TxMetadataValue, [ScriptInEra era])
 fromLedgerAuxiliaryData ShelleyBasedEraShelley (L.ShelleyTxAuxData metadata) =
   (fromShelleyMetadata metadata, [])
@@ -2303,7 +2303,7 @@ fromLedgerAuxiliaryData ShelleyBasedEraConway txAuxData =
 
 fromLedgerTxAuxiliaryData
   :: ShelleyBasedEra era
-  -> Maybe (L.TxAuxData (ShelleyLedgerEra era))
+  -> Maybe (L.TxAuxData (LedgerEra era))
   -> (TxMetadataInEra era, TxAuxScripts era)
 fromLedgerTxAuxiliaryData _ Nothing = (TxMetadataNone, TxAuxScriptsNone)
 fromLedgerTxAuxiliaryData sbe (Just auxData) =
@@ -2326,7 +2326,7 @@ fromLedgerTxAuxiliaryData sbe (Just auxData) =
 
 
 fromLedgerTxExtraKeyWitnesses :: ShelleyBasedEra era
-                              -> Ledger.TxBody (ShelleyLedgerEra era)
+                              -> Ledger.TxBody (LedgerEra era)
                               -> TxExtraKeyWitnesses era
 fromLedgerTxExtraKeyWitnesses sbe body =
   caseShelleyToMaryOrAlonzoEraOnwards
@@ -2345,7 +2345,7 @@ fromLedgerTxExtraKeyWitnesses sbe body =
 
 fromLedgerTxWithdrawals
   :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> TxWithdrawals ViewTx era
 fromLedgerTxWithdrawals sbe body =
   shelleyBasedEraConstraints sbe $
@@ -2356,7 +2356,7 @@ fromLedgerTxWithdrawals sbe body =
 
 fromLedgerTxCertificates
   :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> TxCertificates ViewTx era
 fromLedgerTxCertificates sbe body =
   shelleyBasedEraConstraints sbe $
@@ -2367,7 +2367,7 @@ fromLedgerTxCertificates sbe body =
 
 maybeFromLedgerTxUpdateProposal :: ()
   => ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> TxUpdateProposal era
 maybeFromLedgerTxUpdateProposal sbe body =
   caseShelleyToBabbageOrConwayEraOnwards
@@ -2381,7 +2381,7 @@ maybeFromLedgerTxUpdateProposal sbe body =
 
 fromLedgerTxMintValue
   :: ShelleyBasedEra era
-  -> Ledger.TxBody (ShelleyLedgerEra era)
+  -> Ledger.TxBody (LedgerEra era)
   -> TxMintValue ViewTx era
 fromLedgerTxMintValue sbe body =
   case sbe of
@@ -2474,7 +2474,7 @@ convCollateralTxIns txInsCollateral =
 convReturnCollateral
   :: ShelleyBasedEra era
   -> TxReturnCollateral ctx era
-  -> StrictMaybe (Ledger.TxOut (ShelleyLedgerEra era))
+  -> StrictMaybe (Ledger.TxOut (LedgerEra era))
 convReturnCollateral sbe txReturnCollateral =
   case txReturnCollateral of
     TxReturnCollateralNone -> SNothing
@@ -2487,7 +2487,7 @@ convTotalCollateral txTotalCollateral =
     TxTotalCollateral _ totCollLovelace -> SJust $ toShelleyLovelace totCollLovelace
 
 convTxOuts
-  :: forall ctx era ledgerera. ShelleyLedgerEra era ~ ledgerera
+  :: forall ctx era ledgerera. LedgerEra era ~ ledgerera
   => ShelleyBasedEra era -> [TxOut ctx era] -> Seq.StrictSeq (Ledger.TxOut ledgerera)
 convTxOuts sbe txOuts = Seq.fromList $ map (toShelleyTxOutAny sbe) txOuts
 
@@ -2495,7 +2495,7 @@ convTxOuts sbe txOuts = Seq.fromList $ map (toShelleyTxOutAny sbe) txOuts
 convCertificates
   :: ShelleyBasedEra era
   -> TxCertificates build era
-  -> Seq.StrictSeq (Shelley.TxCert (ShelleyLedgerEra era))
+  -> Seq.StrictSeq (Shelley.TxCert (LedgerEra era))
 convCertificates _ = \case
   TxCertificatesNone    -> Seq.empty
   TxCertificates _ cs _ -> Seq.fromList (map toShelleyCertificate cs)
@@ -2531,7 +2531,7 @@ convValidityUpperBound sbe = \case
 convTxUpdateProposal :: ()
   => ShelleyBasedEra era
   -> TxUpdateProposal era
-  -> Either TxBodyError (StrictMaybe (Ledger.Update (ShelleyLedgerEra era)))
+  -> Either TxBodyError (StrictMaybe (Ledger.Update (LedgerEra era)))
   -- ^ 'Left' when there's protocol params conversion error, 'Right' otherwise, 'Right SNothing' means that
   -- there's no update proposal
 convTxUpdateProposal sbe = \case
@@ -2555,7 +2555,7 @@ convExtraKeyWitnesses txExtraKeyWits =
                                    | PaymentKeyHash kh <- khs ]
 
 convScripts
-  :: ShelleyLedgerEra era ~ ledgerera
+  :: LedgerEra era ~ ledgerera
   => [(ScriptWitnessIndex, AnyScriptWitness era)]
   -> [Ledger.Script ledgerera]
 convScripts scriptWitnesses =
@@ -2603,10 +2603,10 @@ convScriptData sbe txOuts scriptWitnesses =
 convPParamsToScriptIntegrityHash :: ()
   => AlonzoEraOnwards era
   -> BuildTxWith BuildTx (Maybe (LedgerProtocolParameters era))
-  -> Alonzo.Redeemers (ShelleyLedgerEra era)
-  -> Alonzo.TxDats (ShelleyLedgerEra era)
+  -> Alonzo.Redeemers (LedgerEra era)
+  -> Alonzo.TxDats (LedgerEra era)
   -> Set Alonzo.Language
-  -> StrictMaybe (L.ScriptIntegrityHash (Ledger.EraCrypto (ShelleyLedgerEra era)))
+  -> StrictMaybe (L.ScriptIntegrityHash (Ledger.EraCrypto (LedgerEra era)))
 convPParamsToScriptIntegrityHash w txProtocolParams redeemers datums languages =
   alonzoEraOnwardsConstraints w $
     case txProtocolParams of
@@ -2640,7 +2640,7 @@ mkCommonTxBody :: ()
   -> [TxOut ctx era]
   -> TxFee era
   -> TxWithdrawals build era
-  -> Maybe (L.TxAuxData (ShelleyLedgerEra era))
+  -> Maybe (L.TxAuxData (LedgerEra era))
   -> A.TxBody era
 mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData =
   shelleyBasedEraConstraints sbe $ A.TxBody $
@@ -3097,7 +3097,7 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraConway
 -- embedded datums (taking only their hash).
 --
 toShelleyTxOutAny :: forall ctx era ledgerera.
-                   ShelleyLedgerEra era ~ ledgerera
+                   LedgerEra era ~ ledgerera
                 => ShelleyBasedEra era
                 -> TxOut ctx era
                 -> Ledger.TxOut ledgerera
@@ -3120,8 +3120,8 @@ toShelleyTxOutAny sbe = \case
 
 -- TODO: Consolidate with alonzo function and rename
 toBabbageTxOutDatum'
-  :: (L.Era (ShelleyLedgerEra era), Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto)
-  => TxOutDatum ctx era -> Babbage.Datum (ShelleyLedgerEra era)
+  :: (L.Era (LedgerEra era), Ledger.EraCrypto (LedgerEra era) ~ StandardCrypto)
+  => TxOutDatum ctx era -> Babbage.Datum (LedgerEra era)
 toBabbageTxOutDatum'  TxOutDatumNone = Babbage.NoDatum
 toBabbageTxOutDatum' (TxOutDatumHash _ (ScriptDataHash dh)) = Babbage.DatumHash dh
 toBabbageTxOutDatum' (TxOutDatumInTx' _ (ScriptDataHash dh) _) = Babbage.DatumHash dh
@@ -3310,7 +3310,7 @@ toAuxiliaryData
   :: ShelleyBasedEra era
   -> TxMetadataInEra era
   -> TxAuxScripts era
-  -> Maybe (L.TxAuxData (ShelleyLedgerEra era))
+  -> Maybe (L.TxAuxData (LedgerEra era))
 toAuxiliaryData sbe txMetadata txAuxScripts =
   let ms = case txMetadata of
              TxMetadataNone                     -> Map.empty

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -259,7 +259,7 @@ valueToList (Value m) = Map.toList m
 negateValue :: Value -> Value
 negateValue (Value m) = Value (Map.map negate m)
 
-negateLedgerValue :: ShelleyBasedEra era -> L.Value (ShelleyLedgerEra era) -> L.Value (ShelleyLedgerEra era)
+negateLedgerValue :: ShelleyBasedEra era -> L.Value (LedgerEra era) -> L.Value (LedgerEra era)
 negateLedgerValue sbe v =
   caseShelleyToAllegraOrMaryEraOnwards
     (\_ -> v & A.adaAssetL sbe %~ Shelley.Coin . negate . Shelley.unCoin)
@@ -311,10 +311,10 @@ toMaryValue v =
     toMaryAssetName :: AssetName -> Mary.AssetName
     toMaryAssetName (AssetName n) = Mary.AssetName $ Short.toShort n
 
-toLedgerValue :: MaryEraOnwards era -> Value -> L.Value (ShelleyLedgerEra era)
+toLedgerValue :: MaryEraOnwards era -> Value -> L.Value (LedgerEra era)
 toLedgerValue w = maryEraOnwardsConstraints w toMaryValue
 
-fromLedgerValue :: ShelleyBasedEra era -> L.Value (ShelleyLedgerEra era) -> Value
+fromLedgerValue :: ShelleyBasedEra era -> L.Value (LedgerEra era) -> Value
 fromLedgerValue sbe v =
   caseShelleyToAllegraOrMaryEraOnwards
     (const (coinToValue v))

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -216,7 +216,7 @@ module Cardano.Api.Shelley
     LocalNodeClientProtocols(LocalNodeClientProtocols),
 
     -- ** Shelley based eras
-    ShelleyLedgerEra,
+    LedgerEra,
 
 
     -- ** Local State Query


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Merge `ShelleyLedgerEra` and `CardanoLedgerEra` to a single type family `LedgerEra`
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We previously defined two separate type families `ShelleyLedgerEra` and `CardanoLedgerEra` but never use `CardanoLedgerEra` anywhere.

`ShelleyLedgerEra` is basically the same as `CardanoLedgerEra` except Byron is missing.

There is no reason to have two type families because `CardanoLedgerEra` works everywhere `ShelleyLedgerEra` currently does.

This PR merges the two type families into the one `LedgerEra` type family (which includes Byron) which shortens the commonly used name.

Doing this opens the possibility of unifying Byron with the other eras for the minimal set of operations we care to maintain for hard forking purposes.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behaviour, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
