### PR TITLE
Parameterize some script related functions on `ShelleyBasedEra era`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -312,8 +312,7 @@ genScriptInEra era =
     Gen.choice
       [ ScriptInEra langInEra <$> genScript lang
       | AnyScriptLanguage lang <- [minBound..maxBound]
-        -- TODO: scriptLanguageSupportedInEra should be parameterized on ShelleyBasedEra
-      , Just langInEra <- [scriptLanguageSupportedInEra (toCardanoEra era) lang] ]
+      , Just langInEra <- [scriptLanguageSupportedInEra era lang] ]
 
 genScriptHash :: Gen ScriptHash
 genScriptHash = do

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -578,45 +578,45 @@ instance HasTypeProxy era => HasTypeProxy (ScriptInEra era) where
 -- | Check if a given script language is supported in a given era, and if so
 -- return the evidence.
 --
-scriptLanguageSupportedInEra :: CardanoEra era
+scriptLanguageSupportedInEra :: ShelleyBasedEra era
                              -> ScriptLanguage lang
                              -> Maybe (ScriptLanguageInEra lang era)
 scriptLanguageSupportedInEra era lang =
     case (era, lang) of
-      (ShelleyEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraShelley, SimpleScriptLanguage) ->
         Just SimpleScriptInShelley
 
-      (AllegraEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraAllegra, SimpleScriptLanguage) ->
         Just SimpleScriptInAllegra
 
-      (MaryEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraMary, SimpleScriptLanguage) ->
         Just SimpleScriptInMary
 
-      (AlonzoEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraAlonzo, SimpleScriptLanguage) ->
         Just SimpleScriptInAlonzo
 
-      (BabbageEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraBabbage, SimpleScriptLanguage) ->
         Just SimpleScriptInBabbage
 
-      (ConwayEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraConway, SimpleScriptLanguage) ->
         Just SimpleScriptInConway
 
-      (AlonzoEra, PlutusScriptLanguage PlutusScriptV1) ->
+      (ShelleyBasedEraAlonzo, PlutusScriptLanguage PlutusScriptV1) ->
         Just PlutusScriptV1InAlonzo
 
-      (BabbageEra, PlutusScriptLanguage PlutusScriptV1) ->
+      (ShelleyBasedEraBabbage, PlutusScriptLanguage PlutusScriptV1) ->
         Just PlutusScriptV1InBabbage
 
-      (BabbageEra, PlutusScriptLanguage PlutusScriptV2) ->
+      (ShelleyBasedEraBabbage, PlutusScriptLanguage PlutusScriptV2) ->
         Just PlutusScriptV2InBabbage
 
-      (ConwayEra, PlutusScriptLanguage PlutusScriptV1) ->
+      (ShelleyBasedEraConway, PlutusScriptLanguage PlutusScriptV1) ->
         Just PlutusScriptV1InConway
 
-      (ConwayEra, PlutusScriptLanguage PlutusScriptV2) ->
+      (ShelleyBasedEraConway, PlutusScriptLanguage PlutusScriptV2) ->
         Just PlutusScriptV2InConway
 
-      (ConwayEra, PlutusScriptLanguage PlutusScriptV3) ->
+      (ShelleyBasedEraConway, PlutusScriptLanguage PlutusScriptV3) ->
         Just PlutusScriptV3InConway
 
       _ -> Nothing
@@ -664,7 +664,7 @@ eraOfScriptLanguageInEra langInEra =
 -- | Given a target era and a script in some language, check if the language is
 -- supported in that era, and if so return a 'ScriptInEra'.
 --
-toScriptInEra :: CardanoEra era -> ScriptInAnyLang -> Maybe (ScriptInEra era)
+toScriptInEra :: ShelleyBasedEra era -> ScriptInAnyLang -> Maybe (ScriptInEra era)
 toScriptInEra era (ScriptInAnyLang lang s) = do
     lang' <- scriptLanguageSupportedInEra era lang
     return (ScriptInEra lang' s)
@@ -1405,7 +1405,7 @@ instance IsCardanoEra era => FromJSON (ReferenceScript era) where
       (cardanoEra :: CardanoEra era)
 
 refScriptToShelleyScript
-  :: CardanoEra era
+  :: ShelleyBasedEra era
   -> ReferenceScript era
   -> StrictMaybe (Ledger.Script (ShelleyLedgerEra era))
 refScriptToShelleyScript era (ReferenceScript _ s) =

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -697,20 +697,19 @@ toShelleyTxOut :: forall era ledgerera.
                => ShelleyBasedEra era
                -> TxOut CtxUTxO era
                -> Ledger.TxOut ledgerera
-toShelleyTxOut sbe = \case -- jky simplify
+toShelleyTxOut _ = \case -- jky simplify
   TxOut _ (TxOutValueByron _) _ _ ->
     -- TODO: Temporary until we have basic tx
     -- construction functionality
     error "toShelleyTxOut: Expected a Shelley value"
 
-  TxOut addr (TxOutValueShelleyBased _ value) txoutdata refScript ->
-    let cEra = shelleyBasedToCardanoEra sbe in
+  TxOut addr (TxOutValueShelleyBased sbe value) txoutdata refScript ->
     caseShelleyToAlonzoOrBabbageEraOnwards
       (const $ L.mkBasicTxOut (toShelleyAddr addr) value)
       (const $
         L.mkBasicTxOut (toShelleyAddr addr) value
           & L.datumTxOutL .~ toBabbageTxOutDatum txoutdata
-          & L.referenceScriptTxOutL .~ refScriptToShelleyScript cEra refScript
+          & L.referenceScriptTxOutL .~ refScriptToShelleyScript sbe refScript
       )
       sbe
 
@@ -3101,20 +3100,19 @@ toShelleyTxOutAny :: forall ctx era ledgerera.
                 => ShelleyBasedEra era
                 -> TxOut ctx era
                 -> Ledger.TxOut ledgerera
-toShelleyTxOutAny sbe = \case
+toShelleyTxOutAny _ = \case
   TxOut _ (TxOutValueByron _) _ _ ->
     -- TODO: Temporary until we have basic tx
     -- construction functionality
     error "toShelleyTxOutAny: Expected a Shelley value"
 
-  TxOut addr (TxOutValueShelleyBased _ value) txoutdata refScript ->
-    let cEra = shelleyBasedToCardanoEra sbe in
+  TxOut addr (TxOutValueShelleyBased sbe value) txoutdata refScript ->
     caseShelleyToAlonzoOrBabbageEraOnwards
       (const $ L.mkBasicTxOut (toShelleyAddr addr) value)
       (const $
         L.mkBasicTxOut (toShelleyAddr addr) value
           & L.datumTxOutL .~ toBabbageTxOutDatum' txoutdata
-          & L.referenceScriptTxOutL .~ refScriptToShelleyScript cEra refScript
+          & L.referenceScriptTxOutL .~ refScriptToShelleyScript sbe refScript
       )
       sbe
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
@@ -63,7 +63,7 @@ prop_roundtrip_txbodycontent_txouts =
   matchRefScript :: MonadTest m => (ReferenceScript BabbageEra, ReferenceScript BabbageEra) -> m ()
   matchRefScript (a, b)
     | isSimpleScriptV2 a && isSimpleScriptV2 b =
-      refScriptToShelleyScript BabbageEra a === refScriptToShelleyScript BabbageEra b
+      refScriptToShelleyScript ShelleyBasedEraBabbage a === refScriptToShelleyScript ShelleyBasedEraBabbage b
     | otherwise =
       a === b
 


### PR DESCRIPTION

# Changelog

```yaml
- description: | 
     Parameterize some script related functions on `ShelleyBasedEra era`
       - scriptLanguageSupportedInEra
       - toScriptInEra 
       - refScriptToShelleyScript
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
