### PR TITLE
Minor `prettyprinter` fixes

### DIFF
--- a/cardano-api/internal/Cardano/Api/Error.hs
+++ b/cardano-api/internal/Cardano/Api/Error.hs
@@ -67,8 +67,8 @@ data FileError e = FileError FilePath e
                  | FileIOError FilePath IOException
   deriving (Show, Eq, Functor)
 
-instance Error e => Pretty (FileError e) where
-  pretty = \case
+instance Error e => Error (FileError e) where
+  prettyError = \case
     FileErrorTempFile targetPath tempPath h ->
       vsep
         [ "Error creating temporary file at: " <> pretty tempPath

--- a/cardano-api/internal/Cardano/Api/Pretty.hs
+++ b/cardano-api/internal/Cardano/Api/Pretty.hs
@@ -24,6 +24,8 @@ import qualified Data.Text.Lazy as TextLazy
 import           Prettyprinter
 import           Prettyprinter.Render.Terminal
 
+-- | 'Ann' is the prettyprinter annotation for cardano-api and cardano-cli to enable the printing
+-- of colored output. This is a type alias for AnsiStyle.
 type Ann = AnsiStyle
 
 newtype ShowOf a = ShowOf a

--- a/cardano-api/internal/Cardano/Api/Pretty.hs
+++ b/cardano-api/internal/Cardano/Api/Pretty.hs
@@ -1,8 +1,10 @@
 module Cardano.Api.Pretty
   ( Ann
+  , Doc
   , Pretty(..)
   , ShowOf(..)
   , viaShow
+  , prettyToLazyText
   , prettyToText
   , prettyToString
   , pshow
@@ -17,6 +19,7 @@ module Cardano.Api.Pretty
   , white
   ) where
 
+import qualified Data.Text as Text
 import qualified Data.Text.Lazy as TextLazy
 import           Prettyprinter
 import           Prettyprinter.Render.Terminal
@@ -34,8 +37,11 @@ instance Show a => Pretty (ShowOf a) where
 prettyToString :: Doc AnsiStyle -> String
 prettyToString =  show
 
-prettyToText :: Doc AnsiStyle -> TextLazy.Text
-prettyToText = renderLazy . layoutPretty defaultLayoutOptions
+prettyToLazyText :: Doc AnsiStyle -> TextLazy.Text
+prettyToLazyText = renderLazy . layoutPretty defaultLayoutOptions
+
+prettyToText :: Doc AnsiStyle -> Text.Text
+prettyToText = TextLazy.toStrict . prettyToLazyText
 
 black :: Doc AnsiStyle -> Doc AnsiStyle
 black = annotate (color Black)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -26,7 +26,7 @@ prop_createVrfFileWithOwnerPermissions =
     result <- liftIO $ writeLazyByteStringFileWithOwnerPermissions (File file) ""
 
     case result of
-      Left err -> failWith Nothing $ prettyToString $ pretty @(FileError ()) err
+      Left err -> failWith Nothing $ prettyToString $ prettyError @(FileError ()) err
       Right () -> return ()
 
     fResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    `Error` instance for `FileError` instead of `Pretty`
    Make `prettyToText` return strict `Text` and add `prettyToLazyText`
    Export `Doc`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
