### PR TITLE
Use `Pretty` for rendering errors instead of `Show`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -105,6 +105,7 @@ library internal
                         Cardano.Api.Modes
                         Cardano.Api.NetworkId
                         Cardano.Api.OperationalCertificate
+                        Cardano.Api.Pretty
                         Cardano.Api.Protocol
                         Cardano.Api.ProtocolParameters
                         Cardano.Api.Query
@@ -187,6 +188,7 @@ library internal
                       , parsec
                       , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>= 1.15
                       , prettyprinter
+                      , prettyprinter-ansi-terminal
                       , prettyprinter-configurable ^>= 1.15
                       , random
                       , scientific
@@ -224,6 +226,7 @@ library
                         Cardano.Api.Ledger
 
   reexported-modules:   Cardano.Api.Ledger.Lens
+                      , Cardano.Api.Pretty
 
   build-depends:        bytestring
                       , cardano-api:internal

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -137,6 +137,7 @@ import qualified Cardano.Api as Api
 import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness),
                    WitnessNetworkIdOrByronAddress (..))
 import           Cardano.Api.Eon.AllegraEraOnwards (allegraEraOnwardsToShelleyBasedEra)
+import           Cardano.Api.Pretty
 import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Api.Ledger.Lens as A
 import           Cardano.Api.Script (scriptInEraToRefScript)
@@ -449,7 +450,7 @@ genOperationalCertificateWithCounter = do
     case issueOperationalCertificate kesVKey stkPoolOrGenDelExtSign kesP iCounter of
       -- This case should be impossible as we clearly derive the verification
       -- key from the generated signing key.
-      Left err -> fail $ displayError err
+      Left err -> fail $ prettyToString $ prettyError err
       Right pair -> return pair
   where
     convert :: VerificationKey GenesisDelegateExtendedKey
@@ -741,7 +742,7 @@ genTxBodyByron = do
                              , Api.txOuts
                              }
   case Api.createAndValidateTransactionBody ByronEra byronTxBodyContent of
-    Left err -> fail (displayError err)
+    Left err -> fail $ prettyToString $ prettyError err
     Right txBody -> pure txBody
 
 genWitnessesByron :: Gen [KeyWitness ByronEra]
@@ -751,7 +752,7 @@ genTxBody :: ShelleyBasedEra era -> Gen (TxBody era)
 genTxBody era = do
   res <- Api.createAndValidateTransactionBody (toCardanoEra era) <$> genTxBodyContent era
   case res of
-    Left err -> fail (displayError err)
+    Left err -> fail (prettyToString (prettyError err))
     Right txBody -> pure txBody
 
 -- | Generate a 'Featured' for the given 'CardanoEra' with the provided generator.

--- a/cardano-api/gen/Test/Hedgehog/Golden/ErrorMessage.hs
+++ b/cardano-api/gen/Test/Hedgehog/Golden/ErrorMessage.hs
@@ -2,6 +2,7 @@
 module Test.Hedgehog.Golden.ErrorMessage where
 
 import           Cardano.Api (Error (..))
+import           Cardano.Api.Pretty
 
 import           Data.Data
 import           GHC.Stack (HasCallStack, withFrozenCallStack)
@@ -77,4 +78,4 @@ testErrorMessage_ goldenFilesLocation moduleName typeName constructorName err = 
   let fqtn = moduleName <> "." <> typeName
   testProperty constructorName . withTests 1 . property $ do
     H.note_ "Incorrect error message in golden file"
-    displayError err `H.diffVsGoldenFile` (goldenFilesLocation </> fqtn </> constructorName <> ".txt")
+    H.diffVsGoldenFile (prettyToString (prettyError err)) (goldenFilesLocation </> fqtn </> constructorName <> ".txt")

--- a/cardano-api/internal/Cardano/Api/DRepMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/DRepMetadata.hs
@@ -31,6 +31,7 @@ import qualified Cardano.Ledger.Keys as Shelley
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.Either.Combinators (maybeToRight)
+import           Prettyprinter
 
 -- ----------------------------------------------------------------------------
 -- DRep metadata
@@ -68,13 +69,13 @@ data DRepMetadataValidationError
   deriving Show
 
 instance Error DRepMetadataValidationError where
-  displayError = \case
+  prettyError = \case
     DRepMetadataInvalidLengthError maxLen actualLen ->
       mconcat
         [ "DRep metadata must consist of at most "
-        , show maxLen
+        , pretty maxLen
         , " bytes, but it consists of "
-        , show actualLen
+        , pretty actualLen
         , " bytes."
         ]
 

--- a/cardano-api/internal/Cardano/Api/DeserialiseAnyOf.hs
+++ b/cardano-api/internal/Cardano/Api/DeserialiseAnyOf.hs
@@ -44,9 +44,9 @@ import           Data.Data (Data)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Text (Text)
-import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Formatting (build, sformat, (%))
+import           Prettyprinter
 
 ------------------------------------------------------------------------------
 -- Formatted/encoded input deserialisation
@@ -78,18 +78,19 @@ data InputDecodeError
   -- ^ The provided data does not represent a valid value of the provided
   -- type.
   deriving (Eq, Show, Data)
+
 instance Error InputDecodeError where
-  displayError = Text.unpack . renderInputDecodeError
+  prettyError = renderInputDecodeError
 
 -- | Render an error message for a 'InputDecodeError'.
-renderInputDecodeError :: InputDecodeError -> Text
-renderInputDecodeError err =
-  case err of
-    InputTextEnvelopeError textEnvErr ->
-      Text.pack (displayError textEnvErr)
-    InputBech32DecodeError decodeErr ->
-      Text.pack (displayError decodeErr)
-    InputInvalidError -> "Invalid key."
+renderInputDecodeError :: InputDecodeError -> Doc ann
+renderInputDecodeError = \case
+  InputTextEnvelopeError textEnvErr ->
+    prettyError textEnvErr
+  InputBech32DecodeError decodeErr ->
+    prettyError decodeErr
+  InputInvalidError ->
+    "Invalid key."
 
 -- | The result of a deserialisation function.
 --

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -49,6 +50,7 @@ module Cardano.Api.Eras.Core
   ) where
 
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Pretty
 
 import qualified Cardano.Ledger.Api as L
 
@@ -236,9 +238,11 @@ data CardanoEra era where
      ConwayEra  :: CardanoEra ConwayEra
      -- when you add era here, change `instance Bounded AnyCardanoEra`
 
-deriving instance Eq   (CardanoEra era)
-deriving instance Ord  (CardanoEra era)
-deriving instance Show (CardanoEra era)
+deriving instance Eq    (CardanoEra era)
+deriving instance Ord   (CardanoEra era)
+deriving instance Show  (CardanoEra era)
+
+deriving via (ShowOf (CardanoEra era)) instance Pretty (CardanoEra era)
 
 instance ToJSON (CardanoEra era) where
    toJSON ByronEra   = "Byron"

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -54,6 +54,7 @@ import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import qualified Cardano.Api.Ledger.Lens as A
 import           Cardano.Api.NetworkId
+import           Cardano.Api.Pretty
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query
 import           Cardano.Api.Script
@@ -92,7 +93,6 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           Lens.Micro ((.~), (^.))
 import           Prettyprinter
-import           Prettyprinter.Render.String
 
 {- HLINT ignore "Redundant return" -}
 --- ----------------------------------------------------------------------------
@@ -351,49 +351,59 @@ data ScriptExecutionError =
   deriving Show
 
 instance Error ScriptExecutionError where
-  displayError (ScriptErrorMissingTxIn txin) =
-      "The supplied UTxO is missing the txin " ++ Text.unpack (renderTxIn txin)
+  prettyError = \case
+    ScriptErrorMissingTxIn txin ->
+      "The supplied UTxO is missing the txin " <> pretty (renderTxIn txin)
 
-  displayError (ScriptErrorTxInWithoutDatum txin) =
-      "The Plutus script witness for the txin does not have a script datum "
-   ++ "(according to the UTxO). The txin in question is "
-   ++ Text.unpack (renderTxIn txin)
+    ScriptErrorTxInWithoutDatum txin ->
+      mconcat
+        [ "The Plutus script witness for the txin does not have a script datum "
+        , "(according to the UTxO). The txin in question is "
+        , pretty (renderTxIn txin)
+        ]
 
-  displayError (ScriptErrorWrongDatum dh) =
-      "The Plutus script witness has the wrong datum (according to the UTxO). "
-   ++ "The expected datum value has hash " ++ show dh
+    ScriptErrorWrongDatum dh ->
+      mconcat
+        [ "The Plutus script witness has the wrong datum (according to the UTxO). "
+        , "The expected datum value has hash " <> pshow dh
+        ]
 
-  displayError (ScriptErrorEvaluationFailed evalErr logs) =
-      "The Plutus script evaluation failed: " ++ pp evalErr ++
-      "\nScript debugging logs: " <> mconcat (map (\t -> Text.unpack $ t `Text.append` "\n") logs)
-    where
-      pp :: Pretty p => p -> String
-      pp = renderString
-         . layoutPretty defaultLayoutOptions
-         . pretty
+    ScriptErrorEvaluationFailed evalErr logs ->
+      mconcat
+        [ "The Plutus script evaluation failed: " <> pretty evalErr
+        , "\nScript debugging logs: " <> mconcat (map (\t -> pretty $ t `Text.append` "\n") logs)
+        ]
 
-  displayError ScriptErrorExecutionUnitsOverflow =
-      "The execution units required by this Plutus script overflows a 64bit "
-   ++ "word. In a properly configured chain this should be practically "
-   ++ "impossible. So this probably indicates a chain configuration problem, "
-   ++ "perhaps with the values in the cost model."
+    ScriptErrorExecutionUnitsOverflow ->
+      mconcat
+        [ "The execution units required by this Plutus script overflows a 64bit "
+        , "word. In a properly configured chain this should be practically "
+        , "impossible. So this probably indicates a chain configuration problem, "
+        , "perhaps with the values in the cost model."
+        ]
 
-  displayError (ScriptErrorNotPlutusWitnessedTxIn scriptWitness scriptHash) =
-      renderScriptWitnessIndex scriptWitness <> " is not a Plutus script "
-      <> "witnessed tx input and cannot be spent using a Plutus script witness."
-      <> "The script hash is " <> show scriptHash <> "."
+    ScriptErrorNotPlutusWitnessedTxIn scriptWitness scriptHash ->
+      mconcat
+        [ pretty (renderScriptWitnessIndex scriptWitness)
+        , " is not a Plutus script witnessed tx input and cannot be spent using a "
+        , "Plutus script witness.The script hash is " <> pshow scriptHash <> "."
+        ]
 
-  displayError (ScriptErrorRedeemerPointsToUnknownScriptHash scriptWitness) =
-      renderScriptWitnessIndex scriptWitness <> " points to a script hash "
-      <> "that is not known."
+    ScriptErrorRedeemerPointsToUnknownScriptHash scriptWitness ->
+      mconcat
+        [ pretty (renderScriptWitnessIndex scriptWitness)
+        , " points to a script hash that is not known."
+        ]
 
-  displayError (ScriptErrorMissingScript rdmrPtr resolveable) =
-     "The redeemer pointer: " <> show rdmrPtr <> " points to a Plutus "
-     <> "script that does not exist.\n" <>
-     "The pointers that can be resolved are: " <> show resolveable
+    ScriptErrorMissingScript rdmrPtr resolveable ->
+      mconcat
+        [ "The redeemer pointer: " <> pshow rdmrPtr <> " points to a Plutus "
+        , "script that does not exist.\n"
+        , "The pointers that can be resolved are: " <> pshow resolveable
+        ]
 
-  displayError (ScriptErrorMissingCostModel language) =
-      "No cost model was found for language " <> show language
+    ScriptErrorMissingCostModel language ->
+      "No cost model was found for language " <> pshow language
 
 data TransactionValidityError =
     -- | The transaction validity interval is too far into the future.
@@ -421,31 +431,36 @@ data TransactionValidityError =
 deriving instance Show TransactionValidityError
 
 instance Error TransactionValidityError where
-  displayError (TransactionValidityIntervalError pastTimeHorizon) =
-      "The transaction validity interval is too far in the future. "
-   ++ "For this network it must not be more than "
-   ++ show (timeHorizonSlots pastTimeHorizon)
-   ++ "slots ahead of the current time slot. "
-   ++ "(Transactions with Plutus scripts must have validity intervals that "
-   ++ "are close enough in the future that we can reliably turn the slot "
-   ++ "numbers into UTC wall clock times.)"
-    where
-      timeHorizonSlots :: Consensus.PastHorizonException -> Word
-      timeHorizonSlots Consensus.PastHorizon{Consensus.pastHorizonSummary}
-        | eraSummaries@(_:_) <- pastHorizonSummary
-        , Consensus.StandardSafeZone slots <-
-            (Consensus.eraSafeZone . Consensus.eraParams . last) eraSummaries
-        = fromIntegral slots
+  prettyError = \case
+    TransactionValidityIntervalError pastTimeHorizon ->
+      mconcat
+        [ "The transaction validity interval is too far in the future. "
+        , "For this network it must not be more than "
+        , pretty (timeHorizonSlots pastTimeHorizon)
+        , "slots ahead of the current time slot. "
+        , "(Transactions with Plutus scripts must have validity intervals that "
+        , "are close enough in the future that we can reliably turn the slot "
+        , "numbers into UTC wall clock times.)"
+        ]
+      where
+        timeHorizonSlots :: Consensus.PastHorizonException -> Word
+        timeHorizonSlots Consensus.PastHorizon{Consensus.pastHorizonSummary}
+          | eraSummaries@(_:_) <- pastHorizonSummary
+          , Consensus.StandardSafeZone slots <-
+              (Consensus.eraSafeZone . Consensus.eraParams . last) eraSummaries
+          = fromIntegral slots
 
-        | otherwise
-        = 0 -- This should be impossible.
-  displayError (TransactionValidityTranslationError errmsg) =
-    "Error translating the transaction context: " <> show errmsg
+          | otherwise
+          = 0 -- This should be impossible.
+    TransactionValidityTranslationError errmsg ->
+      "Error translating the transaction context: " <> pshow errmsg
 
-  displayError (TransactionValidityCostModelError cModels err) =
-    "An error occurred while converting from the cardano-api cost" <>
-    " models to the cardano-ledger cost models. Error: " <> err <>
-    " Cost models: " <> show cModels
+    TransactionValidityCostModelError cModels err ->
+      mconcat
+        [ "An error occurred while converting from the cardano-api cost"
+        , " models to the cardano-ledger cost models. Error: " <> pretty err
+        , " Cost models: " <> pshow cModels
+        ]
 
 -- | Compute the 'ExecutionUnits' needed for each script in the transaction.
 --
@@ -656,50 +671,66 @@ data TxBodyErrorAutoBalance =
 
 
 instance Error TxBodyErrorAutoBalance where
-  displayError (TxBodyError err) = displayError err
+  prettyError = \case
+    TxBodyError err ->
+      prettyError err
 
-  displayError (TxBodyScriptExecutionError failures) =
-      "The following scripts have execution failures:\n"
-   ++ unlines [ "the script for " ++ renderScriptWitnessIndex index
-                ++ " failed with: " ++ "\n" ++ displayError failure
-              | (index, failure) <- failures ]
+    TxBodyScriptExecutionError failures ->
+      mconcat
+        [ "The following scripts have execution failures:\n"
+        , vsep
+            [ mconcat
+                [ "the script for " <> pretty (renderScriptWitnessIndex index)
+                , " failed with: " <> "\n" <> prettyError failure
+                ]
+            | (index, failure) <- failures
+            ]
+        ]
 
-  displayError TxBodyScriptBadScriptValidity =
+    TxBodyScriptBadScriptValidity ->
       "One or more of the scripts were expected to fail validation, but none did."
 
-  displayError (TxBodyErrorAdaBalanceNegative lovelace) =
-      "The transaction does not balance in its use of ada. The net balance "
-   ++ "of the transaction is negative: " ++ show lovelace ++ " lovelace. "
-   ++ "The usual solution is to provide more inputs, or inputs with more ada."
+    TxBodyErrorAdaBalanceNegative lovelace ->
+      mconcat
+        [ "The transaction does not balance in its use of ada. The net balance "
+        , "of the transaction is negative: " <> pshow lovelace <> " lovelace. "
+        , "The usual solution is to provide more inputs, or inputs with more ada."
+        ]
 
-  displayError (TxBodyErrorAdaBalanceTooSmall changeOutput minUTxO balance) =
-      "The transaction does balance in its use of ada, however the net "
-   ++ "balance does not meet the minimum UTxO threshold. \n"
-   ++ "Balance: " ++ show balance ++ "\n"
-   ++ "Offending output (change output): " ++ Text.unpack (prettyRenderTxOut changeOutput) ++ "\n"
-   ++ "Minimum UTxO threshold: " ++ show minUTxO ++ "\n"
-   ++ "The usual solution is to provide more inputs, or inputs with more ada to "
-   ++ "meet the minimum UTxO threshold"
+    TxBodyErrorAdaBalanceTooSmall changeOutput minUTxO balance ->
+      mconcat
+        [ "The transaction does balance in its use of ada, however the net "
+        , "balance does not meet the minimum UTxO threshold. \n"
+        , "Balance: " <> pshow balance <> "\n"
+        , "Offending output (change output): " <> pretty (prettyRenderTxOut changeOutput) <> "\n"
+        , "Minimum UTxO threshold: " <> pshow minUTxO <> "\n"
+        , "The usual solution is to provide more inputs, or inputs with more ada to "
+        , "meet the minimum UTxO threshold"
+        ]
 
-  displayError TxBodyErrorByronEraNotSupported =
+    TxBodyErrorByronEraNotSupported ->
       "The Byron era is not yet supported by makeTransactionBodyAutoBalance"
 
-  displayError TxBodyErrorMissingParamMinUTxO =
+    TxBodyErrorMissingParamMinUTxO ->
       "The minUTxOValue protocol parameter is required but missing"
 
-  displayError (TxBodyErrorValidityInterval err) =
-      displayError err
+    TxBodyErrorValidityInterval err ->
+      prettyError err
 
-  displayError (TxBodyErrorMinUTxONotMet txout minUTxO) =
-      "Minimum UTxO threshold not met for tx output: " <> Text.unpack (prettyRenderTxOut txout) <> "\n"
-   <> "Minimum required UTxO: " <> show minUTxO
+    TxBodyErrorMinUTxONotMet txout minUTxO ->
+      mconcat
+        [ "Minimum UTxO threshold not met for tx output: " <> pretty (prettyRenderTxOut txout) <> "\n"
+        , "Minimum required UTxO: " <> pshow minUTxO
+        ]
 
-  displayError (TxBodyErrorNonAdaAssetsUnbalanced val) =
-      "Non-Ada assets are unbalanced: " <> Text.unpack (renderValue val)
+    TxBodyErrorNonAdaAssetsUnbalanced val ->
+      "Non-Ada assets are unbalanced: " <> pretty (renderValue val)
 
-  displayError (TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap sIndex eUnitsMap) =
-    "ScriptWitnessIndex (redeemer pointer): " <> show sIndex <> " is missing from the execution "
-    ++ "units (redeemer pointer) map: " <> show eUnitsMap
+    TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap sIndex eUnitsMap ->
+      mconcat
+        [ "ScriptWitnessIndex (redeemer pointer): " <> pshow sIndex <> " is missing from the execution "
+        , "units (redeemer pointer) map: " <> pshow eUnitsMap
+        ]
 
 handleExUnitsErrors ::
      ScriptValidity -- ^ Mark script as expected to pass or fail validation

--- a/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
@@ -43,6 +43,7 @@ import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Class
+import           Cardano.Api.Pretty
 import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseJSON
@@ -65,7 +66,6 @@ import qualified Data.ByteString as BS
 import           Data.Either.Combinators (maybeToRight)
 import           Data.Maybe
 import           Data.String (IsString (..))
-import qualified Data.Text as Text
 
 --
 -- Shelley payment keys
@@ -1469,8 +1469,10 @@ instance FromJSON (Hash StakePoolKey) where
   parseJSON = withText "PoolId" $ \str ->
     case deserialiseFromBech32 (AsHash AsStakePoolKey) str of
       Left err ->
-        fail $ "Error deserialising Hash StakePoolKey: " <> Text.unpack str <>
-               " Error: " <> displayError err
+        fail $ prettyToString $ mconcat
+          [ "Error deserialising Hash StakePoolKey: " <> pretty str
+          , " Error: " <> prettyError err
+          ]
       Right h -> pure h
 
 instance HasTextEnvelope (VerificationKey StakePoolKey) where
@@ -1588,8 +1590,10 @@ instance FromJSON (Hash DRepKey) where
   parseJSON = withText "DRepId" $ \str ->
     case deserialiseFromBech32 (AsHash AsDRepKey) str of
       Left err ->
-        fail $ "Error deserialising Hash DRepKey: " <> Text.unpack str <>
-               " Error: " <> displayError err
+        fail $ prettyToString $ mconcat
+          [ "Error deserialising Hash DRepKey: " <> pretty str
+          , " Error: " <> prettyError err
+          ]
       Right h -> pure h
 
 instance HasTextEnvelope (VerificationKey DRepKey) where

--- a/cardano-api/internal/Cardano/Api/OperationalCertificate.hs
+++ b/cardano-api/internal/Cardano/Api/OperationalCertificate.hs
@@ -100,9 +100,9 @@ data OperationalCertIssueError =
   deriving Show
 
 instance Error OperationalCertIssueError where
-    displayError (OperationalCertKeyMismatch _counterKey _signingKey) =
-      "Key mismatch: the signing key does not match the one that goes with the counter"
-      --TODO: include key ids
+  prettyError (OperationalCertKeyMismatch _counterKey _signingKey) =
+    "Key mismatch: the signing key does not match the one that goes with the counter"
+    --TODO: include key ids
 
 issueOperationalCertificate :: VerificationKey KesKey
                             -> Either (SigningKey StakePoolKey)

--- a/cardano-api/internal/Cardano/Api/Pretty.hs
+++ b/cardano-api/internal/Cardano/Api/Pretty.hs
@@ -1,0 +1,65 @@
+module Cardano.Api.Pretty
+  ( Ann
+  , Pretty(..)
+  , ShowOf(..)
+  , viaShow
+  , prettyToText
+  , prettyToString
+  , pshow
+
+  , black
+  , red
+  , green
+  , yellow
+  , blue
+  , magenta
+  , cyan
+  , white
+  ) where
+
+import qualified Data.Text.Lazy as TextLazy
+import           Prettyprinter
+import           Prettyprinter.Render.Terminal
+
+type Ann = AnsiStyle
+
+newtype ShowOf a = ShowOf a
+
+instance Show a => Show (ShowOf a) where
+  show (ShowOf a) = show a
+
+instance Show a => Pretty (ShowOf a) where
+  pretty = viaShow
+
+prettyToString :: Doc AnsiStyle -> String
+prettyToString =  show
+
+prettyToText :: Doc AnsiStyle -> TextLazy.Text
+prettyToText = renderLazy . layoutPretty defaultLayoutOptions
+
+black :: Doc AnsiStyle -> Doc AnsiStyle
+black = annotate (color Black)
+
+red :: Doc AnsiStyle -> Doc AnsiStyle
+red = annotate (color Red)
+
+green :: Doc AnsiStyle -> Doc AnsiStyle
+green = annotate (color Green)
+
+yellow :: Doc AnsiStyle -> Doc AnsiStyle
+yellow = annotate (color Yellow)
+
+blue :: Doc AnsiStyle -> Doc AnsiStyle
+blue = annotate (color Blue)
+
+magenta :: Doc AnsiStyle -> Doc AnsiStyle
+magenta = annotate (color Magenta)
+
+cyan :: Doc AnsiStyle -> Doc AnsiStyle
+cyan = annotate (color Cyan)
+
+white :: Doc AnsiStyle -> Doc AnsiStyle
+white = annotate (color White)
+
+pshow :: Show a => a -> Doc ann
+pshow = pretty . show

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -106,6 +106,7 @@ import           Cardano.Api.Json (toRationalJSON)
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.Orphans ()
+import           Cardano.Api.Pretty
 import           Cardano.Api.Script
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
@@ -144,11 +145,11 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (isJust)
 import           Data.Maybe.Strict (StrictMaybe (..))
 import           Data.String (IsString)
+import           Data.Text (Text)
 import           GHC.Generics
 import           Lens.Micro
 import           Numeric.Natural
 import           Text.PrettyBy.Default (display)
-
 
 -- -----------------------------------------------------------------------------
 -- Era based ledger protocol parameters
@@ -1856,18 +1857,20 @@ data ProtocolParametersError
   deriving (Show)
 
 instance Error ProtocolParametersError where
-  displayError (PParamsErrorMissingMinUTxoValue (AnyCardanoEra era)) = mconcat
-    [ "The " <> show era <> " protocol parameters value is missing the following "
-    , "field: MinUTxoValue. Did you intend to use a " <> show era <> " protocol "
-    , "parameters value?"
-    ]
-  displayError PParamsErrorMissingAlonzoProtocolParameter = mconcat
-    [ "The Alonzo era protocol parameters in use is missing one or more of the "
-    , "following fields: UTxOCostPerWord, CostModels, Prices, MaxTxExUnits, "
-    , "MaxBlockExUnits, MaxValueSize, CollateralPercent, MaxCollateralInputs. Did "
-    , "you intend to use an Alonzo era protocol parameters value?"
-    ]
-
+  prettyError = \case
+    PParamsErrorMissingMinUTxoValue (AnyCardanoEra era) ->
+      mconcat
+        [ "The " <> pretty era <> " protocol parameters value is missing the following "
+        , "field: MinUTxoValue. Did you intend to use a " <> pretty era <> " protocol "
+        , "parameters value?"
+        ]
+    PParamsErrorMissingAlonzoProtocolParameter ->
+      mconcat
+        [ "The Alonzo era protocol parameters in use is missing one or more of the "
+        , "following fields: UTxOCostPerWord, CostModels, Prices, MaxTxExUnits, "
+        , "MaxBlockExUnits, MaxValueSize, CollateralPercent, MaxCollateralInputs. Did "
+        , "you intend to use an Alonzo era protocol parameters value?"
+        ]
 
 data ProtocolParametersConversionError
   = PpceOutOfBounds !ProtocolParameterName !Rational
@@ -1881,8 +1884,12 @@ type ProtocolParameterName = String
 type ProtocolParameterVersion = Natural
 
 instance Error ProtocolParametersConversionError where
-  displayError = \case
-    PpceOutOfBounds name r -> "Value for '" <> name <> "' is outside of bounds: " <> show (fromRational r :: Double)
-    PpceVersionInvalid majorProtVer -> "Major protocol version is invalid: " <> show majorProtVer
-    PpceInvalidCostModel cm err -> "Invalid cost model: " <> display err <> " Cost model: " <> show cm
-    PpceMissingParameter name -> "Missing parameter: " <> name
+  prettyError = \case
+    PpceOutOfBounds name r ->
+      "Value for '" <> pretty name <> "' is outside of bounds: " <> pretty (fromRational r :: Double)
+    PpceVersionInvalid majorProtVer ->
+      "Major protocol version is invalid: " <> pretty majorProtVer
+    PpceInvalidCostModel cm err ->
+      "Invalid cost model: " <> pretty @Text (display err) <> " Cost model: " <> pshow cm
+    PpceMissingParameter name ->
+      "Missing parameter: " <> pretty name

--- a/cardano-api/internal/Cardano/Api/SerialiseJSON.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseJSON.hs
@@ -17,6 +17,7 @@ module Cardano.Api.SerialiseJSON
 
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Pretty
 
 import           Control.Monad.Trans.Except (runExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
@@ -28,13 +29,12 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Data (Data)
 
-
 newtype JsonDecodeError = JsonDecodeError String
   deriving (Eq, Show, Data)
 
 instance Error JsonDecodeError where
-  displayError (JsonDecodeError err) = err
-
+  prettyError (JsonDecodeError err) =
+    pretty err
 
 serialiseToJSON :: ToJSON a => a -> ByteString
 serialiseToJSON = LBS.toStrict . Aeson.encode

--- a/cardano-api/internal/Cardano/Api/SerialiseRaw.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseRaw.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Raw binary serialisation
@@ -12,8 +13,9 @@ module Cardano.Api.SerialiseRaw
   , serialiseToRawBytesHexText
   ) where
 
-import           Cardano.Api.Error (Error, displayError)
+import           Cardano.Api.Error (Error, prettyError)
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Pretty
 
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.ByteString (ByteString)
@@ -54,14 +56,14 @@ data RawBytesHexError
   deriving (Show)
 
 instance Error RawBytesHexError where
-  displayError = \case
+  prettyError = \case
     RawBytesHexErrorBase16DecodeFail input message ->
-      "Expected Base16-encoded bytestring, but got " ++ pretty input ++ "; "
-      ++ message
+      "Expected Base16-encoded bytestring, but got " <> pretty (toText input) <> "; "
+      <> pretty message
     RawBytesHexErrorRawBytesDecodeFail input asType (SerialiseAsRawBytesError e) ->
-      "Failed to deserialise " ++ pretty input ++ " as " ++ show asType ++ ". " ++ e
+      "Failed to deserialise " <> pretty (toText input) <> " as " <> pshow asType <> ". " <> pretty e
     where
-      pretty bs = case Text.decodeUtf8' bs of
+      toText bs = case Text.decodeUtf8' bs of
         Right t -> Text.unpack t
         Left _ -> show bs
 

--- a/cardano-api/internal/Cardano/Api/SerialiseUsing.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseUsing.hs
@@ -10,6 +10,7 @@ module Cardano.Api.SerialiseUsing
 
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Pretty
 import           Cardano.Api.SerialiseBech32
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseJSON
@@ -23,8 +24,6 @@ import           Data.String (IsString (..))
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Typeable (tyConName, typeRep, typeRepTyCon)
-
-
 
 -- | For use with @deriving via@, to provide 'ToCBOR' and 'FromCBOR' instances,
 -- based on the 'SerialiseAsRawBytes' instance.
@@ -112,7 +111,9 @@ instance SerialiseAsBech32 a => IsString (UsingBech32 a) where
     fromString str =
       case deserialiseFromBech32 ttoken (Text.pack str) of
         Right x  -> UsingBech32 x
-        Left  e -> error ("fromString: " ++ show str ++ ": " ++ displayError e)
+        Left  e ->
+          error $ prettyToString $
+            "fromString: " <> pretty str <> ": " <> prettyError e
       where
         ttoken :: AsType a
         ttoken = proxyToAsType Proxy
@@ -125,7 +126,7 @@ instance SerialiseAsBech32 a => FromJSON (UsingBech32 a) where
       Aeson.withText tname $ \str ->
         case deserialiseFromBech32 ttoken str of
           Right x -> return (UsingBech32 x)
-          Left  e -> fail (show str ++ ": " ++ displayError e)
+          Left  e -> fail $ prettyToString $ pretty str <> ": " <> prettyError e
       where
         ttoken = proxyToAsType (Proxy :: Proxy a)
         tname  = (tyConName . typeRepTyCon . typeRep) (Proxy :: Proxy a)

--- a/cardano-api/internal/Cardano/Api/StakePoolMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/StakePoolMetadata.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Stake pool off-chain metadata
@@ -39,7 +40,7 @@ import           Data.Data (Data)
 import           Data.Either.Combinators (maybeToRight)
 import           Data.Text (Text)
 import qualified Data.Text as Text
-
+import           Prettyprinter
 
 -- ----------------------------------------------------------------------------
 -- Stake pool metadata
@@ -146,13 +147,17 @@ data StakePoolMetadataValidationError
   deriving (Eq, Show, Data)
 
 instance Error StakePoolMetadataValidationError where
-    displayError (StakePoolMetadataJsonDecodeError errStr) = errStr
-    displayError (StakePoolMetadataInvalidLengthError maxLen actualLen) =
-         "Stake pool metadata must consist of at most "
-      <> show maxLen
-      <> " bytes, but it consists of "
-      <> show actualLen
-      <> " bytes."
+  prettyError = \case
+    StakePoolMetadataJsonDecodeError errStr ->
+      pretty errStr
+    StakePoolMetadataInvalidLengthError maxLen actualLen ->
+      mconcat
+        [ "Stake pool metadata must consist of at most "
+        , pretty maxLen
+        , " bytes, but it consists of "
+        , pretty actualLen
+        , " bytes."
+        ]
 
 -- | Decode and validate the provided JSON-encoded bytes as 'StakePoolMetadata'.
 -- Return the decoded metadata and the hash of the original bytes.

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -17,7 +17,7 @@
 {-# LANGUAGE ViewPatterns #-}
 
 {- HLINT ignore "Avoid lambda using `infix`" -}
-{- HLINT ignore "Move brackets to avoid $." -}
+{- HLINT ignore "Move brackets to avoid" -}
 {- HLINT ignore "Redundant flip" -}
 {- HLINT ignore "Use let" -}
 {- HLINT ignore "Use section" -}
@@ -172,6 +172,7 @@ import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Shelley
 import qualified Cardano.Api.Ledger.Lens as A
 import           Cardano.Api.NetworkId
+import           Cardano.Api.Pretty
 import           Cardano.Api.ProtocolParameters
 import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.Script
@@ -233,7 +234,7 @@ import qualified Data.ByteString.Lazy as LBS
 import           Data.Foldable (for_, toList)
 import           Data.Function (on)
 import           Data.Functor (($>))
-import           Data.List (intercalate, sortBy)
+import           Data.List (sortBy)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
@@ -255,7 +256,6 @@ import           Lens.Micro.Extras (view)
 import qualified Text.Parsec as Parsec
 import           Text.Parsec ((<?>))
 import qualified Text.Parsec.String as Parsec
-
 
 -- | Indicates whether a script is expected to fail or pass validation.
 data ScriptValidity
@@ -340,6 +340,8 @@ instance Eq TxOutInAnyEra where
     case testEquality era1 era2 of
       Just Refl -> out1 == out2
       Nothing   -> False
+
+deriving via (ShowOf TxOutInAnyEra) instance Pretty TxOutInAnyEra
 
 -- | Convenience constructor for 'TxOutInAnyEra'
 txOutInAnyEra :: CardanoEra era -> TxOut CtxTx era -> TxOutInAnyEra
@@ -1746,34 +1748,40 @@ data TxBodyError =
      deriving (Eq, Show)
 
 instance Error TxBodyError where
-    displayError TxBodyEmptyTxIns  = "Transaction body has no inputs"
-    displayError TxBodyEmptyTxInsCollateral =
+  prettyError = \case
+    TxBodyEmptyTxIns ->
+      "Transaction body has no inputs"
+    TxBodyEmptyTxInsCollateral ->
       "Transaction body has no collateral inputs, but uses Plutus scripts"
-    displayError TxBodyEmptyTxOuts = "Transaction body has no outputs"
-    displayError (TxBodyOutputNegative (Quantity q) txout) =
-      "Negative quantity (" ++ show q ++ ") in transaction output: " ++
-      show txout
-    displayError (TxBodyOutputOverflow (Quantity q) txout) =
-      "Quantity too large (" ++ show q ++ " >= 2^64) in transaction output: " ++
-      show txout
-    displayError (TxBodyMetadataError [(k, err)]) =
-      "Error in metadata entry " ++ show k ++ ": " ++ displayError err
-    displayError (TxBodyMetadataError errs) =
-      "Error in metadata entries: " ++
-      intercalate "; "
-        [ show k ++ ": " ++ displayError err
-        | (k, err) <- errs ]
-    displayError TxBodyMintAdaError =
+    TxBodyEmptyTxOuts ->
+      "Transaction body has no outputs"
+    TxBodyOutputNegative (Quantity q) txout ->
+      "Negative quantity (" <> pretty q <> ") in transaction output: " <>
+      pretty txout
+    TxBodyOutputOverflow (Quantity q) txout ->
+      "Quantity too large (" <> pretty q <> " >= 2^64) in transaction output: " <>
+      pretty txout
+    TxBodyMetadataError [(k, err)] ->
+      "Error in metadata entry " <> pretty k <> ": " <> prettyError err
+    TxBodyMetadataError errs ->
+      mconcat
+        [ "Error in metadata entries: "
+        , mconcat $ List.intersperse "; "
+            [ pretty k <> ": " <> prettyError err
+            | (k, err) <- errs
+            ]
+        ]
+    TxBodyMintAdaError ->
       "Transaction cannot mint ada, only non-ada assets"
-    displayError TxBodyMissingProtocolParams =
-      "Transaction uses Plutus scripts but does not provide the protocol " ++
+    TxBodyMissingProtocolParams ->
+      "Transaction uses Plutus scripts but does not provide the protocol " <>
       "parameters to hash"
-    displayError (TxBodyInIxOverflow txin) =
-      "Transaction input index is too big, " ++
-      "acceptable value is up to 2^32-1, " ++
-      "in input " ++ show txin
-    displayError (TxBodyProtocolParamsConversionError ppces) =
-      "Errors in protocol parameters conversion: " ++ displayError ppces
+    TxBodyInIxOverflow txin ->
+      "Transaction input index is too big, " <>
+      "acceptable value is up to 2^32-1, " <>
+      "in input " <> pretty txin
+    TxBodyProtocolParamsConversionError ppces ->
+      "Errors in protocol parameters conversion: " <> prettyError ppces
 
 createTransactionBody :: ()
   => ShelleyBasedEra era

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -6,6 +6,7 @@ module Test.Cardano.Api.IO
 
 import           Cardano.Api
 import           Cardano.Api.IO
+import           Cardano.Api.Pretty
 
 import           Control.Monad.Except (runExceptT)
 import           Control.Monad.IO.Class (liftIO)
@@ -25,7 +26,7 @@ prop_createVrfFileWithOwnerPermissions =
     result <- liftIO $ writeLazyByteStringFileWithOwnerPermissions (File file) ""
 
     case result of
-      Left err -> failWith Nothing $ displayError @(FileError ()) err
+      Left err -> failWith Nothing $ prettyToString $ pretty @(FileError ()) err
       Right () -> return ()
 
     fResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `Pretty` for rendering errors instead of `Show`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`Pretty` is a typeclass from the `prettyprinter` package.

It has support for powerful formatting options such as colour and layout.

By switching to `Pretty` we are able to use these features.  Furthermore, `plutus` errors and types have `Pretty` instances so can utilise that to pretty print their error messages in an ergonomic way.

This package is also used by `optparse-applicative` which means it is already a dependency.

`Pretty` also doesn't suffer the problem with `Show` where many of the instances render strings that are not friendly to users.

Ledger also have `Show` instances that may not behave the way we want.

Our `Pretty` instances can help us break away from this status quo.

In order to minimise change, this PR does not utilise these features.

Instead, it preserves formatting of all errors exactly as before leaving future PRs to tidy up the formatting and layout of our rendered errors.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
