### PR TITLE
Expose `stakeCredentialWitness` function, which returns only stake credentials for the certificates requiring witnessing: delegation and deregistration

### DIFF
--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -1150,7 +1150,7 @@ mapTxScriptWitnesses f txbodycontent@TxBodyContent {
               [ (stakecred, ScriptWitness ctx <$> witness')
                 -- The certs are indexed in list order
               | (ix, cert) <- zip [0..] certs
-              , stakecred  <- maybeToList (selectStakeCredential cert)
+              , stakecred  <- maybeToList (selectStakeCredentialWitness cert)
               , ScriptWitness ctx witness
                            <- maybeToList (Map.lookup stakecred witnesses)
               , let witness' = f (ScriptWitnessIndexCertificate ix) witness

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -257,6 +257,7 @@ import qualified Text.Parsec as Parsec
 import           Text.Parsec ((<?>))
 import qualified Text.Parsec.String as Parsec
 
+
 -- | Indicates whether a script is expected to fail or pass validation.
 data ScriptValidity
   = ScriptInvalid -- ^ Script is expected to fail validation.
@@ -1843,7 +1844,8 @@ createTransactionBody sbe bc =
           mkCommonTxBody sbe (txIns bc) (txOuts bc) (txFee bc) (txWithdrawals bc) txAuxData
             & A.certsTxBodyL sbe            .~ certs
             & A.invalidHereAfterTxBodyL sbe .~ convValidityUpperBound sbe (txValidityUpperBound bc)
-            & ( appEndo $ mconcat
+            & appEndo
+                ( mconcat
                   [ setUpdateProposal
                   , setInvalidBefore
                   , setMint
@@ -1854,7 +1856,7 @@ createTransactionBody sbe bc =
                   , setCollateralReturn
                   , setTotalCollateral
                   ]
-              )
+                )
 
     -- TODO: NetworkId for hardware wallets. We don't always want this
     -- & L.networkIdTxBodyL .~ ...
@@ -3264,7 +3266,7 @@ collectTxBodyScriptWitnesses _ TxBodyContent {
           -- The certs are indexed in list order
         | (ix, cert) <- zip [0..] certs
         , ScriptWitness _ witness <- maybeToList $ do
-                                       stakecred <- selectStakeCredential cert
+                                       stakecred <- selectStakeCredentialWitness cert
                                        Map.lookup stakecred witnesses
         ]
 

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -140,3 +140,4 @@ modifyWith :: ()
   => (a -> a)
   -> (a -> a)
 modifyWith = id
+

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -862,6 +862,7 @@ module Cardano.Api (
     makeGenesisKeyDelegationCertificate,
     MIRTarget (..),
     MIRPot(..),
+    selectStakeCredentialWitness,
 
     -- * Protocol parameter updates
     UpdateProposal(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Expose `stakeCredentialWitness` function, which returns only stake credentials for the certificates requiring witnessing: delegation and deregistration.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
