### PR TITLE
`ToJSON` instance for `TxValidationError`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -131,6 +131,7 @@ library internal
                         Cardano.Api.Utils
                         Cardano.Api.Value
                         Cardano.Api.ValueParser
+                        Cardano.Api.Via.ShowOf
                         -- TODO: Eliminate in the future when
                         -- we create wrapper types for the ledger types
                         -- in this module

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -47,6 +47,7 @@ import qualified Cardano.Ledger.BaseTypes as L
 import           Cardano.Ledger.Binary (FromCBOR)
 import qualified Cardano.Ledger.Core as L
 import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.Rules as L
 import qualified Cardano.Ledger.UTxO as L
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
@@ -213,6 +214,8 @@ type ShelleyBasedEraConstraints era =
   , IsCardanoEra era
   , IsShelleyBasedEra era
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
+  , ToJSON (L.PredicateFailure (L.EraRule "LEDGER" (ShelleyLedgerEra era)))
+  , ToJSON (L.PredicateFailure (L.EraRule "UTXOW" (ShelleyLedgerEra era)))
   , Typeable era
   )
 

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -219,59 +219,32 @@ toConsensusTxId (TxIdInMode ConwayEra txid) =
 -- transaction to a local node. The errors are specific to an era.
 --
 data TxValidationError era where
+  ByronTxValidationError
+    :: Consensus.ApplyTxErr Consensus.ByronBlock
+    -> TxValidationError ByronEra
 
-     ByronTxValidationError
-       :: Consensus.ApplyTxErr Consensus.ByronBlock
-       -> TxValidationError ByronEra
-
-     ShelleyTxValidationError
-       :: ShelleyBasedEra era
-       -> Consensus.ApplyTxErr (Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era))
-       -> TxValidationError era
+  ShelleyTxValidationError
+    :: ShelleyBasedEra era
+    -> Consensus.ApplyTxErr (Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era))
+    -> TxValidationError era
 
 -- The GADT in the ShelleyTxValidationError case requires a custom instance
 instance Show (TxValidationError era) where
-    showsPrec p (ByronTxValidationError err) =
+  showsPrec p = \case
+    ByronTxValidationError err ->
       showParen (p >= 11)
         ( showString "ByronTxValidationError "
         . showsPrec 11 err
         )
 
-    showsPrec p (ShelleyTxValidationError ShelleyBasedEraShelley err) =
-      showParen (p >= 11)
-        ( showString "ShelleyTxValidationError ShelleyBasedEraShelley "
-        . showsPrec 11 err
-        )
-
-    showsPrec p (ShelleyTxValidationError ShelleyBasedEraAllegra err) =
-      showParen (p >= 11)
-        ( showString "ShelleyTxValidationError ShelleyBasedEraAllegra "
-        . showsPrec 11 err
-        )
-
-    showsPrec p (ShelleyTxValidationError ShelleyBasedEraMary err) =
-      showParen (p >= 11)
-        ( showString "ShelleyTxValidationError ShelleyBasedEraMary "
-        . showsPrec 11 err
-        )
-
-    showsPrec p (ShelleyTxValidationError ShelleyBasedEraAlonzo err) =
-      showParen (p >= 11)
-        ( showString "ShelleyTxValidationError ShelleyBasedEraAlonzo "
-        . showsPrec 11 err
-        )
-
-    showsPrec p (ShelleyTxValidationError ShelleyBasedEraBabbage err) =
-      showParen (p >= 11)
-        ( showString "ShelleyTxValidationError ShelleyBasedEraBabbage "
-        . showsPrec 11 err
-        )
-
-    showsPrec p (ShelleyTxValidationError ShelleyBasedEraConway err) =
-      showParen (p >= 11)
-        ( showString "ShelleyTxValidationError ShelleyBasedEraConway "
-        . showsPrec 11 err
-        )
+    ShelleyTxValidationError sbe err ->
+      shelleyBasedEraConstraints sbe $
+        showParen (p >= 11)
+          ( showString "ShelleyTxValidationError "
+          . showString (show sbe)
+          . showString " "
+          . showsPrec 11 err
+          )
 
 -- | A 'TxValidationError' in one of the eras supported by a given protocol
 -- mode.

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -220,20 +220,22 @@ toConsensusTxId (TxIdInMode ConwayEra txid) =
 --
 data TxValidationError era where
   ByronTxValidationError
-    :: Consensus.ApplyTxErr Consensus.ByronBlock
-    -> TxValidationError ByronEra
+    :: ByronEraOnly era
+    -> Consensus.ApplyTxErr Consensus.ByronBlock
+    -> TxValidationError era
 
   ShelleyTxValidationError
     :: ShelleyBasedEra era
     -> Consensus.ApplyTxErr (Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era))
     -> TxValidationError era
 
--- The GADT in the ShelleyTxValidationError case requires a custom instance
 instance Show (TxValidationError era) where
   showsPrec p = \case
-    ByronTxValidationError err ->
+    ByronTxValidationError w err ->
       showParen (p >= 11)
         ( showString "ByronTxValidationError "
+        . showString (show w)
+        . showString " "
         . showsPrec 11 err
         )
 
@@ -269,7 +271,7 @@ fromConsensusApplyTxErr :: ()
   -> TxValidationErrorInCardanoMode
 fromConsensusApplyTxErr = \case
   Consensus.ApplyTxErrByron err ->
-    TxValidationErrorInCardanoMode $ ByronTxValidationError err
+    TxValidationErrorInCardanoMode $ ByronTxValidationError ByronEraOnlyByron err
   Consensus.ApplyTxErrShelley err ->
     TxValidationErrorInCardanoMode $ ShelleyTxValidationError ShelleyBasedEraShelley err
   Consensus.ApplyTxErrAllegra err ->

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -225,8 +225,7 @@ toConsensusTxId (TxIdInMode ConwayEra txid) =
 --
 data TxValidationError era where
   ByronTxValidationError
-    :: ByronEraOnly era
-    -> Consensus.ApplyTxErr Consensus.ByronBlock
+    :: Consensus.ApplyTxErr Consensus.ByronBlock
     -> TxValidationError era
 
   ShelleyTxValidationError
@@ -238,11 +237,9 @@ deriving instance Generic (TxValidationError era)
 
 instance Show (TxValidationError era) where
   showsPrec p = \case
-    ByronTxValidationError w err ->
+    ByronTxValidationError err ->
       showParen (p >= 11)
         ( showString "ByronTxValidationError "
-        . showString (show w)
-        . showString " "
         . showsPrec 11 err
         )
 
@@ -257,11 +254,9 @@ instance Show (TxValidationError era) where
 
 instance ToJSON (TxValidationError era) where
   toJSON = \case
-    ByronTxValidationError w err ->
-      byronEraOnlyConstraints w $
+    ByronTxValidationError err ->
         Aeson.object
           [ "kind" .= Aeson.String "ByronTxValidationError"
-          , "era" .= toJSON (Text.pack (show w))
           , "error" .= toJSON err
           ]
     ShelleyTxValidationError sbe err ->
@@ -301,7 +296,7 @@ fromConsensusApplyTxErr :: ()
   -> TxValidationErrorInCardanoMode
 fromConsensusApplyTxErr = \case
   Consensus.ApplyTxErrByron err ->
-    TxValidationErrorInCardanoMode $ ByronTxValidationError ByronEraOnlyByron err
+    TxValidationErrorInCardanoMode $ ByronTxValidationError err
   Consensus.ApplyTxErrShelley err ->
     TxValidationErrorInCardanoMode $ ShelleyTxValidationError ShelleyBasedEraShelley err
   Consensus.ApplyTxErrAllegra err ->

--- a/cardano-api/internal/Cardano/Api/Pretty.hs
+++ b/cardano-api/internal/Cardano/Api/Pretty.hs
@@ -19,6 +19,8 @@ module Cardano.Api.Pretty
   , white
   ) where
 
+import           Cardano.Api.Via.ShowOf
+
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as TextLazy
 import           Prettyprinter
@@ -27,14 +29,6 @@ import           Prettyprinter.Render.Terminal
 -- | 'Ann' is the prettyprinter annotation for cardano-api and cardano-cli to enable the printing
 -- of colored output. This is a type alias for AnsiStyle.
 type Ann = AnsiStyle
-
-newtype ShowOf a = ShowOf a
-
-instance Show a => Show (ShowOf a) where
-  show (ShowOf a) = show a
-
-instance Show a => Pretty (ShowOf a) where
-  pretty = viaShow
 
 prettyToString :: Doc AnsiStyle -> String
 prettyToString =  show

--- a/cardano-api/internal/Cardano/Api/Via/ShowOf.hs
+++ b/cardano-api/internal/Cardano/Api/Via/ShowOf.hs
@@ -1,0 +1,23 @@
+module Cardano.Api.Via.ShowOf
+  ( ShowOf(..)
+  ) where
+
+import           Data.Aeson
+import qualified Data.Aeson.Key as Key
+import           Data.Aeson.Types
+import qualified Data.Text as Text
+import           Prettyprinter
+
+newtype ShowOf a = ShowOf a
+
+instance Show a => Show (ShowOf a) where
+  show (ShowOf a) = show a
+
+instance Show a => Pretty (ShowOf a) where
+  pretty = viaShow
+
+instance Show a => ToJSON (ShowOf a) where
+  toJSON (ShowOf a) = String (Text.pack (show a))
+
+instance Show a => ToJSONKey (ShowOf a) where
+  toJSONKey = toJSONKeyKey (Key.fromString . show)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    `ToJSON` instance for `TxValidationError`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This is needed for reporting errors in machine readable JSON.

Note that the error tree is not completely converted to JSON structure.  Some sub-branches remain as strings because the ledger does not export enough symbols to go all the way down to the leaves.

In any case, these instances are a stop-gap until the instances are implemented in the ledger proper.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
