### PR TITLE
Parameterize `createAndValidateTransactionBody` on `ShelleyBasedEra era`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Byron.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Byron.hs
@@ -7,6 +7,7 @@ module Test.Gen.Cardano.Api.Byron
   ) where
 
 import           Cardano.Api hiding (txIns)
+import           Cardano.Api.Byron
 
 import           Data.Proxy
 
@@ -20,8 +21,8 @@ import           Test.Tasty.Hedgehog
 prop_byron_roundtrip_txbody_CBOR :: Property
 prop_byron_roundtrip_txbody_CBOR = property $ do
   let byron = ByronEra
-  x <- forAll $ makeSignedTransaction [] <$> genTxBodyByron
-  tripping x (serialiseTxLedgerCddl byron) (deserialiseTxLedgerCddl byron)
+  x <- forAll $ makeSignedByronTransaction [] <$> genTxBodyByron
+  tripping (ByronTx ByronEraOnlyByron x) (serialiseTxLedgerCddl byron) deserialiseByronTxCddl
 
 
 prop_byron_roundtrip_tx_CBOR :: Property
@@ -42,7 +43,7 @@ prop_byron_roundtrip_Tx_Cddl :: Property
 prop_byron_roundtrip_Tx_Cddl = property $ do
   let byron = ByronEra
   x <- forAll genTxByron
-  tripping x (serialiseTxLedgerCddl byron) (deserialiseTxLedgerCddl byron)
+  tripping x (serialiseTxLedgerCddl byron) deserialiseByronTxCddl
 
 tests :: TestTree
 tests = testGroup "Test.Gen.Cardano.Api.Byron"

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -137,9 +137,9 @@ import qualified Cardano.Api as Api
 import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness),
                    WitnessNetworkIdOrByronAddress (..))
 import           Cardano.Api.Eon.AllegraEraOnwards (allegraEraOnwardsToShelleyBasedEra)
-import           Cardano.Api.Pretty
 import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Api.Ledger.Lens as A
+import           Cardano.Api.Pretty
 import           Cardano.Api.Script (scriptInEraToRefScript)
 import           Cardano.Api.Shelley
 import qualified Cardano.Api.Shelley as ShelleyApi
@@ -313,7 +313,8 @@ genScriptInEra era =
     Gen.choice
       [ ScriptInEra langInEra <$> genScript lang
       | AnyScriptLanguage lang <- [minBound..maxBound]
-      , Just langInEra <- [scriptLanguageSupportedInEra era lang] ]
+        -- TODO: scriptLanguageSupportedInEra should be parameterized on ShelleyBasedEra
+      , Just langInEra <- [scriptLanguageSupportedInEra (toCardanoEra era) lang] ]
 
 genScriptHash :: Gen ScriptHash
 genScriptHash = do

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -313,8 +313,7 @@ genScriptInEra era =
     Gen.choice
       [ ScriptInEra langInEra <$> genScript lang
       | AnyScriptLanguage lang <- [minBound..maxBound]
-        -- TODO: scriptLanguageSupportedInEra should be parameterized on ShelleyBasedEra
-      , Just langInEra <- [scriptLanguageSupportedInEra (toCardanoEra era) lang] ]
+      , Just langInEra <- [scriptLanguageSupportedInEra era lang] ]
 
 genScriptHash :: Gen ScriptHash
 genScriptHash = do

--- a/cardano-api/internal/Cardano/Api/Governance/Poll.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Poll.hs
@@ -36,6 +36,7 @@ module Cardano.Api.Governance.Poll(
     verifyPollAnswer,
   ) where
 
+import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
@@ -326,9 +327,9 @@ renderGovernancePollError err =
 -- (the existence of the transaction in the ledger provides this guarantee).
 verifyPollAnswer
   :: GovernancePoll
-  -> InAnyCardanoEra Tx
+  -> InAnyShelleyBasedEra Tx
   -> Either GovernancePollError [Hash PaymentKey]
-verifyPollAnswer poll (InAnyCardanoEra _era (getTxBody -> TxBody body)) = do
+verifyPollAnswer poll (InAnyShelleyBasedEra _era (getTxBody -> TxBody body)) = do
   answer <- extractPollAnswer (txMetadata body)
   answer `hasMatchingHash` hashGovernancePoll poll
   answer `isAmongAcceptableChoices` govPollAnswers poll

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -77,6 +77,7 @@ module Cardano.Api.IPC (
   ) where
 
 import           Cardano.Api.Block
+import           Cardano.Api.Eras
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.InMode
 import           Cardano.Api.IO
@@ -85,7 +86,7 @@ import           Cardano.Api.Modes
 import           Cardano.Api.NetworkId
 import           Cardano.Api.Protocol
 import           Cardano.Api.Query
-import           Cardano.Api.Tx (getTxBody)
+import           Cardano.Api.Tx
 import           Cardano.Api.TxBody
 
 import qualified Cardano.Ledger.Api as L
@@ -630,7 +631,11 @@ instance ToJSON LocalTxMonitoringResult where
           ]
         where
           txId = case txInMode of
-            Just (TxInMode _ tx) -> Just $ getTxId $ getTxBody tx
+            Just (TxInMode e tx) ->
+              case e of
+                -- NB: Local tx protocol is not possible in the Byron era
+                ByronEra -> error "ToJSON LocalTxMonitoringResult: Byron era not supported"
+                _ -> Just $ getTxId $ getTxBody tx
             -- TODO: support fetching the ID of a Byron Era transaction
             _ -> Nothing
       LocalTxMonitoringMempoolSizeAndCapacity mempool slot ->

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -73,6 +73,10 @@ module Cardano.Api.ReexposeLedger
   , drepDepositL
   , csCommitteeCredsL
 
+  -- Byron
+  , Annotated
+  , Byron.Tx(..)
+
   -- Babbage
   , CoinPerByte (..)
 
@@ -103,6 +107,7 @@ module Cardano.Api.ReexposeLedger
   , EpochNo(..)
   ) where
 
+import qualified Cardano.Chain.UTxO as Byron
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
 import           Cardano.Ledger.Alonzo.Core (CoinPerWord (..), PParamsUpdate (..))
 import           Cardano.Ledger.Alonzo.Scripts (Prices (..))
@@ -116,6 +121,7 @@ import           Cardano.Ledger.Babbage.Core (CoinPerByte (..))
 import           Cardano.Ledger.BaseTypes (DnsName, Network (..), StrictMaybe (..), Url,
                    boundRational, dnsToText, maybeToStrictMaybe, portToWord16, strictMaybeToMaybe,
                    textToDns, textToUrl, unboundRational, urlToText)
+import           Cardano.Ledger.Binary (Annotated (..))
 import           Cardano.Ledger.CertState (DRepState, csCommitteeCredsL)
 import           Cardano.Ledger.Coin (Coin (..), addDeltaCoin, toDeltaCoin)
 import           Cardano.Ledger.Conway.Core (DRepVotingThresholds (..), PoolVotingThresholds (..),

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -578,45 +578,45 @@ instance HasTypeProxy era => HasTypeProxy (ScriptInEra era) where
 -- | Check if a given script language is supported in a given era, and if so
 -- return the evidence.
 --
-scriptLanguageSupportedInEra :: CardanoEra era
+scriptLanguageSupportedInEra :: ShelleyBasedEra era
                              -> ScriptLanguage lang
                              -> Maybe (ScriptLanguageInEra lang era)
 scriptLanguageSupportedInEra era lang =
     case (era, lang) of
-      (ShelleyEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraShelley, SimpleScriptLanguage) ->
         Just SimpleScriptInShelley
 
-      (AllegraEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraAllegra, SimpleScriptLanguage) ->
         Just SimpleScriptInAllegra
 
-      (MaryEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraMary, SimpleScriptLanguage) ->
         Just SimpleScriptInMary
 
-      (AlonzoEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraAlonzo, SimpleScriptLanguage) ->
         Just SimpleScriptInAlonzo
 
-      (BabbageEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraBabbage, SimpleScriptLanguage) ->
         Just SimpleScriptInBabbage
 
-      (ConwayEra, SimpleScriptLanguage) ->
+      (ShelleyBasedEraConway, SimpleScriptLanguage) ->
         Just SimpleScriptInConway
 
-      (AlonzoEra, PlutusScriptLanguage PlutusScriptV1) ->
+      (ShelleyBasedEraAlonzo, PlutusScriptLanguage PlutusScriptV1) ->
         Just PlutusScriptV1InAlonzo
 
-      (BabbageEra, PlutusScriptLanguage PlutusScriptV1) ->
+      (ShelleyBasedEraBabbage, PlutusScriptLanguage PlutusScriptV1) ->
         Just PlutusScriptV1InBabbage
 
-      (BabbageEra, PlutusScriptLanguage PlutusScriptV2) ->
+      (ShelleyBasedEraBabbage, PlutusScriptLanguage PlutusScriptV2) ->
         Just PlutusScriptV2InBabbage
 
-      (ConwayEra, PlutusScriptLanguage PlutusScriptV1) ->
+      (ShelleyBasedEraConway, PlutusScriptLanguage PlutusScriptV1) ->
         Just PlutusScriptV1InConway
 
-      (ConwayEra, PlutusScriptLanguage PlutusScriptV2) ->
+      (ShelleyBasedEraConway, PlutusScriptLanguage PlutusScriptV2) ->
         Just PlutusScriptV2InConway
 
-      (ConwayEra, PlutusScriptLanguage PlutusScriptV3) ->
+      (ShelleyBasedEraConway, PlutusScriptLanguage PlutusScriptV3) ->
         Just PlutusScriptV3InConway
 
       _ -> Nothing
@@ -664,7 +664,7 @@ eraOfScriptLanguageInEra langInEra =
 -- | Given a target era and a script in some language, check if the language is
 -- supported in that era, and if so return a 'ScriptInEra'.
 --
-toScriptInEra :: CardanoEra era -> ScriptInAnyLang -> Maybe (ScriptInEra era)
+toScriptInEra :: ShelleyBasedEra era -> ScriptInAnyLang -> Maybe (ScriptInEra era)
 toScriptInEra era (ScriptInAnyLang lang s) = do
     lang' <- scriptLanguageSupportedInEra era lang
     return (ScriptInEra lang' s)
@@ -1405,7 +1405,7 @@ instance IsCardanoEra era => FromJSON (ReferenceScript era) where
       (cardanoEra :: CardanoEra era)
 
 refScriptToShelleyScript
-  :: CardanoEra era
+  :: ShelleyBasedEra era
   -> ReferenceScript era
   -> StrictMaybe (Ledger.Script (ShelleyLedgerEra era))
 refScriptToShelleyScript era (ReferenceScript _ s) =

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -2013,7 +2013,7 @@ maxTxOut :: Quantity
 maxTxOut = fromIntegral (maxBound :: Word64)
 
 createAndValidateTransactionBody :: ()
-  => CardanoEra era
+  => ShelleyBasedEra era
   -> TxBodyContent BuildTx era
   -> Either TxBodyError (TxBody era)
 createAndValidateTransactionBody era txBodyContent =

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -31,6 +31,10 @@ module Cardano.Api.TxBody (
     createTransactionBody,
     createAndValidateTransactionBody,
     TxBodyContent(..),
+
+    -- * Byron only
+    makeByronTransactionBody,
+
     -- ** Transaction body builders
     defaultTxBodyContent,
     defaultTxFee,
@@ -71,6 +75,7 @@ module Cardano.Api.TxBody (
     -- * Transaction Ids
     TxId(..),
     getTxId,
+    getTxIdByron,
     getTxIdShelley,
 
     -- * Transaction inputs
@@ -146,6 +151,7 @@ module Cardano.Api.TxBody (
     -- * Data family instances
     AsType(AsTxId, AsTxBody, AsByronTxBody, AsShelleyTxBody, AsMaryTxBody),
 
+    getByronTxBodyContent,
     getTxBodyContent,
   ) where
 
@@ -199,7 +205,7 @@ import qualified Cardano.Ledger.Alonzo.TxWits as Alonzo
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import           Cardano.Ledger.Binary (Annotated (..), reAnnotate, recoverBytes)
+import           Cardano.Ledger.Binary (Annotated (..), reAnnotate)
 import qualified Cardano.Ledger.Binary as CBOR
 import qualified Cardano.Ledger.Block as Ledger
 import           Cardano.Ledger.Core ()
@@ -239,7 +245,7 @@ import qualified Data.List as List
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes, fromMaybe, maybeToList)
+import           Data.Maybe
 import           Data.Monoid
 import qualified Data.OSet.Strict as OSet
 import           Data.Scientific (toBoundedInteger)
@@ -684,8 +690,8 @@ fromByronTxOut ByronEraOnlyByron (Byron.TxOut addr value) =
      TxOutDatumNone ReferenceScriptNone
 
 
-toByronTxOut :: ByronEraOnly era -> TxOut ctx era -> Maybe Byron.TxOut
-toByronTxOut ByronEraOnlyByron = \case
+toByronTxOut :: TxOut ctx ByronEra -> Maybe Byron.TxOut
+toByronTxOut = \case
   TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress addr)) (TxOutValueByron value) _ _ ->
     Byron.TxOut addr <$> toByronLovelace value
   TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress _)) (TxOutValueShelleyBased w _) _ _ ->
@@ -1317,12 +1323,6 @@ setTxScriptValidity v txBodyContent = txBodyContent { txScriptValidity = v }
 --
 
 data TxBody era where
-
-     ByronTxBody
-       :: ByronEraOnly era
-       -> Annotated Byron.Tx ByteString
-       -> TxBody era
-
      ShelleyTxBody
        :: ShelleyBasedEra era
        -> Ledger.TxBody (ShelleyLedgerEra era)
@@ -1368,9 +1368,6 @@ deriving instance L.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto => Show (T
 
 -- The GADT in the ShelleyTxBody case requires a custom instance
 instance Eq (TxBody era) where
-    (==) (ByronTxBody _ txbodyA)
-         (ByronTxBody _ txbodyB) = txbodyA == txbodyB
-
     (==) (ShelleyTxBody sbe txbodyA txscriptsA redeemersA txmetadataA scriptValidityA)
          (ShelleyTxBody _   txbodyB txscriptsB redeemersB txmetadataB scriptValidityB) =
          case sbe of
@@ -1404,18 +1401,8 @@ instance Eq (TxBody era) where
                                   && txmetadataA     == txmetadataB
                                   && scriptValidityA == scriptValidityB
 
-    (==) (ByronTxBody ByronEraOnlyByron _) (ShelleyTxBody sbe _ _ _ _ _) = case sbe of {}
-    (==) (ShelleyTxBody sbe _ _ _ _ _) (ByronTxBody ByronEraOnlyByron _) = case sbe of {}
-
-
 -- The GADT in the ShelleyTxBody case requires a custom instance
 instance Show (TxBody era) where
-    showsPrec p (ByronTxBody _ txbody) =
-      showParen (p >= 11)
-        ( showString "ByronTxBody ByronEraOnlyByron "
-        . showsPrec 11 txbody
-        )
-
     showsPrec p (ShelleyTxBody ShelleyBasedEraShelley
                                txbody txscripts redeemers txmetadata scriptValidity) =
       showParen (p >= 11)
@@ -1523,26 +1510,11 @@ pattern AsMaryTxBody :: AsType (TxBody MaryEra)
 pattern AsMaryTxBody = AsTxBody AsMaryEra
 {-# COMPLETE AsMaryTxBody #-}
 
-instance IsCardanoEra era => SerialiseAsCBOR (TxBody era) where
-
-    serialiseToCBOR (ByronTxBody _ txbody) =
-      recoverBytes txbody
-
+instance IsShelleyBasedEra era => SerialiseAsCBOR (TxBody era) where
     serialiseToCBOR (ShelleyTxBody sbe txbody txscripts redeemers txmetadata scriptValidity) =
       serialiseShelleyBasedTxBody sbe txbody txscripts redeemers txmetadata scriptValidity
 
-    deserialiseFromCBOR _ bs =
-      caseByronOrShelleyBasedEra
-        (\eon ->
-          ByronTxBody eon <$>
-            CBOR.decodeFullAnnotatedBytes
-              CBOR.byronProtVer
-              "Byron TxBody"
-              CBOR.decCBORAnnotated
-              (LBS.fromStrict bs)
-        )
-        (\sbe -> deserialiseShelleyBasedTxBody sbe bs)
-        (cardanoEra :: CardanoEra era)
+    deserialiseFromCBOR _ = deserialiseShelleyBasedTxBody shelleyBasedEra
 
 -- | The serialisation format for the different Shelley-based eras are not the
 -- same, but they can be handled generally with one overloaded implementation.
@@ -1691,31 +1663,32 @@ deserialiseShelleyBasedTxBody sbe bs =
               (flip CBOR.runAnnotator fbs (return $ TxScriptValidity sValiditySupported scriptValidity))
         _ -> fail $ "expected tx body tuple of size 2, 3, 4 or 6, got " <> show len
 
-instance IsCardanoEra era => HasTextEnvelope (TxBody era) where
+instance IsShelleyBasedEra era => HasTextEnvelope (TxBody era) where
     textEnvelopeType _ =
-      case cardanoEra :: CardanoEra era of
-        ByronEra   -> "TxUnsignedByron"
-        ShelleyEra -> "TxUnsignedShelley"
-        AllegraEra -> "TxBodyAllegra"
-        MaryEra    -> "TxBodyMary"
-        AlonzoEra  -> "TxBodyAlonzo"
-        BabbageEra -> "TxBodyBabbage"
-        ConwayEra  -> "TxBodyConway"
+      case shelleyBasedEra :: ShelleyBasedEra era of
+        ShelleyBasedEraShelley -> "TxUnsignedShelley"
+        ShelleyBasedEraAllegra -> "TxBodyAllegra"
+        ShelleyBasedEraMary    -> "TxBodyMary"
+        ShelleyBasedEraAlonzo  -> "TxBodyAlonzo"
+        ShelleyBasedEraBabbage -> "TxBodyBabbage"
+        ShelleyBasedEraConway  -> "TxBodyConway"
 
--- | Calculate the transaction identifier for a 'TxBody'.
---
-getTxId :: TxBody era -> TxId
-getTxId (ByronTxBody _ tx) =
+
+getTxIdByron :: Byron.ATxAux ByteString -> TxId
+getTxIdByron (Byron.ATxAux { Byron.aTaTx = txbody }) =
     TxId
   . fromMaybe impossible
   . Crypto.hashFromBytesShort
   . Byron.abstractHashToShort
   . Byron.hashDecoded
-  $ tx
+  $ txbody
   where
     impossible =
-      error "getTxId: byron and shelley hash sizes do not match"
+      error "getTxIdByron: byron and shelley hash sizes do not match"
 
+-- | Calculate the transaction identifier for a 'TxBody'.
+--
+getTxId :: TxBody era -> TxId
 getTxId (ShelleyTxBody sbe tx _ _ _ _) =
   shelleyBasedEraConstraints sbe $ getTxIdShelley sbe tx
 
@@ -2016,11 +1989,7 @@ createAndValidateTransactionBody :: ()
   => ShelleyBasedEra era
   -> TxBodyContent BuildTx era
   -> Either TxBodyError (TxBody era)
-createAndValidateTransactionBody era txBodyContent =
-  caseByronOrShelleyBasedEra
-    (\eon -> makeByronTransactionBody eon (txIns txBodyContent) (txOuts txBodyContent))
-    (\eon -> makeShelleyTransactionBody eon txBodyContent)
-    era
+createAndValidateTransactionBody = makeShelleyTransactionBody
 
 pattern TxBody :: TxBodyContent ViewTx era -> TxBody era
 pattern TxBody txbodycontent <- (getTxBodyContent -> txbodycontent)
@@ -2028,8 +1997,6 @@ pattern TxBody txbodycontent <- (getTxBodyContent -> txbodycontent)
 
 getTxBodyContent :: TxBody era -> TxBodyContent ViewTx era
 getTxBodyContent = \case
-  ByronTxBody w body ->
-    getByronTxBodyContent w body
   ShelleyTxBody sbe body _scripts scriptdata mAux scriptValidity ->
     fromLedgerTxBody sbe scriptValidity body scriptdata mAux
 
@@ -2407,11 +2374,10 @@ fromLedgerTxMintValue sbe body =
 
 
 makeByronTransactionBody :: ()
-  => ByronEraOnly era
-  -> TxIns BuildTx era
-  -> [TxOut CtxTx era]
-  -> Either TxBodyError (TxBody era)
-makeByronTransactionBody eon txIns txOuts = do
+  => TxIns BuildTx ByronEra
+  -> [TxOut CtxTx ByronEra]
+  -> Either TxBodyError (Annotated Byron.Tx ByteString)
+makeByronTransactionBody txIns txOuts = do
     ins' <- NonEmpty.nonEmpty (map fst txIns) ?! TxBodyEmptyTxIns
     for_ ins' $ \txin@(TxIn _ (TxIx txix)) ->
       guard (fromIntegral txix <= maxByronTxInIx) ?! TxBodyInIxOverflow txin
@@ -2419,20 +2385,19 @@ makeByronTransactionBody eon txIns txOuts = do
 
     outs'  <- NonEmpty.nonEmpty txOuts    ?! TxBodyEmptyTxOuts
     outs'' <- traverse
-                (\out -> toByronTxOut eon out ?! classifyRangeError eon out)
+                (\out -> toByronTxOut out ?! classifyRangeError out)
                 outs'
     return $
-      ByronTxBody eon $
-        reAnnotate CBOR.byronProtVer $
-          Annotated
-            (Byron.UnsafeTx ins'' outs'' (Byron.mkAttributes ()))
-            ()
+      reAnnotate CBOR.byronProtVer $
+        Annotated
+          (Byron.UnsafeTx ins'' outs'' (Byron.mkAttributes ()))
+          ()
   where
     maxByronTxInIx :: Word
     maxByronTxInIx = fromIntegral (maxBound :: Word32)
 
-classifyRangeError :: ByronEraOnly era -> TxOut CtxTx era -> TxBodyError
-classifyRangeError ByronEraOnlyByron txout =
+classifyRangeError :: TxOut CtxTx ByronEra -> TxBodyError
+classifyRangeError txout =
   case txout of
     TxOut (AddressInEra ByronAddressInAnyEra ByronAddress{}) (TxOutValueByron value) _ _
       | value < 0 -> TxBodyOutputNegative (lovelaceToQuantity value) (txOutInAnyEra ByronEra txout)

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -699,20 +699,19 @@ toShelleyTxOut :: forall era ledgerera.
                => ShelleyBasedEra era
                -> TxOut CtxUTxO era
                -> Ledger.TxOut ledgerera
-toShelleyTxOut sbe = \case -- jky simplify
+toShelleyTxOut _ = \case -- jky simplify
   TxOut _ (TxOutValueByron _) _ _ ->
     -- TODO: Temporary until we have basic tx
     -- construction functionality
     error "toShelleyTxOut: Expected a Shelley value"
 
-  TxOut addr (TxOutValueShelleyBased _ value) txoutdata refScript ->
-    let cEra = shelleyBasedToCardanoEra sbe in
+  TxOut addr (TxOutValueShelleyBased sbe value) txoutdata refScript ->
     caseShelleyToAlonzoOrBabbageEraOnwards
       (const $ L.mkBasicTxOut (toShelleyAddr addr) value)
       (const $
         L.mkBasicTxOut (toShelleyAddr addr) value
           & L.datumTxOutL .~ toBabbageTxOutDatum txoutdata
-          & L.referenceScriptTxOutL .~ refScriptToShelleyScript cEra refScript
+          & L.referenceScriptTxOutL .~ refScriptToShelleyScript sbe refScript
       )
       sbe
 
@@ -3109,20 +3108,19 @@ toShelleyTxOutAny :: forall ctx era ledgerera.
                 => ShelleyBasedEra era
                 -> TxOut ctx era
                 -> Ledger.TxOut ledgerera
-toShelleyTxOutAny sbe = \case
+toShelleyTxOutAny _ = \case
   TxOut _ (TxOutValueByron _) _ _ ->
     -- TODO: Temporary until we have basic tx
     -- construction functionality
     error "toShelleyTxOutAny: Expected a Shelley value"
 
-  TxOut addr (TxOutValueShelleyBased _ value) txoutdata refScript ->
-    let cEra = shelleyBasedToCardanoEra sbe in
+  TxOut addr (TxOutValueShelleyBased sbe value) txoutdata refScript ->
     caseShelleyToAlonzoOrBabbageEraOnwards
       (const $ L.mkBasicTxOut (toShelleyAddr addr) value)
       (const $
         L.mkBasicTxOut (toShelleyAddr addr) value
           & L.datumTxOutL .~ toBabbageTxOutDatum' txoutdata
-          & L.referenceScriptTxOutL .~ refScriptToShelleyScript cEra refScript
+          & L.referenceScriptTxOutL .~ refScriptToShelleyScript sbe refScript
       )
       sbe
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -301,9 +301,11 @@ module Cardano.Api (
     -- | Constructing and inspecting transactions
 
     -- ** Transaction bodies
-    TxBody(TxBody),
+    TxBody(..),
     createAndValidateTransactionBody,
+    makeByronTransactionBody,
     TxBodyContent(..),
+    getByronTxBodyContent,
     getTxBodyContent,
 
     -- ** Transaction body builders
@@ -338,6 +340,7 @@ module Cardano.Api (
     -- ** Transaction Ids
     TxId(..),
     getTxId,
+    getTxIdByron,
 
     -- ** Transaction inputs
     TxIn(TxIn),
@@ -419,6 +422,7 @@ module Cardano.Api (
     signShelleyTransaction,
 
     -- ** Incremental signing and separate witnesses
+    makeSignedByronTransaction,
     makeSignedTransaction,
     KeyWitness,
     makeByronKeyWitness,
@@ -668,6 +672,7 @@ module Cardano.Api (
     writeTxWitnessFileTextEnvelopeCddl,
     serialiseTxLedgerCddl,
     deserialiseTxLedgerCddl,
+    deserialiseByronTxCddl,
     serialiseWitnessLedgerCddl,
     deserialiseWitnessLedgerCddl,
     TextEnvelopeCddl(..), -- TODO: Deprecate this when we stop supporting the cli's

--- a/cardano-api/src/Cardano/Api/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Byron.hs
@@ -23,7 +23,6 @@ module Cardano.Api.Byron
 
     -- * Building transactions
     -- | Constructing and inspecting transactions
-    TxBody(ByronTxBody),
     TxId(TxId),
     TxIn(TxIn),
     TxOut(TxOut),

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/CBOR.hs
@@ -27,12 +27,11 @@ import           Test.Tasty.Hedgehog (testProperty)
 
 -- TODO: Need to add PaymentExtendedKey roundtrip tests however
 -- we can't derive an Eq instance for Crypto.HD.XPrv
-
 prop_roundtrip_txbody_CBOR :: Property
 prop_roundtrip_txbody_CBOR = H.property $ do
   AnyShelleyBasedEra era <- H.forAll $ Gen.element [minBound..maxBound]
   x <- H.forAll $ makeSignedTransaction [] <$> genTxBody era
-  H.tripping x (serialiseTxLedgerCddl $ toCardanoEra era) (deserialiseTxLedgerCddl $ toCardanoEra era)
+  H.tripping x (serialiseTxLedgerCddl $ toCardanoEra era) (deserialiseTxLedgerCddl era)
 
 prop_roundtrip_tx_CBOR :: Property
 prop_roundtrip_tx_CBOR = H.property $ do
@@ -171,7 +170,7 @@ prop_roundtrip_Tx_Cddl :: Property
 prop_roundtrip_Tx_Cddl = H.property $ do
   AnyShelleyBasedEra era <- H.forAll $ Gen.element [minBound..maxBound]
   x <- forAll $ genTx era
-  H.tripping x (serialiseTxLedgerCddl $ toCardanoEra era) (deserialiseTxLedgerCddl $ toCardanoEra era)
+  H.tripping x (serialiseTxLedgerCddl $ toCardanoEra era) (deserialiseTxLedgerCddl era)
 
 prop_roundtrip_TxWitness_Cddl :: Property
 prop_roundtrip_TxWitness_Cddl = H.property $ do

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
@@ -63,7 +63,7 @@ prop_roundtrip_txbodycontent_txouts =
   matchRefScript :: MonadTest m => (ReferenceScript BabbageEra, ReferenceScript BabbageEra) -> m ()
   matchRefScript (a, b)
     | isSimpleScriptV2 a && isSimpleScriptV2 b =
-      refScriptToShelleyScript BabbageEra a === refScriptToShelleyScript BabbageEra b
+      refScriptToShelleyScript ShelleyBasedEraBabbage a === refScriptToShelleyScript ShelleyBasedEraBabbage b
     | otherwise =
       a === b
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
@@ -25,8 +25,8 @@ import           Test.Tasty.Hedgehog (testProperty)
 prop_roundtrip_txbodycontent_txouts:: Property
 prop_roundtrip_txbodycontent_txouts =
   H.property $ do
-    let era = BabbageEra
-    content <- H.forAll $ genTxBodyContent ShelleyBasedEraBabbage
+    let era = ShelleyBasedEraBabbage
+    content <- H.forAll $ genTxBodyContent era
     -- Create the ledger body & auxiliaries
     body <- case createAndValidateTransactionBody era content of
       Left err -> annotateShow err >> failure


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Parameterize `createAndValidateTransactionBody` on `ShelleyBasedEra era`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
