### PR TITLE
Remove renderEra. Rename prettyTo* to docTo* functions

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -451,7 +451,7 @@ genOperationalCertificateWithCounter = do
     case issueOperationalCertificate kesVKey stkPoolOrGenDelExtSign kesP iCounter of
       -- This case should be impossible as we clearly derive the verification
       -- key from the generated signing key.
-      Left err -> fail $ prettyToString $ prettyError err
+      Left err -> fail $ docToString $ prettyError err
       Right pair -> return pair
   where
     convert :: VerificationKey GenesisDelegateExtendedKey
@@ -750,7 +750,7 @@ genTxBody :: ShelleyBasedEra era -> Gen (TxBody era)
 genTxBody era = do
   res <- Api.createAndValidateTransactionBody era <$> genTxBodyContent era
   case res of
-    Left err -> fail (prettyToString (prettyError err))
+    Left err -> fail (docToString (prettyError err))
     Right txBody -> pure txBody
 
 -- | Generate a 'Featured' for the given 'CardanoEra' with the provided generator.

--- a/cardano-api/gen/Test/Hedgehog/Golden/ErrorMessage.hs
+++ b/cardano-api/gen/Test/Hedgehog/Golden/ErrorMessage.hs
@@ -78,4 +78,4 @@ testErrorMessage_ goldenFilesLocation moduleName typeName constructorName err = 
   let fqtn = moduleName <> "." <> typeName
   testProperty constructorName . withTests 1 . property $ do
     H.note_ "Incorrect error message in golden file"
-    H.diffVsGoldenFile (prettyToString (prettyError err)) (goldenFilesLocation </> fqtn </> constructorName <> ".txt")
+    H.diffVsGoldenFile (docToString (prettyError err)) (goldenFilesLocation </> fqtn </> constructorName <> ".txt")

--- a/cardano-api/internal/Cardano/Api/Error.hs
+++ b/cardano-api/internal/Cardano/Api/Error.hs
@@ -47,14 +47,14 @@ instance Error ErrorAsException where
 
 instance Show ErrorAsException where
   show (ErrorAsException e) =
-    prettyToString $ prettyError e
+    docToString $ prettyError e
 
 instance Exception ErrorAsException where
   displayException (ErrorAsException e) =
-    prettyToString $ prettyError e
+    docToString $ prettyError e
 
 displayError :: Error a => a -> String
-displayError = prettyToString . prettyError
+displayError = docToString . prettyError
 
 data FileError e = FileError FilePath e
                  | FileErrorTempFile

--- a/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
@@ -1469,7 +1469,7 @@ instance FromJSON (Hash StakePoolKey) where
   parseJSON = withText "PoolId" $ \str ->
     case deserialiseFromBech32 (AsHash AsStakePoolKey) str of
       Left err ->
-        fail $ prettyToString $ mconcat
+        fail $ docToString $ mconcat
           [ "Error deserialising Hash StakePoolKey: " <> pretty str
           , " Error: " <> prettyError err
           ]
@@ -1590,7 +1590,7 @@ instance FromJSON (Hash DRepKey) where
   parseJSON = withText "DRepId" $ \str ->
     case deserialiseFromBech32 (AsHash AsDRepKey) str of
       Left err ->
-        fail $ prettyToString $ mconcat
+        fail $ docToString $ mconcat
           [ "Error deserialising Hash DRepKey: " <> pretty str
           , " Error: " <> prettyError err
           ]

--- a/cardano-api/internal/Cardano/Api/Pretty.hs
+++ b/cardano-api/internal/Cardano/Api/Pretty.hs
@@ -4,9 +4,9 @@ module Cardano.Api.Pretty
   , Pretty(..)
   , ShowOf(..)
   , viaShow
-  , prettyToLazyText
-  , prettyToText
-  , prettyToString
+  , docToLazyText
+  , docToText
+  , docToString
   , pshow
 
   , black
@@ -30,14 +30,14 @@ import           Prettyprinter.Render.Terminal
 -- of colored output. This is a type alias for AnsiStyle.
 type Ann = AnsiStyle
 
-prettyToString :: Doc AnsiStyle -> String
-prettyToString =  show
+docToString :: Doc AnsiStyle -> String
+docToString =  show
 
-prettyToLazyText :: Doc AnsiStyle -> TextLazy.Text
-prettyToLazyText = renderLazy . layoutPretty defaultLayoutOptions
+docToLazyText :: Doc AnsiStyle -> TextLazy.Text
+docToLazyText = renderLazy . layoutPretty defaultLayoutOptions
 
-prettyToText :: Doc AnsiStyle -> Text.Text
-prettyToText = TextLazy.toStrict . prettyToLazyText
+docToText :: Doc AnsiStyle -> Text.Text
+docToText = TextLazy.toStrict . docToLazyText
 
 black :: Doc AnsiStyle -> Doc AnsiStyle
 black = annotate (color Black)
@@ -64,4 +64,4 @@ white :: Doc AnsiStyle -> Doc AnsiStyle
 white = annotate (color White)
 
 pshow :: Show a => a -> Doc ann
-pshow = pretty . show
+pshow = viaShow

--- a/cardano-api/internal/Cardano/Api/SerialiseUsing.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseUsing.hs
@@ -112,7 +112,7 @@ instance SerialiseAsBech32 a => IsString (UsingBech32 a) where
       case deserialiseFromBech32 ttoken (Text.pack str) of
         Right x  -> UsingBech32 x
         Left  e ->
-          error $ prettyToString $
+          error $ docToString $
             "fromString: " <> pretty str <> ": " <> prettyError e
       where
         ttoken :: AsType a
@@ -126,7 +126,7 @@ instance SerialiseAsBech32 a => FromJSON (UsingBech32 a) where
       Aeson.withText tname $ \str ->
         case deserialiseFromBech32 ttoken str of
           Right x -> return (UsingBech32 x)
-          Left  e -> fail $ prettyToString $ pretty str <> ": " <> prettyError e
+          Left  e -> fail $ docToString $ pretty str <> ": " <> prettyError e
       where
         ttoken = proxyToAsType (Proxy :: Proxy a)
         tname  = (tyConName . typeRepTyCon . typeRep) (Proxy :: Proxy a)

--- a/cardano-api/internal/Cardano/Api/TxIn.hs
+++ b/cardano-api/internal/Cardano/Api/TxIn.hs
@@ -130,7 +130,7 @@ parseTxId :: Parsec.Parser TxId
 parseTxId = do
   str <- some Parsec.hexDigit <?> "transaction id (hexadecimal)"
   failEitherWith
-    (\e -> prettyToString $ "Incorrect transaction id format: " <> prettyError e)
+    (\e -> docToString $ "Incorrect transaction id format: " <> prettyError e)
     (deserialiseFromRawBytesHex AsTxId $ BSC.pack str)
 
 parseTxIn :: Parsec.Parser TxIn

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -22,7 +22,6 @@ module Cardano.Api.Utils
   , note
   , parseFilePath
   , readFileBlocking
-  , renderEra
   , runParsecParser
   , textShow
   , modifyWith
@@ -30,8 +29,6 @@ module Cardano.Api.Utils
     -- ** CLI option parsing
   , bounded
   ) where
-
-import           Cardano.Api.Eras
 
 import           Cardano.Ledger.Shelley ()
 
@@ -117,15 +114,6 @@ readFileBlocking path = bracket
 
 textShow :: Show a => a -> Text
 textShow = Text.pack . show
-
-renderEra :: AnyCardanoEra -> Text
-renderEra (AnyCardanoEra ByronEra)   = "Byron"
-renderEra (AnyCardanoEra ShelleyEra) = "Shelley"
-renderEra (AnyCardanoEra AllegraEra) = "Allegra"
-renderEra (AnyCardanoEra MaryEra)    = "Mary"
-renderEra (AnyCardanoEra AlonzoEra)  = "Alonzo"
-renderEra (AnyCardanoEra BabbageEra) = "Babbage"
-renderEra (AnyCardanoEra ConwayEra)  = "Conway"
 
 bounded :: forall a. (Bounded a, Integral a, Show a) => String -> ReadM a
 bounded t = eitherReader $ \s -> do

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -927,7 +927,6 @@ module Cardano.Api (
     -- ** Misc
     ScriptLockedTxInsError(..),
     TxInsExistError(..),
-    renderEra,
     renderNotScriptLockedTxInsError,
     renderTxInsExistError,
     txInsExistInUTxO,

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.ProtocolParameters.ProtocolParametersError/PParamsErrorMissingMinUTxoValue.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.ProtocolParameters.ProtocolParametersError/PParamsErrorMissingMinUTxoValue.txt
@@ -1,1 +1,1 @@
-The ConwayEra protocol parameters value is missing the following field: MinUTxoValue. Did you intend to use a ConwayEra protocol parameters value?
+The Conway protocol parameters value is missing the following field: MinUTxoValue. Did you intend to use a Conway protocol parameters value?

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -26,7 +26,7 @@ prop_createVrfFileWithOwnerPermissions =
     result <- liftIO $ writeLazyByteStringFileWithOwnerPermissions (File file) ""
 
     case result of
-      Left err -> failWith Nothing $ prettyToString $ prettyError @(FileError ()) err
+      Left err -> failWith Nothing $ docToString $ prettyError @(FileError ()) err
       Right () -> return ()
 
     fResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    - Remove `renderEra` Use `docToText . pretty` instead.
    - Rename `prettyTo*` functions to `docTo*`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR introduces consistency in prettyprinting functions naming and simplifies rendering of names of eras.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
